### PR TITLE
feat: domain contracts — DTOs, enums, constants, paging (#24, #25)

### DIFF
--- a/src/FoundryGate.Domain/Audit/Contracts/AuditContracts.cs
+++ b/src/FoundryGate.Domain/Audit/Contracts/AuditContracts.cs
@@ -1,0 +1,29 @@
+namespace FoundryGate.Domain.Audit.Contracts;
+
+/// <summary>One audit log entry (spec &#167;3.1 <c>AuditLog</c>). GET /audit (paged, filterable).</summary>
+/// <param name="AuditLogId">Surrogate int PK.</param>
+/// <param name="ActorUserId">The admin (or system job) that performed the action. Null for system-initiated actions with no actor, e.g. an unattended background job.</param>
+/// <param name="ActorDisplayName">Denormalized for display; null when <paramref name="ActorUserId"/> is null.</param>
+/// <param name="Action">One of <see cref="Constants.AuditActions"/>, or a future action not yet constant-ized — the column is free text by design.</param>
+/// <param name="TargetType">e.g. "User" | "Group" | "Request" (spec &#167;3.1). Null when the action has no single target.</param>
+/// <param name="TargetId">Identifier of the affected record, as a string (spec &#167;3.1 keeps this loosely typed since <paramref name="TargetType"/> varies). Null when the action has no single target.</param>
+/// <param name="Details">Opaque JSON blob (spec &#167;3.1); the API does not interpret it, only the UI's audit viewer renders it.</param>
+/// <param name="OccurredDate">When the action happened.</param>
+public record AuditLogEntryResponse(
+    int AuditLogId,
+    int? ActorUserId,
+    string? ActorDisplayName,
+    string Action,
+    string? TargetType,
+    string? TargetId,
+    string? Details,
+    DateTimeOffset OccurredDate);
+
+/// <summary>Filter parameters for GET /audit. Bind alongside <see cref="Common.PagedRequest"/> via a separate <c>[FromQuery]</c> parameter.</summary>
+public record AuditLogQuery(
+    int? ActorUserId,
+    string? Action,
+    string? TargetType,
+    string? TargetId,
+    DateTimeOffset? FromDate,
+    DateTimeOffset? ToDate);

--- a/src/FoundryGate.Domain/Common/ApiError.cs
+++ b/src/FoundryGate.Domain/Common/ApiError.cs
@@ -1,0 +1,23 @@
+namespace FoundryGate.Domain.Common;
+
+/// <summary>
+/// RFC 7807-shaped error envelope. FoundryGate.Api's single <c>IExceptionHandler</c>
+/// (CONVENTIONS.md) serializes ASP.NET Core's <c>ProblemDetails</c> onto the wire in
+/// this shape; Domain defines its own POCO mirror — rather than referencing
+/// <c>Microsoft.AspNetCore.Http.ProblemDetails</c> directly — so FoundryGate.Web (which
+/// references Domain only, per the Blazor WASM hard boundary) can deserialize error
+/// responses without pulling an ASP.NET Core dependency into the WASM client.
+/// </summary>
+/// <param name="Type">A URI reference identifying the problem type (RFC 7807 <c>type</c>).</param>
+/// <param name="Title">Short, human-readable summary of the problem.</param>
+/// <param name="Status">The HTTP status code generated for this occurrence.</param>
+/// <param name="Detail">Human-readable explanation specific to this occurrence.</param>
+/// <param name="Instance">A URI reference identifying the specific occurrence (typically the request path).</param>
+/// <param name="Errors">Per-field validation failures, when <see cref="Status"/> is 400.</param>
+public record ApiError(
+    string Type,
+    string Title,
+    int Status,
+    string? Detail = null,
+    string? Instance = null,
+    IReadOnlyDictionary<string, string[]>? Errors = null);

--- a/src/FoundryGate.Domain/Common/ApiError.cs
+++ b/src/FoundryGate.Domain/Common/ApiError.cs
@@ -8,16 +8,29 @@ namespace FoundryGate.Domain.Common;
 /// references Domain only, per the Blazor WASM hard boundary) can deserialize error
 /// responses without pulling an ASP.NET Core dependency into the WASM client.
 /// </summary>
-/// <param name="Type">A URI reference identifying the problem type (RFC 7807 <c>type</c>).</param>
+/// <remarks>
+/// <see cref="Type"/> and <see cref="Title"/> are nullable even though the API's own
+/// responses always populate them: this record's other job is deserializing whatever
+/// error payload actually comes back over the wire (a foreign/malformed response, a
+/// proxy's own error page, a future API version that dropped a field) — System.Text.Json
+/// materializes a missing JSON property as <c>null</c> regardless of the property's C#
+/// nullable-reference-type annotation, so declaring them non-nullable here would just be
+/// a compile-time promise the deserializer doesn't keep at runtime.
+/// </remarks>
+/// <param name="Type">A URI reference identifying the problem type (RFC 7807 <c>type</c>). RFC 7807's own default is <see cref="DefaultType"/> when no more specific value is known.</param>
 /// <param name="Title">Short, human-readable summary of the problem.</param>
 /// <param name="Status">The HTTP status code generated for this occurrence.</param>
 /// <param name="Detail">Human-readable explanation specific to this occurrence.</param>
 /// <param name="Instance">A URI reference identifying the specific occurrence (typically the request path).</param>
 /// <param name="Errors">Per-field validation failures, when <see cref="Status"/> is 400.</param>
 public record ApiError(
-    string Type,
-    string Title,
+    string? Type,
+    string? Title,
     int Status,
     string? Detail = null,
     string? Instance = null,
-    IReadOnlyDictionary<string, string[]>? Errors = null);
+    IReadOnlyDictionary<string, string[]>? Errors = null)
+{
+    /// <summary>RFC 7807's own default <c>type</c> value when no more specific problem type URI applies.</summary>
+    public const string DefaultType = "about:blank";
+}

--- a/src/FoundryGate.Domain/Common/PagedRequest.cs
+++ b/src/FoundryGate.Domain/Common/PagedRequest.cs
@@ -1,0 +1,34 @@
+namespace FoundryGate.Domain.Common;
+
+/// <summary>
+/// Paging parameters accepted by every "(paged)" list endpoint (spec &#167;4). Bind
+/// directly from the query string via <c>[FromQuery]</c>.
+/// </summary>
+/// <remarks>
+/// Deliberately carries no <c>System.ComponentModel.DataAnnotations</c> attributes.
+/// An out-of-range <see cref="Page"/> or <see cref="PageSize"/> here is a client being
+/// sloppy about pagination, not a validation failure worth a 400 — call
+/// <see cref="Clamp"/> before using the values in a query and the request degrades to a
+/// safe default instead. Request/response DTOs that represent actual domain input (a
+/// quota justification, a group name, ...) DO carry validation attributes; see the
+/// per-area <c>Contracts</c> types.
+/// </remarks>
+/// <param name="Page">1-based page number. Values below 1 clamp up to 1.</param>
+/// <param name="PageSize">Rows per page. Clamps into [1, <see cref="MaxPageSize"/>].</param>
+public record PagedRequest(int Page = 1, int PageSize = PagedRequest.DefaultPageSize)
+{
+    public const int DefaultPageSize = 25;
+    public const int MaxPageSize = 200;
+
+    /// <summary>Returns a copy with <see cref="Page"/>/<see cref="PageSize"/> normalized into sane bounds.</summary>
+    public PagedRequest Clamp() => this with
+    {
+        Page = Page < 1 ? 1 : Page,
+        PageSize = PageSize switch
+        {
+            < 1 => DefaultPageSize,
+            > MaxPageSize => MaxPageSize,
+            _ => PageSize,
+        },
+    };
+}

--- a/src/FoundryGate.Domain/Common/PagedResult.cs
+++ b/src/FoundryGate.Domain/Common/PagedResult.cs
@@ -1,0 +1,29 @@
+namespace FoundryGate.Domain.Common;
+
+/// <summary>
+/// Generic paged-list envelope returned by every "(paged)" list endpoint in the API
+/// surface (spec &#167;4). Shared between FoundryGate.Api and FoundryGate.Web so the
+/// Blazor client can bind directly to it without a translation layer.
+/// </summary>
+/// <param name="Items">The page of results, in the order the query returned them.</param>
+/// <param name="TotalCount">Total number of matching rows across all pages, not just this one.</param>
+/// <param name="Page">The 1-based page number this result represents.</param>
+/// <param name="PageSize">The page size used to produce this result.</param>
+public record PagedResult<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    int Page,
+    int PageSize)
+{
+    /// <summary>
+    /// Total number of pages implied by <see cref="TotalCount"/> and <see cref="PageSize"/>.
+    /// Never negative; reports 0 only when <see cref="PageSize"/> is non-positive (defensive
+    /// only — a well-formed <see cref="PagedRequest"/> never produces that).
+    /// </summary>
+    public int TotalPages => PageSize <= 0
+        ? 0
+        : (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+    /// <summary>Convenience factory for an empty page (e.g. an admin list with zero matches).</summary>
+    public static PagedResult<T> Empty(int page, int pageSize) => new([], 0, page, pageSize);
+}

--- a/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
+++ b/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Domain.Config.Contracts;
+
+/// <summary>One <c>SystemConfiguration</c> row (spec &#167;3.1). GET /config, admin-only.</summary>
+public record SystemConfigEntryResponse(
+    string Key,
+    string Value,
+    DateTimeOffset UpdatedDate,
+    int UpdatedByUserId);
+
+/// <summary>PUT /config/{key} body.</summary>
+public record UpdateSystemConfigRequest(
+    [property: Required, StringLength(ValidationConstants.ConfigValueMaxLength)]
+    string Value);
+
+/// <summary>
+/// Gateway connection details a developer needs to point Claude Code, Codex CLI, or
+/// any Anthropic/OpenAI-compatible client at this fork's APIM gateway. Rendered by the
+/// "Configure your CLI" panel on <c>/me</c> (docs-site's getting-started/cli-setup.mdx).
+/// </summary>
+/// <param name="GatewayBaseUrl">
+/// The APIM gateway origin, e.g. <c>https://ai.yourcompany.com</c>
+/// (<see cref="SystemConfigurationKeys.ApimGatewayUrl"/>).
+/// </param>
+/// <param name="AnthropicBasePath">Path segment for the Anthropic Messages front door, e.g. <c>/anthropic</c>.</param>
+/// <param name="OpenAiBasePath">Path segment for the OpenAI Responses front door, e.g. <c>/openai/v1</c>.</param>
+/// <param name="ModelAliases">
+/// The virtual model names this developer's product allows (plans/25-model-aliases-routing.md).
+/// CLI config should pin to the alias, not the underlying Foundry deployment name, so
+/// deployments can rotate underneath without every developer editing env vars.
+/// </param>
+public record GatewayConnectionInfo(
+    string GatewayBaseUrl,
+    string AnthropicBasePath,
+    string OpenAiBasePath,
+    IReadOnlyList<ModelAliasInfo> ModelAliases);
+
+/// <summary>
+/// One virtual model alias exposed by the gateway's alias map. <paramref name="Alias"/>
+/// is the stable name a developer's CLI config references (e.g. <c>sonnet</c>);
+/// <paramref name="DeploymentName"/> is the underlying Foundry deployment it currently
+/// resolves to, shown for transparency/debugging only.
+/// </summary>
+public record ModelAliasInfo(
+    string Alias,
+    string DeploymentName,
+    ModelProviderType Provider);

--- a/src/FoundryGate.Domain/Config/ModelProviderType.cs
+++ b/src/FoundryGate.Domain/Config/ModelProviderType.cs
@@ -1,0 +1,15 @@
+namespace FoundryGate.Domain.Config;
+
+/// <summary>
+/// Which upstream API shape a gateway model alias speaks (plans/25-model-aliases-routing.md).
+/// Determines which base path and auth header style a CLI client uses — see
+/// <see cref="Contracts.GatewayConnectionInfo"/> and docs-site's cli-setup.mdx.
+/// </summary>
+public enum ModelProviderType
+{
+    /// <summary>Anthropic Messages API (<c>/anthropic/v1/messages</c>), <c>x-api-key</c> auth.</summary>
+    Anthropic = 0,
+
+    /// <summary>OpenAI Responses/Chat Completions API (<c>/openai/v1</c>), <c>api-key</c> auth.</summary>
+    OpenAi = 1,
+}

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -1,0 +1,65 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// Well-known values for <c>AuditLog.Action</c> (spec &#167;3.1: a free-form string,
+/// e.g. <c>"quota.approved"</c>, <c>"key.rotated"</c>). Kept as string constants rather
+/// than an enum: the audit trail is an open-ended, append-only log and new action
+/// kinds get added as the feature set grows (new endpoints, new admin tools) — an enum
+/// would force a schema-affecting change (the column is a plain string, not an
+/// <c>int</c>-backed enum column per CONVENTIONS.md) every time a new action is added,
+/// and would block a future action namespace external integrations might write without
+/// a Domain code change. A closed, small, structurally significant set
+/// (<see cref="Requests.QuotaRequestStatusType"/>, <see cref="Config.ModelProviderType"/>)
+/// stays an enum; this open-ended label set stays strings.
+/// </summary>
+public static class AuditActions
+{
+    // -- Users (spec 4.1) --
+
+    /// <summary>PUT /users/{id}/activate.</summary>
+    public const string UserActivated = "user.activated";
+
+    /// <summary>PUT /users/{id}/deactivate.</summary>
+    public const string UserDeactivated = "user.deactivated";
+
+    /// <summary>PUT /users/{id}/quota.</summary>
+    public const string UserQuotaChanged = "user.quota-changed";
+
+    /// <summary>POST /users/sync.</summary>
+    public const string UsersSynced = "users.synced";
+
+    // -- Groups (spec 4.2) --
+
+    public const string GroupCreated = "group.created";
+    public const string GroupUpdated = "group.updated";
+    public const string GroupDeleted = "group.deleted";
+    public const string GroupMemberAdded = "group.member-added";
+    public const string GroupMemberRemoved = "group.member-removed";
+
+    /// <summary>POST /groups/sync-entra.</summary>
+    public const string GroupEntraSynced = "group.entra-synced";
+
+    // -- Quota / requests (spec 4.3, 4.4, 6) --
+
+    /// <summary>The scheduled monthly reset job (spec &#167;6, exact string from spec).</summary>
+    public const string QuotaMonthlyReset = "quota.monthly-reset";
+
+    /// <summary>PUT /requests/{id}/approve (spec &#167;3.1, exact example string from spec).</summary>
+    public const string QuotaIncreaseApproved = "quota.approved";
+
+    /// <summary>PUT /requests/{id}/reject.</summary>
+    public const string QuotaIncreaseRejected = "quota.rejected";
+
+    // -- Keys (spec 4.5, 5.2, 5.3) --
+
+    public const string KeyProvisioned = "key.provisioned";
+
+    /// <summary>Spec &#167;3.1, exact example string from spec.</summary>
+    public const string KeyRotated = "key.rotated";
+
+    public const string KeyRevoked = "key.revoked";
+
+    // -- Config (spec 4.6) --
+
+    public const string ConfigUpdated = "config.updated";
+}

--- a/src/FoundryGate.Domain/Constants/PolicyNames.cs
+++ b/src/FoundryGate.Domain/Constants/PolicyNames.cs
@@ -1,0 +1,11 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// ASP.NET Core authorization policy names registered in FoundryGate.Api's
+/// <c>Program.cs</c> and referenced from <c>[Authorize(Policy = ...)]</c>.
+/// </summary>
+public static class PolicyNames
+{
+    /// <summary>Requires <see cref="RoleNames.Admin"/>. Used on every admin-only endpoint.</summary>
+    public const string AdminOnly = "AdminOnly";
+}

--- a/src/FoundryGate.Domain/Constants/RoleNames.cs
+++ b/src/FoundryGate.Domain/Constants/RoleNames.cs
@@ -1,0 +1,11 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// Entra ID App Role names used in <c>[Authorize(Roles = ...)]</c> attributes
+/// (spec &#167;4: "The admin role is an Entra App Role defined in the app registration").
+/// </summary>
+public static class RoleNames
+{
+    /// <summary>Grants access to every admin-only endpoint across the API surface.</summary>
+    public const string Admin = "FoundryGate.Admin";
+}

--- a/src/FoundryGate.Domain/Constants/SystemConfigurationKeys.cs
+++ b/src/FoundryGate.Domain/Constants/SystemConfigurationKeys.cs
@@ -1,0 +1,47 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// The eight <c>SystemConfiguration</c> keys seeded on first deploy (plans/02-data-layer.md
+/// #23). Shared between the Data-layer seeder, the Api's config endpoints, and any
+/// service that reads a configuration value by key, so the key string is never
+/// duplicated as a magic literal.
+/// </summary>
+public static class SystemConfigurationKeys
+{
+    /// <summary>Per-user fallback monthly token budget (quota resolution precedence, spec &#167;3.2 step 5).</summary>
+    public const string DefaultMonthlyTokenQuota = nameof(DefaultMonthlyTokenQuota);
+
+    /// <summary>ARM resource ID of the APIM instance.</summary>
+    public const string ApimResourceId = nameof(ApimResourceId);
+
+    /// <summary>APIM gateway base URL shown to developers on <c>/me</c> (see <see cref="Config.Contracts.GatewayConnectionInfo"/>).</summary>
+    public const string ApimGatewayUrl = nameof(ApimGatewayUrl);
+
+    /// <summary>APIM product name covering the Foundry routes (spec &#167;5.1).</summary>
+    public const string ApimProductId = nameof(ApimProductId);
+
+    /// <summary>ARM resource ID of the Azure AI Foundry account.</summary>
+    public const string FoundryResourceId = nameof(FoundryResourceId);
+
+    /// <summary>Azure AD tenant ID used for Microsoft Graph sync (spec &#167;7).</summary>
+    public const string EntraTenantId = nameof(EntraTenantId);
+
+    /// <summary>"true" | "false" — whether Entra group sync (spec &#167;7.3) is active.</summary>
+    public const string EntraGroupSyncEnabled = nameof(EntraGroupSyncEnabled);
+
+    /// <summary>Day of month the monthly reset fires; always "1" for v1 (spec &#167;6).</summary>
+    public const string ResetDayOfMonth = nameof(ResetDayOfMonth);
+
+    /// <summary>All seeded keys, for iteration in seeders and completeness tests.</summary>
+    public static readonly IReadOnlyList<string> All =
+    [
+        DefaultMonthlyTokenQuota,
+        ApimResourceId,
+        ApimGatewayUrl,
+        ApimProductId,
+        FoundryResourceId,
+        EntraTenantId,
+        EntraGroupSyncEnabled,
+        ResetDayOfMonth,
+    ];
+}

--- a/src/FoundryGate.Domain/Constants/ValidationConstants.cs
+++ b/src/FoundryGate.Domain/Constants/ValidationConstants.cs
@@ -8,10 +8,18 @@ public static class ValidationConstants
 {
     public const int DisplayNameMaxLength = 200;
 
-    /// <summary>RFC 5321 &#167;4.5.3.1.3 maximum mailbox length.</summary>
+    /// <summary>
+    /// A conservative upper bound, not an RFC-derived one: the commonly cited
+    /// "64 (local-part, RFC 5321 &#167;4.5.3.1.1) + 1 ('@') + 255 (domain) = 320"
+    /// folk sum. RFC 5321 &#167;4.5.3.1.3 actually caps the total reverse-/forward-path
+    /// at 256 octets, which nets out to a 254-character deliverable address — 320 is
+    /// deliberately looser than that so this bound never rejects a real address.
+    /// </summary>
     public const int EmailMaxLength = 320;
 
+    /// <summary>Entra object ids are GUIDs (36 chars); this leaves headroom without being unbounded. See <see cref="GuidPattern"/>.</summary>
     public const int EntraObjectIdMaxLength = 64;
+
     public const int EmployeeIdMaxLength = 64;
 
     public const int GroupNameMaxLength = 200;
@@ -34,4 +42,13 @@ public static class ValidationConstants
     /// reaching APIM. 100B tokens/month is far beyond any real allocation.
     /// </summary>
     public const long MaxMonthlyTokenQuota = 100_000_000_000;
+
+    /// <summary>
+    /// Canonical (hyphenated, no braces) GUID shape, for <c>[RegularExpression]</c> on
+    /// GUID-shaped identifier strings such as <c>Group.EntraGroupId</c> — kept as a
+    /// string rather than typing those fields <see cref="Guid"/> directly so they stay
+    /// consistent with <c>User.EntraObjectId</c>, which the data layer also models as a
+    /// string.
+    /// </summary>
+    public const string GuidPattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
 }

--- a/src/FoundryGate.Domain/Constants/ValidationConstants.cs
+++ b/src/FoundryGate.Domain/Constants/ValidationConstants.cs
@@ -1,0 +1,37 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// Max-length and range constraints shared between API <c>DataAnnotations</c>
+/// attributes and Blazor form validation, so the two never drift (issue #25).
+/// </summary>
+public static class ValidationConstants
+{
+    public const int DisplayNameMaxLength = 200;
+
+    /// <summary>RFC 5321 &#167;4.5.3.1.3 maximum mailbox length.</summary>
+    public const int EmailMaxLength = 320;
+
+    public const int EntraObjectIdMaxLength = 64;
+    public const int EmployeeIdMaxLength = 64;
+
+    public const int GroupNameMaxLength = 200;
+    public const int DescriptionMaxLength = 1000;
+
+    public const int JustificationMinLength = 10;
+    public const int JustificationMaxLength = 2000;
+    public const int ReviewNotesMaxLength = 2000;
+
+    public const int ConfigKeyMaxLength = 200;
+    public const int ConfigValueMaxLength = 4000;
+
+    public const int AuditActionMaxLength = 100;
+    public const int AuditTargetTypeMaxLength = 50;
+    public const int AuditTargetIdMaxLength = 100;
+
+    /// <summary>
+    /// Sanity ceiling for an admin-entered monthly token quota — not a business rule
+    /// from the spec, just a guardrail against a fat-fingered value (e.g. an extra zero)
+    /// reaching APIM. 100B tokens/month is far beyond any real allocation.
+    /// </summary>
+    public const long MaxMonthlyTokenQuota = 100_000_000_000;
+}

--- a/src/FoundryGate.Domain/Dashboard/Contracts/DashboardContracts.cs
+++ b/src/FoundryGate.Domain/Dashboard/Contracts/DashboardContracts.cs
@@ -1,0 +1,24 @@
+namespace FoundryGate.Domain.Dashboard.Contracts;
+
+/// <summary>Admin dashboard summary stats (spec &#167;4.6: "total users, active, top consumers"). GET /dashboard.</summary>
+/// <remarks>
+/// <see cref="TotalTokensUsedThisPeriod"/> and every consumer's usage figure are
+/// reconciliation numbers from the Log Analytics sync (spec &#167;5.4), refreshed on the
+/// sync job's cadence — not a live view of gateway enforcement state.
+/// </remarks>
+public record DashboardSummaryResponse(
+    int TotalUserCount,
+    int ActiveUserCount,
+    int UnlimitedUserCount,
+    int PendingQuotaIncreaseRequestCount,
+    long TotalTokensUsedThisPeriod,
+    IReadOnlyList<TopConsumerResponse> TopConsumers);
+
+/// <summary>One entry in the dashboard's top-consumers list.</summary>
+public record TopConsumerResponse(
+    int UserId,
+    Guid UserUnique,
+    string DisplayName,
+    long TokensUsed,
+    long? AllocatedTokens,
+    double? PercentUsed);

--- a/src/FoundryGate.Domain/FoundryGate.Domain.csproj
+++ b/src/FoundryGate.Domain/FoundryGate.Domain.csproj
@@ -1,3 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Zero dependencies by design (CONVENTIONS.md): enums, DTO records, constants,
+       validation. FoundryGate.Web (Blazor WASM) references this project only, so
+       anything added here becomes part of the WASM client's dependency graph.
+       Do not add PackageReference/ProjectReference without re-reading CONVENTIONS.md. -->
 
 </Project>

--- a/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
+++ b/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Domain.Groups.Contracts;
+
+/// <summary>A group as seen in admin lists (spec &#167;3.1 <c>Group</c>). GET /groups.</summary>
+public record GroupResponse(
+    int GroupId,
+    Guid GroupUnique,
+    string Name,
+    string? Description,
+    bool IsEntraSynced,
+    bool IsUnlimited,
+    long? MonthlyTokenQuota,
+    int MemberCount,
+    DateTimeOffset CreatedDate);
+
+/// <summary>Group detail with its full member roster. GET /groups/{id}.</summary>
+public record GroupDetailResponse(
+    GroupResponse Group,
+    IReadOnlyList<GroupMemberResponse> Members);
+
+/// <summary>One member of a group's roster.</summary>
+public record GroupMemberResponse(
+    int UserId,
+    Guid UserUnique,
+    string DisplayName,
+    string Email,
+    DateTimeOffset AddedDate,
+    int AddedByUserId);
+
+/// <summary>POST /groups body.</summary>
+public record CreateGroupRequest(
+    [property: Required, StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
+    string Name,
+    [property: StringLength(ValidationConstants.DescriptionMaxLength)]
+    string? Description,
+    string? EntraGroupId,
+    bool IsUnlimited,
+    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    long? MonthlyTokenQuota);
+
+/// <summary>PUT /groups/{id} body — admin updates name/description/quota (spec &#167;4.2).</summary>
+public record UpdateGroupRequest(
+    [property: Required, StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
+    string Name,
+    [property: StringLength(ValidationConstants.DescriptionMaxLength)]
+    string? Description,
+    bool IsUnlimited,
+    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    long? MonthlyTokenQuota);
+
+/// <summary>POST /groups/{id}/members body.</summary>
+public record AddGroupMemberRequest([property: Range(1, int.MaxValue, ErrorMessage = "UserId must be a valid user id.")] int UserId);
+
+/// <summary>Result of POST /groups/sync-entra for one group (spec &#167;7.3).</summary>
+public record GroupSyncResult(int GroupId, int AddedCount, int RemovedCount);

--- a/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
+++ b/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
@@ -4,11 +4,27 @@ using FoundryGate.Domain.Constants;
 namespace FoundryGate.Domain.Groups.Contracts;
 
 /// <summary>A group as seen in admin lists (spec &#167;3.1 <c>Group</c>). GET /groups.</summary>
+/// <param name="GroupId">Surrogate int PK.</param>
+/// <param name="GroupUnique">Externally-shared stable id.</param>
+/// <param name="Name">Group display name.</param>
+/// <param name="Description">Optional free-text description.</param>
+/// <param name="EntraGroupId">
+/// The linked Entra group's object id, when <paramref name="IsEntraSynced"/> is true
+/// (spec &#167;3.1, &#167;7.3). Exposed so an admin can see and verify which Entra group a
+/// FoundryGate group is linked to — previously settable via
+/// <see cref="CreateGroupRequest"/> but unreadable afterward.
+/// </param>
+/// <param name="IsEntraSynced">True when <paramref name="EntraGroupId"/> is set and membership is kept in sync from Entra.</param>
+/// <param name="IsUnlimited">When true, members of this group get unlimited quota unless overridden individually (spec &#167;3.2).</param>
+/// <param name="MonthlyTokenQuota">Group-level quota override for members; null falls through the resolution chain (spec &#167;3.2).</param>
+/// <param name="MemberCount">Number of users currently in the group.</param>
+/// <param name="CreatedDate">When the group was created.</param>
 public record GroupResponse(
     int GroupId,
     Guid GroupUnique,
     string Name,
     string? Description,
+    string? EntraGroupId,
     bool IsEntraSynced,
     bool IsUnlimited,
     long? MonthlyTokenQuota,
@@ -30,11 +46,23 @@ public record GroupMemberResponse(
     int AddedByUserId);
 
 /// <summary>POST /groups body.</summary>
+/// <param name="Name">Group display name.</param>
+/// <param name="Description">Optional free-text description.</param>
+/// <param name="EntraGroupId">
+/// Optional Entra group object id to link for &#167;7.3 group sync. Validated as
+/// GUID-shaped (Entra object ids are always GUIDs) rather than typed as <see cref="Guid"/>
+/// directly, to stay consistent with <c>User.EntraObjectId</c> — also a GUID-shaped
+/// <see cref="string"/> elsewhere in this domain (see <see cref="ValidationConstants.EntraObjectIdMaxLength"/>).
+/// </param>
+/// <param name="IsUnlimited">When true, members get unlimited quota unless overridden individually.</param>
+/// <param name="MonthlyTokenQuota">Group-level quota override for members; null falls through the resolution chain (spec &#167;3.2).</param>
 public record CreateGroupRequest(
     [property: Required, StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
     string Name,
     [property: StringLength(ValidationConstants.DescriptionMaxLength)]
     string? Description,
+    [property: StringLength(ValidationConstants.EntraObjectIdMaxLength)]
+    [property: RegularExpression(ValidationConstants.GuidPattern, ErrorMessage = "EntraGroupId must be a GUID (Entra object id).")]
     string? EntraGroupId,
     bool IsUnlimited,
     [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]

--- a/src/FoundryGate.Domain/Keys/Contracts/ApiKeyContracts.cs
+++ b/src/FoundryGate.Domain/Keys/Contracts/ApiKeyContracts.cs
@@ -1,0 +1,15 @@
+namespace FoundryGate.Domain.Keys.Contracts;
+
+/// <summary>
+/// A developer's APIM subscription key, masked to only the last 4 characters (spec
+/// &#167;4.5: "get own APIM key (masked except last 4)"). Returned by GET /keys/me,
+/// POST /keys/me/rotate, POST /keys/{userId}/rotate, and POST /keys/{userId}/provision
+/// — and embedded in <see cref="Users.Contracts.UserProfileResponse"/> for <c>/me</c>.
+/// </summary>
+/// <param name="IsProvisioned">False when the user has no APIM subscription yet (never logged in / not yet provisioned).</param>
+/// <param name="MaskedKey">e.g. <c>"••••••••1a2b"</c>. Null when <paramref name="IsProvisioned"/> is false.</param>
+/// <param name="ApimSubscriptionId">The APIM subscription resource ID (spec &#167;5.1). Null when not provisioned.</param>
+public record ApiKeyResponse(
+    bool IsProvisioned,
+    string? MaskedKey,
+    string? ApimSubscriptionId);

--- a/src/FoundryGate.Domain/Keys/Contracts/ApiKeyContracts.cs
+++ b/src/FoundryGate.Domain/Keys/Contracts/ApiKeyContracts.cs
@@ -2,9 +2,11 @@ namespace FoundryGate.Domain.Keys.Contracts;
 
 /// <summary>
 /// A developer's APIM subscription key, masked to only the last 4 characters (spec
-/// &#167;4.5: "get own APIM key (masked except last 4)"). Returned by GET /keys/me,
-/// POST /keys/me/rotate, POST /keys/{userId}/rotate, and POST /keys/{userId}/provision
-/// — and embedded in <see cref="Users.Contracts.UserProfileResponse"/> for <c>/me</c>.
+/// &#167;4.5: "get own APIM key (masked except last 4)"). Returned anywhere a key is
+/// <em>displayed</em>: GET /keys/me, admin user list/detail views, and embedded in
+/// <see cref="Users.Contracts.UserProfileResponse"/> for <c>/me</c>. Never returned by
+/// rotate/provision — those hand back the one-time plaintext value instead, see
+/// <see cref="ApiKeyRevealResponse"/>.
 /// </summary>
 /// <param name="IsProvisioned">False when the user has no APIM subscription yet (never logged in / not yet provisioned).</param>
 /// <param name="MaskedKey">e.g. <c>"••••••••1a2b"</c>. Null when <paramref name="IsProvisioned"/> is false.</param>
@@ -13,3 +15,27 @@ public record ApiKeyResponse(
     bool IsProvisioned,
     string? MaskedKey,
     string? ApimSubscriptionId);
+
+/// <summary>
+/// The one-time plaintext delivery of an APIM subscription key. Returned ONLY by the
+/// three endpoints that mint or regenerate a key — POST /keys/me/rotate, POST
+/// /keys/{userId}/rotate, POST /keys/{userId}/provision (spec &#167;5.1 key
+/// provisioning, &#167;5.2 key rotation) — the single moment the real key value crosses
+/// the API boundary. Every other read of this user's key (GET /keys/me,
+/// <see cref="Users.Contracts.UserProfileResponse.ApiKey"/>, admin lists/detail)
+/// returns the masked <see cref="ApiKeyResponse"/> instead; the API must not persist
+/// <see cref="PlaintextKey"/> anywhere it can be re-served later (spec &#167;5.1 step 4:
+/// only the encrypted key is stored). The UI should render this value once, behind a
+/// copy-to-clipboard affordance, and never fetch or display it again after this
+/// response is consumed — that's what makes the corresponding
+/// <c>getting-started/cli-setup.mdx</c> "Configure your CLI" panel possible at all.
+/// </summary>
+/// <param name="PlaintextKey">The real APIM subscription key value. Shown once; not retrievable again through any other endpoint.</param>
+/// <param name="MaskedKey">The same masked form <see cref="ApiKeyResponse"/> would show, for the UI to fall back to display after this response leaves scope.</param>
+/// <param name="ApimSubscriptionId">The APIM subscription resource ID (spec &#167;5.1).</param>
+/// <param name="IssuedDate">When this plaintext value was generated (provisioning) or regenerated (rotation).</param>
+public record ApiKeyRevealResponse(
+    string PlaintextKey,
+    string MaskedKey,
+    string ApimSubscriptionId,
+    DateTimeOffset IssuedDate);

--- a/src/FoundryGate.Domain/Quota/Contracts/QuotaContracts.cs
+++ b/src/FoundryGate.Domain/Quota/Contracts/QuotaContracts.cs
@@ -1,0 +1,48 @@
+namespace FoundryGate.Domain.Quota.Contracts;
+
+/// <summary>
+/// A user's resolved token allocation for one billing period (spec &#167;3.1
+/// <c>QuotaAllocation</c>, &#167;3.2 resolution logic). Returned by GET
+/// /quota/allocations (paged), /quota/allocations/me, /quota/allocations/{userId}, and
+/// embedded in <see cref="Users.Contracts.UserProfileResponse"/> for <c>/me</c>'s quota
+/// gauge.
+/// </summary>
+/// <remarks>
+/// <see cref="AllocatedTokens"/>, <see cref="TokensUsed"/>, and <see cref="PercentUsed"/>
+/// are reconciliation numbers synced from the <c>ApiManagementGatewayLlmLog</c> Log
+/// Analytics table (spec &#167;5.4) — a dashboard/audit view, not the enforcement
+/// boundary. Quota is enforced in real time at the APIM gateway (<c>llm-token-limit</c>:
+/// 429 on the per-minute cap, 403 on the monthly cap); the gateway's own response
+/// headers (<c>x-fg-remaining-quota</c>, <c>x-fg-remaining-tpm</c>) are the live source
+/// of truth for whether a given request will succeed, not this DTO.
+/// </remarks>
+/// <param name="QuotaAllocationId">Surrogate int PK.</param>
+/// <param name="UserId">Owning user's int PK.</param>
+/// <param name="UserUnique">Owning user's externally-shared stable id.</param>
+/// <param name="PeriodYear">Calendar year of the billing period.</param>
+/// <param name="PeriodMonth">Calendar month (1-12) of the billing period.</param>
+/// <param name="IsUnlimited">Derived: true when <paramref name="AllocatedTokens"/> is null.</param>
+/// <param name="AllocatedTokens">Null means unlimited for this period.</param>
+/// <param name="TokensUsed">Reconciled token usage for the period so far.</param>
+/// <param name="PercentUsed">Null when unlimited; otherwise <c>TokensUsed / AllocatedTokens * 100</c>, computed by the API.</param>
+/// <param name="IsHardStopped">
+/// Set when an admin revokes this user's key (spec &#167;5.3), not automatically on
+/// quota exhaustion — quota exhaustion alone never sets this; the gateway just starts
+/// returning 403 until the next monthly reset.
+/// </param>
+/// <param name="ResetDate">When this period's allocation row was last (re)computed, e.g. by the monthly reset job.</param>
+public record QuotaAllocationResponse(
+    int QuotaAllocationId,
+    int UserId,
+    Guid UserUnique,
+    int PeriodYear,
+    int PeriodMonth,
+    bool IsUnlimited,
+    long? AllocatedTokens,
+    long TokensUsed,
+    double? PercentUsed,
+    bool IsHardStopped,
+    DateTimeOffset? ResetDate);
+
+/// <summary>Result of POST /quota/reset (spec &#167;6, admin-triggered manual reset).</summary>
+public record QuotaResetResult(int UsersResetCount, DateTimeOffset ResetDate);

--- a/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
+++ b/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Domain.Requests.Contracts;
+
+/// <summary>A quota increase request (spec &#167;3.1 <c>QuotaIncreaseRequest</c>). GET /requests (paged), GET /requests/{id}.</summary>
+public record QuotaIncreaseRequestResponse(
+    int QuotaIncreaseRequestId,
+    Guid QuotaIncreaseRequestUnique,
+    int UserId,
+    Guid UserUnique,
+    string UserDisplayName,
+    int RequestedByUserId,
+    int PeriodYear,
+    int PeriodMonth,
+    long? CurrentQuota,
+    long? RequestedQuota,
+    string Justification,
+    QuotaRequestStatusType StatusType,
+    int? ReviewedByUserId,
+    DateTimeOffset? ReviewedDate,
+    string? ReviewNotes,
+    DateTimeOffset CreatedDate);
+
+/// <summary>POST /requests body — a developer (or admin on their behalf) submits a quota increase request.</summary>
+/// <param name="RequestedQuota">Null means requesting unlimited (spec &#167;3.1).</param>
+/// <param name="Justification">Free-text reason for the request; required so reviewers have something to evaluate.</param>
+public record SubmitQuotaIncreaseRequest(
+    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    long? RequestedQuota,
+    [property: Required, StringLength(ValidationConstants.JustificationMaxLength, MinimumLength = ValidationConstants.JustificationMinLength)]
+    string Justification);
+
+/// <summary>PUT /requests/{id}/approve or PUT /requests/{id}/reject body — same shape for both (spec &#167;4.4).</summary>
+public record ReviewQuotaIncreaseRequest(
+    [property: StringLength(ValidationConstants.ReviewNotesMaxLength)]
+    string? ReviewNotes);

--- a/src/FoundryGate.Domain/Requests/QuotaRequestStatusType.cs
+++ b/src/FoundryGate.Domain/Requests/QuotaRequestStatusType.cs
@@ -1,0 +1,12 @@
+namespace FoundryGate.Domain.Requests;
+
+/// <summary>
+/// Review status of a <c>QuotaIncreaseRequest</c> (spec &#167;3.1). Stored as <c>int</c>
+/// (CONVENTIONS.md: "Enums stored as int, property suffixed Type").
+/// </summary>
+public enum QuotaRequestStatusType
+{
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2,
+}

--- a/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
+++ b/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Keys.Contracts;
+using FoundryGate.Domain.Quota.Contracts;
+
+namespace FoundryGate.Domain.Users.Contracts;
+
+/// <summary>A user as seen in admin lists/detail (spec &#167;3.1 <c>User</c>). GET /users (paged), GET /users/{id}.</summary>
+public record UserResponse(
+    int UserId,
+    Guid UserUnique,
+    string DisplayName,
+    string Email,
+    string? EmployeeId,
+    bool IsActive,
+    bool IsUnlimited,
+    long? MonthlyTokenQuota,
+    bool HasApiKey,
+    DateTimeOffset CreatedDate,
+    DateTimeOffset? LastSyncedDate);
+
+/// <summary>
+/// The caller's own profile: identity fields, current-period quota gauge, masked API
+/// key, and the gateway connection info needed to configure a CLI. GET /users/me
+/// (spec &#167;4.1: "get own profile, quota, key info").
+/// </summary>
+public record UserProfileResponse(
+    int UserId,
+    Guid UserUnique,
+    string DisplayName,
+    string Email,
+    bool IsActive,
+    bool IsUnlimited,
+    QuotaAllocationResponse Quota,
+    ApiKeyResponse ApiKey,
+    GatewayConnectionInfo CliConfig);
+
+/// <summary>PUT /users/{id}/quota body — admin sets a user's quota or unlimited flag.</summary>
+/// <param name="IsUnlimited">When true, <paramref name="MonthlyTokenQuota"/> is ignored (spec &#167;3.2 step 1).</param>
+/// <param name="MonthlyTokenQuota">Null means "use the system/group default" (spec &#167;3.2 steps 2-5); ignored when <paramref name="IsUnlimited"/> is true.</param>
+public record UpdateUserQuotaRequest(
+    bool IsUnlimited,
+    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    long? MonthlyTokenQuota);
+
+/// <summary>Result of POST /users/sync (spec &#167;7.2 bulk Entra sync).</summary>
+public record UserSyncResult(int AddedCount, int UpdatedCount, int DeactivatedCount);

--- a/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
+++ b/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
@@ -7,6 +7,21 @@ using FoundryGate.Domain.Quota.Contracts;
 namespace FoundryGate.Domain.Users.Contracts;
 
 /// <summary>A user as seen in admin lists/detail (spec &#167;3.1 <c>User</c>). GET /users (paged), GET /users/{id}.</summary>
+/// <param name="UserId">Surrogate int PK.</param>
+/// <param name="UserUnique">Externally-shared stable id.</param>
+/// <param name="DisplayName">Name from Entra (spec &#167;7).</param>
+/// <param name="Email">Email from Entra (spec &#167;7).</param>
+/// <param name="EmployeeId">HR employee id from Entra, when available.</param>
+/// <param name="IsActive">False when deactivated (spec &#167;5.3) or not found in the last Entra sync (spec &#167;7.2).</param>
+/// <param name="IsUnlimited">When true, <paramref name="MonthlyTokenQuota"/> is ignored (spec &#167;3.2 step 1).</param>
+/// <param name="MonthlyTokenQuota">Null means "use the system/group default" (spec &#167;3.2).</param>
+/// <param name="IsApiKeyProvisioned">
+/// Same derived fact as <see cref="ApiKeyResponse.IsProvisioned"/> — named to match it
+/// exactly (rather than a "Has..." variant) so Web components can treat "is this user's
+/// key provisioned" as one concept with one name everywhere it appears.
+/// </param>
+/// <param name="CreatedDate">When the user record was first created (spec &#167;7.1).</param>
+/// <param name="LastSyncedDate">When this user was last touched by an Entra sync (spec &#167;7).</param>
 public record UserResponse(
     int UserId,
     Guid UserUnique,
@@ -16,7 +31,7 @@ public record UserResponse(
     bool IsActive,
     bool IsUnlimited,
     long? MonthlyTokenQuota,
-    bool HasApiKey,
+    bool IsApiKeyProvisioned,
     DateTimeOffset CreatedDate,
     DateTimeOffset? LastSyncedDate);
 

--- a/src/FoundryGate.Tests.Predeployment/Domain/ApiErrorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/ApiErrorTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>
+/// <see cref="ApiError"/> exists to deserialize whatever error payload actually comes
+/// back over the wire, including a payload missing fields entirely — these tests prove
+/// that doesn't throw and that the "missing" case is observable as null, not a silent
+/// non-null default (PR #91 review nit).
+/// </summary>
+public class ApiErrorTests
+{
+    // Mirrors JsonSerializerDefaults.Web (camelCase, case-insensitive) — what
+    // System.Net.Http.Json's HttpClient extensions use by default, and what
+    // FoundryGate.Web's HttpClient will realistically be configured with.
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Deserializing_a_payload_missing_type_and_title_does_not_throw_and_yields_null()
+    {
+        const string Json = """{"status":404,"detail":"User 42 not found."}""";
+
+        ApiError? error = JsonSerializer.Deserialize<ApiError>(Json, WebOptions);
+
+        Assert.NotNull(error);
+        Assert.Null(error.Type);
+        Assert.Null(error.Title);
+        Assert.Equal(404, error.Status);
+        Assert.Equal("User 42 not found.", error.Detail);
+    }
+
+    [Fact]
+    public void Deserializing_a_full_payload_round_trips()
+    {
+        var original = new ApiError(
+            Type: "https://tools.ietf.org/html/rfc7807",
+            Title: "Not Found",
+            Status: 404,
+            Detail: "User 42 not found.",
+            Instance: "/api/v1/users/42");
+
+        string json = JsonSerializer.Serialize(original, WebOptions);
+        ApiError? roundTripped = JsonSerializer.Deserialize<ApiError>(json, WebOptions);
+
+        Assert.Equal(original, roundTripped);
+    }
+
+    [Fact]
+    public void DefaultType_matches_RFC7807s_own_default()
+    {
+        Assert.Equal("about:blank", ApiError.DefaultType);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>
+/// FoundryGate.Domain must stay a pure enums/records/constants library with zero
+/// dependencies (CONVENTIONS.md: "Domain (zero deps: enums, DTO records, exceptions,
+/// validation)"). FoundryGate.Web (Blazor WASM) references Domain only — anything
+/// Domain pulls in becomes part of the WASM client's dependency graph, and EF Core /
+/// ASP.NET Core types have no business running in the browser.
+///
+/// These tests reflect over the compiled FoundryGate.Domain assembly's own
+/// <see cref="Assembly.GetReferencedAssemblies"/> manifest rather than parsing the
+/// .csproj, so they fail if a disallowed dependency sneaks in transitively too (e.g.
+/// via a future PackageReference that itself pulls in EF Core).
+/// </summary>
+public class DomainArchitectureTests
+{
+    private static readonly Assembly DomainAssembly = typeof(PagedResult<>).Assembly;
+
+    private static readonly string[] DisallowedAssemblyNamePrefixes =
+    [
+        "Microsoft.EntityFrameworkCore",
+        "Microsoft.AspNetCore",
+        "Microsoft.Data.SqlClient",
+        "System.Data.SqlClient",
+        "Azure.",
+        "Microsoft.Azure.",
+        "Microsoft.Graph",
+    ];
+
+    [Fact]
+    public void Domain_assembly_references_no_disallowed_packages()
+    {
+        List<string?> violations = DomainAssembly.GetReferencedAssemblies()
+            .Where(referenced => DisallowedAssemblyNamePrefixes.Any(prefix =>
+                referenced.Name?.StartsWith(prefix, StringComparison.Ordinal) == true))
+            .Select(referenced => referenced.Name)
+            .ToList();
+
+        Assert.True(
+            violations.Count == 0,
+            $"FoundryGate.Domain references disallowed assemblies: {string.Join(", ", violations)}");
+    }
+
+    [Fact]
+    public void Domain_assembly_has_no_references_to_other_FoundryGate_projects()
+    {
+        // Domain must not depend on Data, Api, Web, Functions, or any other
+        // FoundryGate.* project — it is the leaf of the dependency graph.
+        List<string?> foundryGateReferences = DomainAssembly.GetReferencedAssemblies()
+            .Where(referenced => referenced.Name?.StartsWith("FoundryGate.", StringComparison.Ordinal) == true)
+            .Select(referenced => referenced.Name)
+            .ToList();
+
+        Assert.True(
+            foundryGateReferences.Count == 0,
+            $"FoundryGate.Domain references other FoundryGate projects: {string.Join(", ", foundryGateReferences)}");
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
@@ -9,46 +9,73 @@ namespace FoundryGate.Tests.Predeployment.Domain;
 /// validation)"). FoundryGate.Web (Blazor WASM) references Domain only — anything
 /// Domain pulls in becomes part of the WASM client's dependency graph, and EF Core /
 /// ASP.NET Core types have no business running in the browser.
-///
-/// These tests reflect over the compiled FoundryGate.Domain assembly's own
-/// <see cref="Assembly.GetReferencedAssemblies"/> manifest rather than parsing the
-/// .csproj, so they fail if a disallowed dependency sneaks in transitively too (e.g.
-/// via a future PackageReference that itself pulls in EF Core).
 /// </summary>
+/// <remarks>
+/// <see cref="Domain_assembly_references_exactly_the_allowlisted_BCL_assemblies"/>
+/// reflects over the compiled FoundryGate.Domain assembly's own
+/// <see cref="Assembly.GetReferencedAssemblies"/> manifest (its AssemblyRef metadata
+/// table) rather than parsing the .csproj — but this only catches assemblies Domain's
+/// own IL <em>directly</em> references. It does NOT catch a dependency that is present
+/// on disk / in the lock file but never actually used by any type in Domain's code (a
+/// stray <c>PackageReference</c> with zero call sites emits no AssemblyRef), and it
+/// cannot see further than one hop — an allowed BCL assembly's own transitive
+/// dependencies are irrelevant here since the BCL doesn't depend on EF
+/// Core/ASP.NET Core/Azure SDK etc. The real "zero PackageReference/ProjectReference"
+/// guarantee is the empty <c>FoundryGate.Domain.csproj</c> itself (see its comment);
+/// this test is the automated, CI-enforced cross-check that whatever code lands in
+/// Domain doesn't start actually pulling types from something Domain never declared a
+/// reference to.
+///
+/// Deliberately an exact allowlist, not a prefix pattern like <c>"System."</c>: the
+/// list below is every assembly this project happened to compile against as of this
+/// writing (captured via a throwaway <c>ITestOutputHelper</c> probe run against the
+/// built DLL). A new BCL assembly showing up (e.g. Domain code starts using
+/// <c>System.Net.Http</c>) fails this test just as loudly as EF Core would, and must be
+/// added here deliberately — with a one-line justification in the same PR — rather than
+/// silently passing because it happened to start with "System.".
+/// </remarks>
 public class DomainArchitectureTests
 {
     private static readonly Assembly DomainAssembly = typeof(PagedResult<>).Assembly;
 
-    private static readonly string[] DisallowedAssemblyNamePrefixes =
+    /// <summary>
+    /// Every assembly FoundryGate.Domain.dll is allowed to reference, by exact name.
+    /// Captured from a clean build's <see cref="Assembly.GetReferencedAssemblies"/> —
+    /// re-capture and update deliberately (with justification) when Domain code starts
+    /// using a new BCL type; never widen this to a prefix/wildcard match.
+    /// </summary>
+    private static readonly string[] AllowedAssemblyNames =
     [
-        "Microsoft.EntityFrameworkCore",
-        "Microsoft.AspNetCore",
-        "Microsoft.Data.SqlClient",
-        "System.Data.SqlClient",
-        "Azure.",
-        "Microsoft.Azure.",
-        "Microsoft.Graph",
+        "System.Collections",
+        "System.ComponentModel.Annotations",
+        "System.Runtime",
     ];
 
     [Fact]
-    public void Domain_assembly_references_no_disallowed_packages()
+    public void Domain_assembly_references_exactly_the_allowlisted_BCL_assemblies()
     {
-        List<string?> violations = DomainAssembly.GetReferencedAssemblies()
-            .Where(referenced => DisallowedAssemblyNamePrefixes.Any(prefix =>
-                referenced.Name?.StartsWith(prefix, StringComparison.Ordinal) == true))
+        List<string?> disallowed = DomainAssembly.GetReferencedAssemblies()
+            .Where(referenced => !AllowedAssemblyNames.Contains(referenced.Name))
             .Select(referenced => referenced.Name)
             .ToList();
 
         Assert.True(
-            violations.Count == 0,
-            $"FoundryGate.Domain references disallowed assemblies: {string.Join(", ", violations)}");
+            disallowed.Count == 0,
+            "FoundryGate.Domain references assemblies outside the allowlist: "
+                + $"{string.Join(", ", disallowed)}. If this is an intentional new BCL "
+                + "dependency, add it to AllowedAssemblyNames with a justification; if "
+                + "it's EF Core/ASP.NET Core/Azure SDK/a third-party package, Domain "
+                + "must not reference it (CONVENTIONS.md zero-dependency rule).");
     }
 
     [Fact]
     public void Domain_assembly_has_no_references_to_other_FoundryGate_projects()
     {
         // Domain must not depend on Data, Api, Web, Functions, or any other
-        // FoundryGate.* project — it is the leaf of the dependency graph.
+        // FoundryGate.* project — it is the leaf of the dependency graph. Redundant
+        // with the allowlist test above (FoundryGate.* names aren't in
+        // AllowedAssemblyNames either) but kept as its own assertion so a failure here
+        // reads immediately as "wrong architectural layer", not "update the allowlist".
         List<string?> foundryGateReferences = DomainAssembly.GetReferencedAssemblies()
             .Where(referenced => referenced.Name?.StartsWith("FoundryGate.", StringComparison.Ordinal) == true)
             .Select(referenced => referenced.Name)

--- a/src/FoundryGate.Tests.Predeployment/Domain/PagedRequestTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/PagedRequestTests.cs
@@ -1,0 +1,64 @@
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+public class PagedRequestTests
+{
+    [Fact]
+    public void Defaults_are_already_in_bounds()
+    {
+        var request = new PagedRequest();
+
+        Assert.Equal(1, request.Page);
+        Assert.Equal(PagedRequest.DefaultPageSize, request.PageSize);
+
+        PagedRequest clamped = request.Clamp();
+        Assert.Equal(request, clamped);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Clamp_normalizes_a_non_positive_page_to_1(int page)
+    {
+        var request = new PagedRequest(page, PagedRequest.DefaultPageSize);
+
+        PagedRequest clamped = request.Clamp();
+
+        Assert.Equal(1, clamped.Page);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Clamp_normalizes_a_non_positive_pageSize_to_the_default(int pageSize)
+    {
+        var request = new PagedRequest(1, pageSize);
+
+        PagedRequest clamped = request.Clamp();
+
+        Assert.Equal(PagedRequest.DefaultPageSize, clamped.PageSize);
+    }
+
+    [Fact]
+    public void Clamp_caps_an_oversized_pageSize_at_the_maximum()
+    {
+        var request = new PagedRequest(1, PagedRequest.MaxPageSize + 1000);
+
+        PagedRequest clamped = request.Clamp();
+
+        Assert.Equal(PagedRequest.MaxPageSize, clamped.PageSize);
+    }
+
+    [Fact]
+    public void Clamp_leaves_an_in_range_pageSize_untouched()
+    {
+        var request = new PagedRequest(3, 50);
+
+        PagedRequest clamped = request.Clamp();
+
+        Assert.Equal(50, clamped.PageSize);
+        Assert.Equal(3, clamped.Page);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/PagedResultTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/PagedResultTests.cs
@@ -1,0 +1,32 @@
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+public class PagedResultTests
+{
+    [Theory]
+    [InlineData(0, 25, 0)]
+    [InlineData(1, 25, 1)]
+    [InlineData(25, 25, 1)]
+    [InlineData(26, 25, 2)]
+    [InlineData(250, 25, 10)]
+    [InlineData(251, 25, 11)]
+    public void TotalPages_is_the_ceiling_of_totalCount_over_pageSize(int totalCount, int pageSize, int expectedTotalPages)
+    {
+        var result = new PagedResult<string>([], totalCount, Page: 1, pageSize);
+
+        Assert.Equal(expectedTotalPages, result.TotalPages);
+    }
+
+    [Fact]
+    public void Empty_factory_produces_a_zero_item_zero_count_page()
+    {
+        PagedResult<int> result = PagedResult<int>.Empty(page: 2, pageSize: 10);
+
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+        Assert.Equal(2, result.Page);
+        Assert.Equal(10, result.PageSize);
+        Assert.Equal(0, result.TotalPages);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Groups.Contracts;
+using FoundryGate.Domain.Requests.Contracts;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>
+/// Smoke-checks that request DTOs' <c>DataAnnotations</c> attributes actually fire
+/// (plans/03-shared-dtos.md verification: "All request DTOs have at least one
+/// validation attribute"). Not exhaustive over every DTO — enough to prove the
+/// pattern (<c>[Required]</c>/<c>[StringLength]</c>/<c>[Range]</c> composed on a
+/// positional record via <c>[property: ...]</c>) actually validates.
+/// </summary>
+public class RequestDtoValidationTests
+{
+    private static IList<ValidationResult> Validate(object dto)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(dto, new ValidationContext(dto), results, validateAllProperties: true);
+        return results;
+    }
+
+    [Fact]
+    public void CreateGroupRequest_with_empty_name_fails_validation()
+    {
+        var request = new CreateGroupRequest(
+            Name: string.Empty,
+            Description: null,
+            EntraGroupId: null,
+            IsUnlimited: false,
+            MonthlyTokenQuota: null);
+
+        IList<ValidationResult> results = Validate(request);
+
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateGroupRequest.Name)));
+    }
+
+    [Fact]
+    public void CreateGroupRequest_with_a_valid_name_passes_validation()
+    {
+        var request = new CreateGroupRequest(
+            Name: "Platform Team",
+            Description: "Core platform developers",
+            EntraGroupId: null,
+            IsUnlimited: false,
+            MonthlyTokenQuota: 5_000_000);
+
+        Assert.Empty(Validate(request));
+    }
+
+    [Fact]
+    public void SubmitQuotaIncreaseRequest_with_too_short_justification_fails_validation()
+    {
+        var request = new SubmitQuotaIncreaseRequest(RequestedQuota: 2_000_000, Justification: "need more");
+
+        IList<ValidationResult> results = Validate(request);
+
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(SubmitQuotaIncreaseRequest.Justification)));
+    }
+
+    [Fact]
+    public void SubmitQuotaIncreaseRequest_with_negative_requestedQuota_fails_validation()
+    {
+        var request = new SubmitQuotaIncreaseRequest(
+            RequestedQuota: -1,
+            Justification: "Running large batch evals against the shared model this sprint.");
+
+        IList<ValidationResult> results = Validate(request);
+
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(SubmitQuotaIncreaseRequest.RequestedQuota)));
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
@@ -48,6 +48,37 @@ public class RequestDtoValidationTests
         Assert.Empty(Validate(request));
     }
 
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("12345")]
+    [InlineData("11111111-2222-3333-4444-55555555555")] // one hex digit short
+    public void CreateGroupRequest_with_a_non_guid_entraGroupId_fails_validation(string entraGroupId)
+    {
+        var request = new CreateGroupRequest(
+            Name: "Platform Team",
+            Description: null,
+            EntraGroupId: entraGroupId,
+            IsUnlimited: false,
+            MonthlyTokenQuota: null);
+
+        IList<ValidationResult> results = Validate(request);
+
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateGroupRequest.EntraGroupId)));
+    }
+
+    [Fact]
+    public void CreateGroupRequest_with_a_guid_shaped_entraGroupId_passes_validation()
+    {
+        var request = new CreateGroupRequest(
+            Name: "Platform Team",
+            Description: null,
+            EntraGroupId: "11111111-2222-3333-4444-555555555555",
+            IsUnlimited: false,
+            MonthlyTokenQuota: null);
+
+        Assert.Empty(Validate(request));
+    }
+
     [Fact]
     public void SubmitQuotaIncreaseRequest_with_too_short_justification_fails_validation()
     {

--- a/src/FoundryGate.Tests.Predeployment/Domain/SystemConfigurationKeysTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/SystemConfigurationKeysTests.cs
@@ -1,0 +1,27 @@
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+public class SystemConfigurationKeysTests
+{
+    [Fact]
+    public void All_contains_exactly_the_eight_seeded_keys_with_no_duplicates()
+    {
+        Assert.Equal(8, SystemConfigurationKeys.All.Count);
+        Assert.Equal(SystemConfigurationKeys.All.Count, SystemConfigurationKeys.All.Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(nameof(SystemConfigurationKeys.DefaultMonthlyTokenQuota))]
+    [InlineData(nameof(SystemConfigurationKeys.ApimResourceId))]
+    [InlineData(nameof(SystemConfigurationKeys.ApimGatewayUrl))]
+    [InlineData(nameof(SystemConfigurationKeys.ApimProductId))]
+    [InlineData(nameof(SystemConfigurationKeys.FoundryResourceId))]
+    [InlineData(nameof(SystemConfigurationKeys.EntraTenantId))]
+    [InlineData(nameof(SystemConfigurationKeys.EntraGroupSyncEnabled))]
+    [InlineData(nameof(SystemConfigurationKeys.ResetDayOfMonth))]
+    public void All_contains_the_named_key(string expectedKey)
+    {
+        Assert.Contains(expectedKey, SystemConfigurationKeys.All);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #24 (request/response DTOs) and #25 (enums, shared constants,
paged-result wrapper) — populates `src/FoundryGate.Domain` (zero dependencies,
per CONVENTIONS.md) with every contract type the API and Blazor WASM client
will share.

- **`Common/`** — `PagedResult<T>` + `PagedRequest` (with `Clamp()` for
  bounds-safe paging), and `ApiError` (an RFC 7807 mirror, not a reference to
  `Microsoft.AspNetCore.Http.ProblemDetails`, so `FoundryGate.Web` can
  deserialize error responses without pulling in an ASP.NET Core dependency).
- **Enums** — `QuotaRequestStatusType` (`Requests/`) and `ModelProviderType`
  (`Config/`), each stored `int`-backed per CONVENTIONS.md.
- **`Constants/`** — `SystemConfigurationKeys` (the eight seeded keys from
  plans/02-data-layer.md), `RoleNames`/`PolicyNames` (`FoundryGate.Admin`),
  `ValidationConstants` (max-length/range bounds shared between API validation
  attributes and future Blazor form validation), and `AuditActions` (see
  decisions below).
- **Per-area `<Area>/Contracts/*Contracts.cs`** — `Users`, `Groups`, `Quota`,
  `Requests`, `Keys`, `Config`, `Audit`, `Dashboard`. `UserProfileResponse`
  (`/me`) embeds the quota gauge, masked API key, and a new
  `GatewayConnectionInfo`/`ModelAliasInfo` CLI-config block so `/me` can render
  the "Configure your CLI" panel (gateway base URL, Anthropic/OpenAI paths,
  the model aliases from plans/25-model-aliases-routing.md).

## Decisions

- **Layout deviates from plan-03's one-file-per-DTO list**: mirrors
  `imagile-app`'s `Imagile.App.Domain.<Area>.Contracts` style instead (one
  `Contracts.cs` per area; enums live directly under `<Area>/`), per this
  task's explicit imagile-alignment direction (mandatory reading item #5).
  DTO *names* still match plan-03 (`UserResponse`, `CreateGroupRequest`, etc.)
  — only the file grouping changed.
- **`AuditLog.Action` stays a `string` constants class, not an enum.** Spec
  §3.1 describes it as free-form text (`"quota.approved"`, `"key.rotated"`)
  and the column isn't `int`-backed; an enum would force a Domain change (and
  a DB migration under the "enums stored as int" convention) every time a new
  admin action needs auditing. `Constants/AuditActions.cs` documents this
  reasoning inline and defines one constant per admin-mutating endpoint in the
  spec, with the two exact strings the spec itself uses
  (`quota.approved`, `key.rotated`, `quota.monthly-reset`) called out.
- **No `UserStatusType`/`KeyStatusType` enums, and no `QuotaLevel` enum
  either** (plan-03 lists `QuotaLevel` alongside the enums it expects `#25` to
  add). Spec's `User` entity has no status column (just `IsActive`), key state
  is fully derived from `ApimSubscriptionId` nullability, and spec has no
  "quota level/tier" concept anywhere in §3 — nothing in the domain model
  resolves to a small closed set of named levels the way quota is actually
  computed (§3.2's precedence chain over `IsUnlimited`/`MonthlyTokenQuota`
  values, not a level). All three would be state invented past what the spec
  defines. `ApiKeyResponse.IsProvisioned` is a plain derived `bool` instead.
- **`PagedRequest` carries no `DataAnnotations`.** It's meant to degrade
  gracefully via `Clamp()`, not 400 the caller for an out-of-range page/size —
  putting `[Range]` on it would fight that behavior under ASP.NET Core's
  automatic model-state validation. Every actual domain-input request DTO
  (`CreateGroupRequest`, `SubmitQuotaIncreaseRequest`, ...) does carry
  attributes.
- **Reconciliation vs. enforcement framing.** Per this pass's direction
  (quota enforcement is real-time at the gateway; usage numbers surfaced to
  the UI are reconciliation data), `QuotaAllocationResponse` and
  `DashboardSummaryResponse` carry doc comments making explicit that
  `TokensUsed`/`PercentUsed`/etc. reflect the last Log Analytics sync (spec
  §5.4), not live enforcement — the gateway's own `x-fg-remaining-*` response
  headers are the real-time source of truth. `IsHardStopped` is preserved
  (admin-facing only) since spec §5.3 sets it on key revocation, not on quota
  exhaustion, so it doesn't actually imply suspension-on-exhaustion.
- **Int PK + Guid Unique.** DTOs expose the data layer's `int` PK plus a
  `{Entity}Unique` `Guid` on `User`, `Group`, and `QuotaIncreaseRequest` — the
  entities judged most likely to be referenced externally (audit trails,
  cross-system correlation). `QuotaAllocation`, `ApiKey`, `AuditLog`, and
  `SystemConfiguration` DTOs stick to the int PK (or, for config, its natural
  string key) since nothing external needs to reference them by a stable id.
- **Plaintext key delivery is a distinct type.** `ApiKeyResponse` (masked,
  returned by every *display* endpoint) and the new `ApiKeyRevealResponse`
  (plaintext, returned ONLY by rotate/provision) are separate records rather
  than one type with a sometimes-null `PlaintextKey` field, so the type system
  documents the one-time-delivery semantic instead of relying on callers to
  remember which endpoints populate the sensitive field.

## Review round 2

Addressed all findings from the first review pass
([comment](https://github.com/kolatts/foundry-gate/pull/91#issuecomment-5497995349)):
plaintext key delivery shape (`ApiKeyRevealResponse`), the architecture test
inverted to an exact allowlist, `EntraGroupId` validation + exposure on
`GroupResponse`, `ApiError.Type`/`Title` made nullable, the email-length RFC
citation corrected, `HasApiKey`→`IsApiKeyProvisioned` naming unified, and the
`QuotaLevel` decision documented above. Point-by-point response posted as a
PR comment. Test count below reflects the added coverage (38, up from 31).

## Verification

- [x] `dotnet build FoundryGate.sln` — 0 warnings, 0 errors
  (`TreatWarningsAsErrors` is on repo-wide, including `GenerateDocumentationFile`
  + `CS1591`-suppressed XML-doc analysis)
- [x] `dotnet test src/FoundryGate.Tests.Predeployment` — 38/38 passing, including:
  - `DomainArchitectureTests` — now an exact allowlist: asserts the compiled
    `FoundryGate.Domain` assembly's `GetReferencedAssemblies()` contains only
    `System.Collections`/`System.ComponentModel.Annotations`/`System.Runtime`
    (captured from a clean build), so any new reference at all — not just the
    previous seven-prefix blocklist — fails the test; doc comment now states
    precisely what direct-IL-reference reflection does and doesn't catch
  - `PagedRequestTests` / `PagedResultTests` — clamping and `TotalPages` logic
  - `SystemConfigurationKeysTests` — the eight seeded keys, no duplicates
  - `RequestDtoValidationTests` — `DataAnnotations` actually fire (via
    `Validator.TryValidateObject`) on representative request DTOs, including
    `EntraGroupId`'s new GUID-shape validation
  - `ApiErrorTests` — a payload missing `type`/`title` deserializes to `null`
    without throwing, using `JsonSerializerDefaults.Web` (case-insensitive
    camelCase, matching how `HttpClient` JSON extensions actually deserialize)
- [x] `dotnet format FoundryGate.sln --verify-no-changes` — clean (exit 0)
- plans/03-shared-dtos.md verification:
  - [x] `dotnet build` passes with zero warnings
  - [x] `FoundryGate.Domain` has no dependencies on ASP.NET Core or EF Core packages
  - [x] All request DTOs have at least one validation attribute
  - [x] `PagedResult<T>` is usable from both the API and the Blazor WASM project
    (plain positional record, no non-portable dependencies; `FoundryGate.Web`
    and `FoundryGate.Api` both already reference `FoundryGate.Domain`)

## Scope notes

- Domain + its own Predeployment tests only — no `FoundryGate.Data` entities,
  `FoundryGate.Api`, or `FoundryGate.Web` touched, per instructions (a parallel
  agent owns the `Data` entities). New test files are namespaced under
  `FoundryGate.Tests.Predeployment.Domain` / a `Domain/` subfolder to avoid
  colliding with that agent's own Predeployment test additions.
- `Foundry/` (deployment DTOs, epic #20) intentionally not touched — plan-03
  notes it's out of scope for #24/#25.
- Current branch already contained PR #90's `.NET 10` scaffold merge and
  matched `origin/main` exactly at start, so no additional merge/pull was
  needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
