### PR TITLE
feat(db): dacpac tables, foundrygate CLI, reusable db-deploy workflow (#77, #78, #79)

### DIFF
--- a/.github/workflows/_deploy-database.yml
+++ b/.github/workflows/_deploy-database.yml
@@ -1,0 +1,163 @@
+name: Deploy Database (Reusable)
+
+# Reusable workflow_call: deploys the FoundryGate.Database dacpac to a target environment's Azure
+# SQL Server, then syncs reference data. Modeled on imagile-app's .github/workflows/_deploy-database.yml
+# (runner IP whitelist -> firewall propagation wait -> TCP probe -> dacpac deploy -> seed), minus
+# the metabase/tenant shard split (a FoundryGate fork IS the tenant, CONVENTIONS.md).
+#
+# Expects two artifacts to already exist in the calling workflow run (produced by a build-dacpac
+# job and a CLI publish job — neither exists yet as of #77/#78/#79; the full-stack orchestration
+# lands with #67's CI/CD epic, e.g. deploy-all.yml):
+#   - "dacpac": contains FoundryGate.Database.dacpac (dotnet build src/FoundryGate.Database -o artifacts)
+#   - "foundrygate-cli": contains a framework-dependent publish of FoundryGate.Cli
+#     (dotnet publish src/FoundryGate.Cli --no-self-contained -o cli)
+#
+# Standalone-valid today: this file's shape (inputs, jobs, steps) does not depend on anything else
+# in #67 to be syntactically/semantically complete, only to actually run successfully end-to-end.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub Environment name (dev, production, ...) — provides the deployment gate and scopes environment secrets."
+        required: true
+        type: string
+      sql-server-name:
+        description: "Azure SQL logical server name (without the .database.windows.net suffix)."
+        required: true
+        type: string
+      sql-database-name:
+        description: "Target database name to deploy the dacpac to."
+        required: true
+        type: string
+      sql-resource-group:
+        description: "Resource group containing the SQL Server, used for connectivity diagnostics."
+        required: true
+        type: string
+      run-seed-test:
+        description: "Whether to also seed Bogus demo data after reference data. Never set true for a production environment."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+jobs:
+  deploy:
+    name: Database - Deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Download dacpac artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dacpac
+          path: ./artifacts
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: foundrygate-cli
+          path: ./cli
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # STUB: `foundrygate ip setup` doesn't whitelist anything real yet — it needs an Azure SQL
+      # Server resource that doesn't exist until the Bicep infra modules (#43/#44) deploy. This
+      # step is kept continue-on-error so the rest of the deploy pipeline shape is exercised today
+      # instead of hard-blocking on infra that isn't built yet. Remove continue-on-error once
+      # https://github.com/kolatts/foundry-gate/issues/96 implements the command for real.
+      - name: Whitelist runner IP address
+        continue-on-error: true
+        run: |
+          dotnet ./cli/FoundryGate.Cli.dll \
+            ip setup \
+            --env ${{ inputs.environment }} \
+            --yes
+
+      - name: Wait for firewall rule propagation
+        run: |
+          echo "Waiting 60 seconds for the firewall rule to propagate..."
+          sleep 60
+
+      - name: Verify network connectivity to SQL Server
+        run: |
+          SERVER_FQDN=$(az sql server show \
+            --name ${{ inputs.sql-server-name }} \
+            --resource-group ${{ inputs.sql-resource-group }} \
+            --query fullyQualifiedDomainName -o tsv)
+
+          echo "Server: $SERVER_FQDN"
+
+          if timeout 10 bash -c "cat < /dev/null > /dev/tcp/${SERVER_FQDN}/1433" 2>/dev/null; then
+            echo "Network connectivity OK - port 1433 is reachable"
+          else
+            echo "Cannot reach SQL Server on port 1433 yet - firewall rule may not have propagated."
+            echo "Waiting an additional 30 seconds..."
+            sleep 30
+          fi
+
+      - name: Deploy dacpac
+        run: |
+          SERVER_FQDN=$(az sql server show \
+            --name ${{ inputs.sql-server-name }} \
+            --resource-group ${{ inputs.sql-resource-group }} \
+            --query fullyQualifiedDomainName -o tsv)
+
+          # Authentication=Active Directory Default lets DacServices/SqlClient pick up the OIDC
+          # token azure/login@v2 already established for this runner (CONVENTIONS.md: no SQL
+          # passwords in the cloud).
+          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
+
+          dotnet ./cli/FoundryGate.Cli.dll \
+            db deploy \
+            ./artifacts/FoundryGate.Database.dacpac \
+            "${CONNECTION_STRING}" \
+            --drop-objects
+
+      - name: Seed reference data
+        run: |
+          SERVER_FQDN=$(az sql server show \
+            --name ${{ inputs.sql-server-name }} \
+            --resource-group ${{ inputs.sql-resource-group }} \
+            --query fullyQualifiedDomainName -o tsv)
+
+          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
+
+          dotnet ./cli/FoundryGate.Cli.dll \
+            db seed-reference \
+            "${CONNECTION_STRING}"
+
+      # Never runs for production: run-seed-test must be explicitly opted into by the caller
+      # (e.g. deploy-all.yml passing true only for the dev environment), and this repo's callers
+      # must never pass true for a production environment input.
+      - name: Seed test data
+        if: inputs.run-seed-test
+        run: |
+          SERVER_FQDN=$(az sql server show \
+            --name ${{ inputs.sql-server-name }} \
+            --resource-group ${{ inputs.sql-resource-group }} \
+            --query fullyQualifiedDomainName -o tsv)
+
+          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
+
+          dotnet ./cli/FoundryGate.Cli.dll \
+            db seed-test \
+            "${CONNECTION_STRING}"

--- a/.github/workflows/_deploy-database.yml
+++ b/.github/workflows/_deploy-database.yml
@@ -14,6 +14,23 @@ name: Deploy Database (Reusable)
 #
 # Standalone-valid today: this file's shape (inputs, jobs, steps) does not depend on anything else
 # in #67 to be syntactically/semantically complete, only to actually run successfully end-to-end.
+#
+# OIDC permissions: a reusable workflow cannot grant itself `id-token: write` — GitHub only issues
+# the ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN that azure/login@v2 needs when the CALLING workflow (or
+# job) declares `permissions: id-token: write, contents: read`. The `permissions:` block below is a
+# same-or-narrower request within whatever the caller already granted, not a grant on its own — every
+# caller of this workflow MUST include that permissions block, e.g.:
+#
+#   jobs:
+#     deploy-database:
+#       uses: ./.github/workflows/_deploy-database.yml
+#       permissions:
+#         id-token: write
+#         contents: read
+#       with: { ... }
+#
+# The "Verify OIDC permissions" step below fails fast with that exact guidance instead of letting
+# azure/login@v2 fail later with a cryptic AADSTS error.
 
 on:
   workflow_call:
@@ -35,7 +52,12 @@ on:
         required: true
         type: string
       run-seed-test:
-        description: "Whether to also seed Bogus demo data after reference data. Never set true for a production environment."
+        description: "Whether to also seed Bogus demo data after reference data. Ignored (forced false) for a production environment regardless of what the caller passes."
+        required: false
+        type: boolean
+        default: false
+      allow-data-loss:
+        description: "Passes --allow-data-loss to `db deploy`, permitting a deployment that could drop/truncate data. Default false (DacFx blocks on possible data loss). Production callers must NEVER set this true without a reviewed migration plan for the affected column(s) — it exists for intentional, one-off schema changes, not routine deploys."
         required: false
         type: boolean
         default: false
@@ -47,13 +69,33 @@ on:
       AZURE_SUBSCRIPTION_ID:
         required: true
 
+# One deploy at a time per target environment — a second run queued mid-deploy would race the
+# first over the same database.
+concurrency:
+  group: deploy-database-${{ inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Database - Deploy to ${{ inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify OIDC permissions are granted
+        run: |
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::ACTIONS_ID_TOKEN_REQUEST_URL is not set. The workflow (or job) that calls" \
+              "_deploy-database.yml must declare 'permissions: id-token: write' and 'contents: read'" \
+              "— this reusable workflow's own 'permissions:' block can only narrow what the caller" \
+              "grants, it cannot add id-token access on its own. See this file's header comment for" \
+              "the exact snippet to add to the caller."
+            exit 1
+          fi
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -79,6 +121,22 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Resolve SQL Server connection details
+        run: |
+          SERVER_FQDN=$(az sql server show \
+            --name ${{ inputs.sql-server-name }} \
+            --resource-group ${{ inputs.sql-resource-group }} \
+            --query fullyQualifiedDomainName -o tsv)
+
+          echo "Server: $SERVER_FQDN"
+          echo "SERVER_FQDN=${SERVER_FQDN}" >> "$GITHUB_ENV"
+
+          # Authentication=Active Directory Default lets DacServices/SqlClient pick up the OIDC
+          # token azure/login@v2 already established for this runner (CONVENTIONS.md: no SQL
+          # passwords in the cloud). Computed once here so every later step uses the identical
+          # string instead of re-deriving (and risking drift between) their own copies.
+          echo "CONNECTION_STRING=Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True" >> "$GITHUB_ENV"
+
       # STUB: `foundrygate ip setup` doesn't whitelist anything real yet — it needs an Azure SQL
       # Server resource that doesn't exist until the Bicep infra modules (#43/#44) deploy. This
       # step is kept continue-on-error so the rest of the deploy pipeline shape is exercised today
@@ -99,13 +157,6 @@ jobs:
 
       - name: Verify network connectivity to SQL Server
         run: |
-          SERVER_FQDN=$(az sql server show \
-            --name ${{ inputs.sql-server-name }} \
-            --resource-group ${{ inputs.sql-resource-group }} \
-            --query fullyQualifiedDomainName -o tsv)
-
-          echo "Server: $SERVER_FQDN"
-
           if timeout 10 bash -c "cat < /dev/null > /dev/tcp/${SERVER_FQDN}/1433" 2>/dev/null; then
             echo "Network connectivity OK - port 1433 is reachable"
           else
@@ -116,48 +167,31 @@ jobs:
 
       - name: Deploy dacpac
         run: |
-          SERVER_FQDN=$(az sql server show \
-            --name ${{ inputs.sql-server-name }} \
-            --resource-group ${{ inputs.sql-resource-group }} \
-            --query fullyQualifiedDomainName -o tsv)
-
-          # Authentication=Active Directory Default lets DacServices/SqlClient pick up the OIDC
-          # token azure/login@v2 already established for this runner (CONVENTIONS.md: no SQL
-          # passwords in the cloud).
-          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
+          DATA_LOSS_FLAG=""
+          if [ "${{ inputs.allow-data-loss }}" = "true" ]; then
+            echo "::warning::--allow-data-loss is set — this deploy can drop/truncate data. Only use this for an intentional, reviewed migration, never a routine deploy."
+            DATA_LOSS_FLAG="--allow-data-loss"
+          fi
 
           dotnet ./cli/FoundryGate.Cli.dll \
             db deploy \
             ./artifacts/FoundryGate.Database.dacpac \
             "${CONNECTION_STRING}" \
-            --drop-objects
+            --drop-objects \
+            ${DATA_LOSS_FLAG}
 
       - name: Seed reference data
         run: |
-          SERVER_FQDN=$(az sql server show \
-            --name ${{ inputs.sql-server-name }} \
-            --resource-group ${{ inputs.sql-resource-group }} \
-            --query fullyQualifiedDomainName -o tsv)
-
-          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
-
           dotnet ./cli/FoundryGate.Cli.dll \
             db seed-reference \
             "${CONNECTION_STRING}"
 
-      # Never runs for production: run-seed-test must be explicitly opted into by the caller
-      # (e.g. deploy-all.yml passing true only for the dev environment), and this repo's callers
-      # must never pass true for a production environment input.
+      # Machine-enforced, not just documented: forces false for production regardless of what the
+      # caller passes, so a copy-pasted `run-seed-test: true` in a production caller can't seed
+      # Bogus demo data into a real environment.
       - name: Seed test data
-        if: inputs.run-seed-test
+        if: inputs.run-seed-test && inputs.environment != 'production'
         run: |
-          SERVER_FQDN=$(az sql server show \
-            --name ${{ inputs.sql-server-name }} \
-            --resource-group ${{ inputs.sql-resource-group }} \
-            --query fullyQualifiedDomainName -o tsv)
-
-          CONNECTION_STRING="Server=${SERVER_FQDN};Database=${{ inputs.sql-database-name }};Authentication=Active Directory Default;Encrypt=True"
-
           dotnet ./cli/FoundryGate.Cli.dll \
             db seed-test \
             "${CONNECTION_STRING}"

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -32,7 +32,10 @@
   tenant-connection resolvers/factories, no `CurrentTenantContext`, no shard math.
   A fork IS the tenant.
 - Cloud SQL auth: `Authentication=Active Directory Default` (no SQL passwords);
-  local: `Server=localhost,3433;User Id=sa;Password=<local only>` via docker-compose.
+  local: `Server=127.0.0.1,3433;User Id=sa;Password=<local only>` via docker-compose (use the
+  literal `127.0.0.1`, not `localhost` — SqlClient's dual-stack resolution can time out probing the
+  container's IPv6 loopback, which docker's port mapping doesn't listen on, before falling back to
+  IPv4, even though the port is reachable).
 - Entity config: data annotations first; `internal sealed` `IEntityTypeConfiguration`
   **co-located in the entity's file** only for what annotations can't express
   (delete behavior, composite keys); applied via `ApplyConfigurationsFromAssembly`.
@@ -70,7 +73,11 @@
 - EF entities are the model source of truth. Local: CLI `local setup` runs
   `EnsureCreated` against docker SQL; DacFx schema-compare regenerates the checked-in
   `FoundryGate.Database/dbo/Tables/*.sql`; `.sqlproj` builds the **dacpac**; CI
-  deploys via CLI `db deploy` (DacServices, `--drop-objects` in CI).
+  deploys via CLI `db deploy` (DacServices, `--drop-objects` in CI). Data-loss blocking is **on by
+  default** (DacFx's own `BlockOnPossibleDataLoss=true`) and requires an explicit
+  `--allow-data-loss`/`allow-data-loss: true` override to bypass — a deliberate deviation from
+  imagile-app (which inverts this to opt-in blocking), because a fork's production database
+  deserves a safe default more than CI convenience does.
 - Seeding is code, idempotent, run post-deploy: reference data via the
   `IReferenceDataEntity`/`SyncReferenceDataAsync` pattern
   (Imagile.Framework `[DoNotUpdate]` respected); demo/test data via **Bogus**;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
 
     <!-- Cli -->
     <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.SqlServer.DacFx" Version="170.2.70" />
 
     <!-- Web -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />

--- a/plans/23-database-tooling.md
+++ b/plans/23-database-tooling.md
@@ -24,6 +24,12 @@ Table file names below also use each table's actual (plural) name —
 `AppDbContext`'s `DbSet` names and the file-name-equals-table-name convention the parity test
 depends on.
 
+The parity test's documented gaps (no data type/length/precision checking, no composite-FK
+support, no index-composition validation beyond the `UNIQUE` flag) and the `db compare` deferral
+above are tracked as follow-up work in
+[#100](https://github.com/kolatts/foundry-gate/issues/100) rather than left as inline TODOs, per
+CLAUDE.md's "everything is a GitHub issue" rule.
+
 ## Overview
 Foundry Gate uses a hybrid schema management approach borrowed from imagile-app: EF Core migrations are the developer-facing workflow (fast iteration, `dotnet ef migrations add`), but the canonical schema artifact is a `.sqlproj` file that DacFx can build into a dacpac. A `FoundryGate.Cli` dotnet tool ties it together — `Foundry Gate db compare` runs a DacFx schema comparison between the local database (kept current by EF migrations) and the `.sqlproj` files, then publishes any delta back into the project's SQL files. CI builds the dacpac and the CLI deploys it. This gives the precision of dacpac-based deployments without abandoning EF's migration ergonomics.
 

--- a/plans/23-database-tooling.md
+++ b/plans/23-database-tooling.md
@@ -4,8 +4,31 @@
 > Milestone: v0.1 — Foundation  
 > Labels: epic, backend
 
+## Status update (2026-09-01, #77/#78/#79 implemented)
+
+CONVENTIONS.md's finalized "Schema pipeline" section (written after this plan) supersedes the
+`dotnet ef migrations add` / `db compare` workflow described below — **CONVENTIONS.md wins**. The
+actual pipeline implemented: EF entities are the schema source of truth → `local setup` runs
+`EnsureCreated` against docker SQL → the `dbo/Tables/*.sql` files are hand-authored to match the EF
+model (verified by a regex-level Predeployment parity test, since DacFx schema-compare is
+Windows-only native tooling and isn't available in every environment these run in) → `.sqlproj`
+builds the dacpac → CI/CD `db deploy`. No EF Core migrations exist or are planned; `foundrygate db
+compare` (and the `LibGit2Sharp`/ordering-noise-discarding machinery it implied) was **not**
+implemented — there is no live database to compare *from* in this model, only the checked-in .sql
+files compared *against* the entity model via the parity test. The CLI also uses
+`System.CommandLine` (already pinned in `Directory.Packages.props`), not `Spectre.Console.Cli` as
+originally planned below.
+
+Table file names below also use each table's actual (plural) name —
+`SystemConfigurations.sql`/`AuditLogs.sql`, not `SystemConfiguration.sql`/`AuditLog.sql` — to match
+`AppDbContext`'s `DbSet` names and the file-name-equals-table-name convention the parity test
+depends on.
+
 ## Overview
 Foundry Gate uses a hybrid schema management approach borrowed from imagile-app: EF Core migrations are the developer-facing workflow (fast iteration, `dotnet ef migrations add`), but the canonical schema artifact is a `.sqlproj` file that DacFx can build into a dacpac. A `FoundryGate.Cli` dotnet tool ties it together — `Foundry Gate db compare` runs a DacFx schema comparison between the local database (kept current by EF migrations) and the `.sqlproj` files, then publishes any delta back into the project's SQL files. CI builds the dacpac and the CLI deploys it. This gives the precision of dacpac-based deployments without abandoning EF's migration ergonomics.
+
+> **Historical note**: the section above is the original plan and is now superseded by the Status
+> update note (no EF migrations, no `db compare`). Kept for context on how the design evolved.
 
 ---
 
@@ -47,16 +70,22 @@ src/
 ### Add FoundryGate.Database .sqlproj and populate initial SQL files (#77)
 Create `src/FoundryGate.Database/FoundryGate.Database.sqlproj` using SDK `Microsoft.Build.Sql/2.0.0` targeting `SqlAzureV12DatabaseSchemaProvider`. Add one `.sql` file per table under `dbo/Tables/` matching the EF entities defined in epic #2 exactly (column names, types, nullability, and indexes). The `.sqlproj` is the schema source of truth for dacpac generation — it must stay in sync with EF migrations via the `Foundry Gate db compare` workflow, not be edited by hand. Add the project to `FoundryGate.sln`. The dacpac output goes to `artifacts/FoundryGate.Database.dacpac` for the CI pipeline to consume.
 
-Files expected to be created or modified:
-- `src/FoundryGate.Database/FoundryGate.Database.sqlproj`
+Files actually created (see the Status update note for the `SystemConfigurations`/`AuditLogs` naming correction):
+- `src/FoundryGate.Database/FoundryGate.Database.sqlproj` (already scaffolded by #1 at
+  `Microsoft.Build.Sql/2.2.0`, not `2.0.0` as originally planned)
 - `src/FoundryGate.Database/dbo/Tables/Users.sql`
 - `src/FoundryGate.Database/dbo/Tables/Groups.sql`
 - `src/FoundryGate.Database/dbo/Tables/GroupMembers.sql`
 - `src/FoundryGate.Database/dbo/Tables/QuotaAllocations.sql`
 - `src/FoundryGate.Database/dbo/Tables/QuotaIncreaseRequests.sql`
-- `src/FoundryGate.Database/dbo/Tables/SystemConfiguration.sql`
-- `src/FoundryGate.Database/dbo/Tables/AuditLog.sql`
-- `FoundryGate.sln`
+- `src/FoundryGate.Database/dbo/Tables/SystemConfigurations.sql`
+- `src/FoundryGate.Database/dbo/Tables/AuditLogs.sql`
+- `src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs` (new — the drift
+  alarm substituting for `db compare`)
+
+`FoundryGate.sln` already referenced the project (scaffolded by #1); no change needed. The SDK
+globs `dbo/**/*.sql` by default, so no explicit `<ItemGroup>`/`<Folder>` wiring was needed for the
+new files either — verified by `dotnet build src/FoundryGate.Database` picking them all up.
 
 ### Add FoundryGate.Cli dotnet tool with db compare, deploy, and seed commands (#78)
 Create `src/FoundryGate.Cli/FoundryGate.Cli.csproj` as a packable dotnet tool (`PackAsTool: true`, `ToolCommandName: Foundry Gate`). Reference `FoundryGate.Data` for DbContext access. Use `Spectre.Console.Cli` for command structure and `Spectre.Console` for output. Key packages: `Microsoft.SqlServer.DacFx`, `LibGit2Sharp`.
@@ -99,16 +128,23 @@ One-command local dev bootstrap:
 5. Run `Foundry Gate db seed --env local`
 6. Print connection string for `appsettings.Development.json`
 
-Files expected to be created or modified:
-- `src/FoundryGate.Cli/FoundryGate.Cli.csproj`
-- `src/FoundryGate.Cli/Program.cs`
-- `src/FoundryGate.Cli/Commands/Db/Compare/CompareCommand.cs`
+Files actually created (`System.CommandLine`, not `Spectre.Console.Cli`; no `db compare`/`db seed`,
+`db seed-reference` + `db seed-test` instead per CONVENTIONS.md's reference-vs-test-data seeding
+split; `ip setup` stub added — see the Status update note):
+- `src/FoundryGate.Cli/FoundryGate.Cli.csproj` (already scaffolded by #1)
+- `src/FoundryGate.Cli/Program.cs` (already scaffolded by #1; wired to the new commands)
+- `src/FoundryGate.Cli/Commands/Db/DbCommand.cs`
 - `src/FoundryGate.Cli/Commands/Db/Deploy/DeployCommand.cs`
-- `src/FoundryGate.Cli/Commands/Db/Seed/SeedCommand.cs`
+- `src/FoundryGate.Cli/Commands/Db/SeedReference/SeedReferenceCommand.cs`
+- `src/FoundryGate.Cli/Commands/Db/SeedTest/SeedTestCommand.cs`
+- `src/FoundryGate.Cli/Commands/Local/LocalCommand.cs`
 - `src/FoundryGate.Cli/Commands/Local/Setup/SetupCommand.cs`
-- `src/FoundryGate.Cli/Helpers/SchemaComparisonHelpers.cs`
-- `src/FoundryGate.Cli/Helpers/DatabaseHelpers.cs`
-- `FoundryGate.sln`
+- `src/FoundryGate.Cli/Commands/Ip/IpCommand.cs`
+- `src/FoundryGate.Cli/Commands/Ip/Setup/SetupCommand.cs` (stub — #96)
+- `src/FoundryGate.Cli/Helpers/CliDbContextFactory.cs`
+- `.github/workflows/_deploy-database.yml` (#79)
+
+`FoundryGate.sln` already referenced the project (scaffolded by #1); no change needed.
 
 ---
 
@@ -157,13 +193,50 @@ build-dacpac:
 
 A separate `db-deploy.yml` workflow (reusable, `workflow_call`) downloads the dacpac artifact and runs `Foundry Gate db deploy` against the target environment.
 
+> **Naming correction**: implemented as `.github/workflows/_deploy-database.yml` (leading
+> underscore, matching imagile-app's convention for `workflow_call`-only files that never trigger
+> directly) rather than `db-deploy.yml`. It does not yet have a `build-dacpac`
+> job/caller to feed it artifacts — that lands with #67's CI/CD epic — but the file's `inputs`/
+> `jobs` shape is standalone-valid today (see its own header comment for the exact artifact names
+> it expects: `dacpac` and `foundrygate-cli`).
+
 ---
 
 ## Verification
-- [ ] `dotnet build src/FoundryGate.Database` produces a `.dacpac` file
-- [ ] `Foundry Gate local setup` creates a local SQL Server container, applies migrations, and seeds
-- [ ] `Foundry Gate db compare` on a clean repo produces no changes (schema already in sync)
-- [ ] Adding a new EF migration and running `Foundry Gate db compare` updates the corresponding `.sql` file
-- [ ] `Foundry Gate db compare` on Linux exits with a clear "Windows-only" error message
-- [ ] `Foundry Gate db deploy` successfully deploys to a local SQL Server instance
-- [ ] `Foundry Gate db deploy` blocks on possible data loss when `--drop` is not specified
+
+- [x] `dotnet build src/FoundryGate.Database` produces a `.dacpac` file — builds clean, 0 warnings
+      (`src/FoundryGate.Database/bin/Debug/FoundryGate.Database.dacpac`).
+- [x] `dotnet build FoundryGate.sln` — 0 warnings, 0 errors across all 9 projects including the
+      dacpac.
+- [x] `dotnet test src/FoundryGate.Tests.Predeployment` — 66/66 passing, including the new
+      `SchemaParityTests.CheckedInSqlFiles_ShouldMatchEfModel` drift alarm (verified it actually
+      catches drift, not just passes vacuously, by injecting a deliberate column-name mismatch and
+      confirming the test failed with the expected violation messages before reverting).
+- [x] `dotnet format FoundryGate.sln --verify-no-changes` — clean.
+- [x] `dotnet run --project src/FoundryGate.Cli -- local setup --test-data` against docker SQL
+      (`docker compose up -d`, port 3433) — dropped, `EnsureCreated`, seeded 8
+      `SystemConfiguration` rows + Bogus demo data end-to-end. Verified via `sqlcmd` inside the
+      container: 7 tables created (`Users`, `Groups`, `GroupMembers`, `QuotaAllocations`,
+      `QuotaIncreaseRequests`, `SystemConfigurations`, `AuditLogs`), row counts match
+      `TestDataSeeder`'s output (8 users, 1 group, 3 members, 8 allocations, 1 request, 8 config
+      keys).
+- [x] `dotnet run --project src/FoundryGate.Cli -- db deploy <dacpac> <connection-string>
+      --drop-objects` deployed the built dacpac to a **second** local database
+      (`FoundryGateDeployTest`) against the same docker SQL Server, confirming `db deploy` works
+      independently of `local setup`'s `EnsureCreated` path. Also ran `db seed-reference` and
+      `db seed-test` against that same deployed database to exercise the full CLI surface.
+- [x] **Bonus**: this `db deploy` run against real SQL Server is the first time the FK
+      `DeleteBehavior` graph from #92 (Group→GroupMember, User→QuotaAllocation,
+      User→QuotaIncreaseRequest cascade; everything else `NoAction`) has been checked against
+      anything other than SQLite in-memory. It deployed clean with **no** "multiple cascade
+      paths" error, and `sys.foreign_keys` on the deployed database confirms the exact intended
+      `CASCADE`/`NO_ACTION` split — directly resolves #94's ask; see PR body for the query output.
+- [x] `docker compose down` — torn back down after verification.
+- [ ] `Foundry Gate db compare` — **not implemented** (see the Status update note above): DacFx
+      schema-compare is Windows-only and there is no live-database-to-compare-from in the
+      EnsureCreated-based pipeline this repo actually uses. The `SchemaParityTests` Predeployment
+      test is the substitute drift check, and it runs cross-platform in CI.
+- [x] `foundrygate ip setup` is a documented stub (issues #96 tracks the real implementation) that
+      prints guidance and exits 1 rather than doing anything; the reusable
+      `.github/workflows/_deploy-database.yml` (#79) calls it with `continue-on-error: true` and a
+      comment pointing at #96.

--- a/src/FoundryGate.Api/appsettings.Development.json
+++ b/src/FoundryGate.Api/appsettings.Development.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "FoundryGate": "Server=localhost,3433;Database=FoundryGate;User Id=sa;Password=Temp1234!;TrustServerCertificate=True"
+    "FoundryGate": "Server=127.0.0.1,3433;Database=FoundryGate;User Id=sa;Password=Temp1234!;TrustServerCertificate=True"
   }
 }

--- a/src/FoundryGate.Cli/Commands/Db/DbCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/DbCommand.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+using FoundryGate.Cli.Commands.Db.Deploy;
+using FoundryGate.Cli.Commands.Db.SeedReference;
+using FoundryGate.Cli.Commands.Db.SeedTest;
+
+namespace FoundryGate.Cli.Commands.Db;
+
+/// <summary>Parent command grouping the FoundryGate database lifecycle subcommands.</summary>
+internal sealed class DbCommand : Command
+{
+    public DbCommand() : base("db", "Commands to manage the FoundryGate database")
+    {
+        Add(new DeployCommand());
+        Add(new SeedReferenceCommand());
+        Add(new SeedTestCommand());
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Db/Deploy/DeployCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/Deploy/DeployCommand.cs
@@ -15,6 +15,8 @@ namespace FoundryGate.Cli.Commands.Db.Deploy;
 /// </summary>
 internal sealed class DeployCommand : Command
 {
+    private static readonly TimeSpan DeployTimeout = TimeSpan.FromMinutes(10);
+
     public DeployCommand() : base("deploy", "Deploys a dacpac to a target SQL Server database")
     {
         var dacpacArg = new Argument<string>("dacpac")
@@ -32,28 +34,37 @@ internal sealed class DeployCommand : Command
             Description = "Drop objects in the target database that are not present in the dacpac"
         };
 
-        var blockOnDataLossOption = new Option<bool>("--block-on-data-loss", "-b")
+        // Safety is the default (DacFx's own BlockOnPossibleDataLoss=true) — CONVENTIONS.md
+        // deliberately deviates from imagile-app here (which inverts this to opt-in blocking): a
+        // fork's production database deserves a safe default more than CI convenience does. Pass
+        // --allow-data-loss to explicitly opt out.
+        var allowDataLossOption = new Option<bool>("--allow-data-loss")
         {
-            Description = "Block the deployment if it could cause data loss"
+            Description = "Allow the deployment to proceed even if it could cause data loss (default: blocked)"
         };
 
         Add(dacpacArg);
         Add(connectionStringArg);
         Add(dropObjectsOption);
-        Add(blockOnDataLossOption);
+        Add(allowDataLossOption);
 
-        SetAction(context =>
+        SetAction(async (context, cancellationToken) =>
         {
             var dacpacPath = context.GetValue(dacpacArg)!;
             var connectionString = context.GetValue(connectionStringArg)!;
             var dropObjects = context.GetValue(dropObjectsOption);
-            var blockOnDataLoss = context.GetValue(blockOnDataLossOption);
+            var allowDataLoss = context.GetValue(allowDataLossOption);
 
-            Execute(dacpacPath, connectionString, dropObjects, blockOnDataLoss);
+            await ExecuteAsync(dacpacPath, connectionString, dropObjects, allowDataLoss, cancellationToken);
         });
     }
 
-    private static void Execute(string dacpacPath, string connectionString, bool dropObjects, bool blockOnDataLoss)
+    private static async Task ExecuteAsync(
+        string dacpacPath,
+        string connectionString,
+        bool dropObjects,
+        bool allowDataLoss,
+        CancellationToken cancellationToken)
     {
         if (!File.Exists(dacpacPath))
         {
@@ -69,7 +80,7 @@ internal sealed class DeployCommand : Command
         }
 
         Console.WriteLine($"Deploying {Path.GetFileName(dacpacPath)} to {builder.DataSource}/{databaseName}...");
-        Console.WriteLine($"  --drop-objects: {dropObjects}, --block-on-data-loss: {blockOnDataLoss}");
+        Console.WriteLine($"  --drop-objects: {dropObjects}, --allow-data-loss: {allowDataLoss} (BlockOnPossibleDataLoss: {!allowDataLoss})");
 
         var dacServices = new DacServices(connectionString);
         dacServices.ProgressChanged += (_, args) => Console.WriteLine(args.Message);
@@ -87,15 +98,22 @@ internal sealed class DeployCommand : Command
 
         var options = new DacDeployOptions
         {
-            BlockOnPossibleDataLoss = blockOnDataLoss,
+            BlockOnPossibleDataLoss = !allowDataLoss,
             GenerateSmartDefaults = true,
             DropObjectsNotInSource = dropObjects,
             ExcludeObjectTypes = [ObjectType.Users],
             ScriptDatabaseCompatibility = true
         };
 
+        // Same 10-minute deploy ceiling imagile-app's DeployCommand uses, linked to the process's
+        // own cancellation (Ctrl+C) so either one aborts the blocking DacServices.Deploy call.
+        using var timeoutSource = new CancellationTokenSource(DeployTimeout);
+        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutSource.Token);
+
         using var package = DacPackage.Load(dacpacPath);
-        dacServices.Deploy(package, databaseName, upgradeExisting: true, options);
+        await Task.Run(
+            () => dacServices.Deploy(package, databaseName, upgradeExisting: true, options, linkedSource.Token),
+            linkedSource.Token);
 
         Console.WriteLine($"Deployed {databaseName} successfully.");
     }

--- a/src/FoundryGate.Cli/Commands/Db/Deploy/DeployCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/Deploy/DeployCommand.cs
@@ -1,0 +1,102 @@
+using System.CommandLine;
+using Microsoft.Data.SqlClient;
+using Microsoft.SqlServer.Dac;
+
+namespace FoundryGate.Cli.Commands.Db.Deploy;
+
+/// <summary>
+/// Deploys a built dacpac (<c>dotnet build src/FoundryGate.Database</c>) to a target SQL Server
+/// database via DacFx <see cref="DacServices"/>. Works against both SQL auth (connection string
+/// carries <c>User Id</c>/<c>Password</c>, e.g. local docker SQL) and Entra auth (connection string
+/// carries <c>Authentication=Active Directory Default</c>, per CONVENTIONS.md) — <see cref="DacServices"/>
+/// reads the auth method straight out of the connection string, so no separate credential plumbing
+/// is needed here (unlike imagile-app's metabase/tenant split, which explicitly branches on SQL vs.
+/// Entra auth to build a <c>DacServicesAuthProvider</c>).
+/// </summary>
+internal sealed class DeployCommand : Command
+{
+    public DeployCommand() : base("deploy", "Deploys a dacpac to a target SQL Server database")
+    {
+        var dacpacArg = new Argument<string>("dacpac")
+        {
+            Description = "Path to the built dacpac file"
+        };
+
+        var connectionStringArg = new Argument<string>("connection-string")
+        {
+            Description = "Connection string to the target database (must include Initial Catalog)"
+        };
+
+        var dropObjectsOption = new Option<bool>("--drop-objects", "-d")
+        {
+            Description = "Drop objects in the target database that are not present in the dacpac"
+        };
+
+        var blockOnDataLossOption = new Option<bool>("--block-on-data-loss", "-b")
+        {
+            Description = "Block the deployment if it could cause data loss"
+        };
+
+        Add(dacpacArg);
+        Add(connectionStringArg);
+        Add(dropObjectsOption);
+        Add(blockOnDataLossOption);
+
+        SetAction(context =>
+        {
+            var dacpacPath = context.GetValue(dacpacArg)!;
+            var connectionString = context.GetValue(connectionStringArg)!;
+            var dropObjects = context.GetValue(dropObjectsOption);
+            var blockOnDataLoss = context.GetValue(blockOnDataLossOption);
+
+            Execute(dacpacPath, connectionString, dropObjects, blockOnDataLoss);
+        });
+    }
+
+    private static void Execute(string dacpacPath, string connectionString, bool dropObjects, bool blockOnDataLoss)
+    {
+        if (!File.Exists(dacpacPath))
+        {
+            throw new FileNotFoundException($"Dacpac file not found: {dacpacPath}", dacpacPath);
+        }
+
+        var builder = new SqlConnectionStringBuilder(connectionString);
+        var databaseName = builder.InitialCatalog;
+        if (string.IsNullOrWhiteSpace(databaseName))
+        {
+            throw new InvalidOperationException(
+                "Connection string must specify an Initial Catalog/Database to deploy to.");
+        }
+
+        Console.WriteLine($"Deploying {Path.GetFileName(dacpacPath)} to {builder.DataSource}/{databaseName}...");
+        Console.WriteLine($"  --drop-objects: {dropObjects}, --block-on-data-loss: {blockOnDataLoss}");
+
+        var dacServices = new DacServices(connectionString);
+        dacServices.ProgressChanged += (_, args) => Console.WriteLine(args.Message);
+        dacServices.Message += (_, args) =>
+        {
+            if (args.Message.MessageType == DacMessageType.Error)
+            {
+                Console.Error.WriteLine(args.Message.Message);
+            }
+            else
+            {
+                Console.WriteLine(args.Message.Message);
+            }
+        };
+
+        var options = new DacDeployOptions
+        {
+            BlockOnPossibleDataLoss = blockOnDataLoss,
+            GenerateSmartDefaults = true,
+            DropObjectsNotInSource = dropObjects,
+            ExcludeObjectTypes = [ObjectType.Users],
+            ScriptDatabaseCompatibility = true
+        };
+
+        using var package = DacPackage.Load(dacpacPath);
+        dacServices.Deploy(package, databaseName, upgradeExisting: true, options);
+
+        Console.WriteLine($"Deployed {databaseName} successfully.");
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Db/SeedReference/SeedReferenceCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/SeedReference/SeedReferenceCommand.cs
@@ -1,0 +1,46 @@
+using System.CommandLine;
+using FoundryGate.Cli.Helpers;
+using FoundryGate.Data.Seeding;
+
+namespace FoundryGate.Cli.Commands.Db.SeedReference;
+
+/// <summary>
+/// Syncs the code-defined reference data (currently <c>SystemConfiguration</c>'s eight placeholder
+/// keys, via <see cref="ReferenceDataSeeder"/>) to the target database. Idempotent and safe to run
+/// on every deploy — see <c>ReferenceDataExtensions.SyncReferenceDataAsync</c> for the
+/// <c>[DoNotUpdate]</c>-respecting upsert semantics that keep it from clobbering operator edits.
+/// </summary>
+internal sealed class SeedReferenceCommand : Command
+{
+    public SeedReferenceCommand() : base("seed-reference", "Syncs code-defined reference data to the target database")
+    {
+        var connectionStringArg = new Argument<string>("connection-string")
+        {
+            Description = "Connection string to the target database"
+        };
+
+        Add(connectionStringArg);
+
+        SetAction(async context =>
+        {
+            var connectionString = context.GetValue(connectionStringArg)!;
+            await ExecuteAsync(connectionString);
+        });
+    }
+
+    private static async Task ExecuteAsync(string connectionString)
+    {
+        await using var context = CliDbContextFactory.Create(connectionString);
+
+        Console.WriteLine("Syncing reference data...");
+        var results = await ReferenceDataSeeder.SeedAsync(context);
+        foreach (var (entityName, result) in results)
+        {
+            Console.WriteLine(result.TotalChanges == 0
+                ? $"  {entityName}: no changes"
+                : $"  {entityName}: +{result.Added} ~{result.Updated} -{result.Deleted}");
+        }
+
+        Console.WriteLine("Reference data sync complete.");
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Db/SeedReference/SeedReferenceCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/SeedReference/SeedReferenceCommand.cs
@@ -21,19 +21,19 @@ internal sealed class SeedReferenceCommand : Command
 
         Add(connectionStringArg);
 
-        SetAction(async context =>
+        SetAction(async (context, cancellationToken) =>
         {
             var connectionString = context.GetValue(connectionStringArg)!;
-            await ExecuteAsync(connectionString);
+            await ExecuteAsync(connectionString, cancellationToken);
         });
     }
 
-    private static async Task ExecuteAsync(string connectionString)
+    private static async Task ExecuteAsync(string connectionString, CancellationToken cancellationToken)
     {
         await using var context = CliDbContextFactory.Create(connectionString);
 
         Console.WriteLine("Syncing reference data...");
-        var results = await ReferenceDataSeeder.SeedAsync(context);
+        var results = await ReferenceDataSeeder.SeedAsync(context, cancellationToken);
         foreach (var (entityName, result) in results)
         {
             Console.WriteLine(result.TotalChanges == 0

--- a/src/FoundryGate.Cli/Commands/Db/SeedTest/SeedTestCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/SeedTest/SeedTestCommand.cs
@@ -20,19 +20,19 @@ internal sealed class SeedTestCommand : Command
 
         Add(connectionStringArg);
 
-        SetAction(async context =>
+        SetAction(async (context, cancellationToken) =>
         {
             var connectionString = context.GetValue(connectionStringArg)!;
-            await ExecuteAsync(connectionString);
+            await ExecuteAsync(connectionString, cancellationToken);
         });
     }
 
-    private static async Task ExecuteAsync(string connectionString)
+    private static async Task ExecuteAsync(string connectionString, CancellationToken cancellationToken)
     {
         await using var context = CliDbContextFactory.Create(connectionString);
 
         Console.WriteLine("Seeding demo test data...");
-        await TestDataSeeder.SeedAsync(context, TimeProvider.System);
+        await TestDataSeeder.SeedAsync(context, TimeProvider.System, cancellationToken: cancellationToken);
 
         Console.WriteLine("Test data seeding complete.");
     }

--- a/src/FoundryGate.Cli/Commands/Db/SeedTest/SeedTestCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Db/SeedTest/SeedTestCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using FoundryGate.Cli.Helpers;
+using FoundryGate.Data.Seeding;
+
+namespace FoundryGate.Cli.Commands.Db.SeedTest;
+
+/// <summary>
+/// Seeds Bogus-generated demo data (<see cref="TestDataSeeder"/>) to the target database.
+/// Local/dev/CI only — never run against a production connection string. No-ops if any
+/// <c>User</c> row already exists, so it is safe to call repeatedly without piling up duplicates.
+/// </summary>
+internal sealed class SeedTestCommand : Command
+{
+    public SeedTestCommand() : base("seed-test", "Seeds Bogus-generated demo data to the target database (local/dev/CI only)")
+    {
+        var connectionStringArg = new Argument<string>("connection-string")
+        {
+            Description = "Connection string to the target database"
+        };
+
+        Add(connectionStringArg);
+
+        SetAction(async context =>
+        {
+            var connectionString = context.GetValue(connectionStringArg)!;
+            await ExecuteAsync(connectionString);
+        });
+    }
+
+    private static async Task ExecuteAsync(string connectionString)
+    {
+        await using var context = CliDbContextFactory.Create(connectionString);
+
+        Console.WriteLine("Seeding demo test data...");
+        await TestDataSeeder.SeedAsync(context, TimeProvider.System);
+
+        Console.WriteLine("Test data seeding complete.");
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Ip/IpCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Ip/IpCommand.cs
@@ -1,0 +1,13 @@
+using System.CommandLine;
+using FoundryGate.Cli.Commands.Ip.Setup;
+
+namespace FoundryGate.Cli.Commands.Ip;
+
+/// <summary>Parent command grouping Azure SQL Server firewall management subcommands.</summary>
+internal sealed class IpCommand : Command
+{
+    public IpCommand() : base("ip", "Commands to manage Azure SQL Server firewall rules")
+    {
+        Add(new SetupCommand());
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Ip/Setup/SetupCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Ip/Setup/SetupCommand.cs
@@ -1,0 +1,49 @@
+using System.CommandLine;
+
+namespace FoundryGate.Cli.Commands.Ip.Setup;
+
+/// <summary>
+/// STUB. Real implementation is blocked on the Azure SQL Server resource that doesn't exist in
+/// this repo yet (it lands with the Bicep infra modules, #43/#44) — see
+/// <see href="https://github.com/kolatts/foundry-gate/issues/96">#96</see> for the full plan
+/// (detect caller public IP, ArmClient + <c>SqlFirewallRuleResource</c> CreateOrUpdate, modeled on
+/// imagile-app's <c>Imagile.App.Cli\Commands\Ip\Setup\SetupCommand.cs</c>).
+/// <para>
+/// This stub exists purely so <c>.github/workflows/_deploy-database.yml</c> (#79) has the right
+/// command shape to call today; that workflow marks the calling step <c>continue-on-error: true</c>
+/// with a comment pointing at #96 until this is implemented for real.
+/// </para>
+/// </summary>
+internal sealed class SetupCommand : Command
+{
+    public SetupCommand() : base("setup", "STUB (see #96): whitelists the caller's public IP on the target environment's Azure SQL Server")
+    {
+        var envOption = new Option<string>("--env")
+        {
+            Description = "Target environment (e.g. dev, prod)",
+            Required = true
+        };
+
+        var yesOption = new Option<bool>("--yes", "-y")
+        {
+            Description = "Accepted for forward compatibility with the reusable deploy workflow; unused by this stub"
+        };
+
+        Add(envOption);
+        Add(yesOption);
+
+        SetAction(context =>
+        {
+            var environment = context.GetValue(envOption);
+
+            Console.Error.WriteLine(
+                $"'ip setup' is not implemented yet for environment '{environment}'. It needs a real " +
+                "Azure SQL Server resource (Bicep infra, #43/#44) before a firewall rule can be " +
+                "created against it. See https://github.com/kolatts/foundry-gate/issues/96 for the " +
+                "full implementation plan (detect caller public IP -> SqlFirewallRuleResource " +
+                "CreateOrUpdate, modeled on imagile-app's Ip/Setup/SetupCommand.cs).");
+
+            return 1;
+        });
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Local/LocalCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Local/LocalCommand.cs
@@ -1,0 +1,13 @@
+using System.CommandLine;
+using FoundryGate.Cli.Commands.Local.Setup;
+
+namespace FoundryGate.Cli.Commands.Local;
+
+/// <summary>Parent command grouping local development environment subcommands.</summary>
+internal sealed class LocalCommand : Command
+{
+    public LocalCommand() : base("local", "Commands for local development environment setup")
+    {
+        Add(new SetupCommand());
+    }
+}

--- a/src/FoundryGate.Cli/Commands/Local/Setup/SetupCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Local/Setup/SetupCommand.cs
@@ -31,27 +31,27 @@ internal sealed class SetupCommand : Command
 
         Add(testDataOption);
 
-        SetAction(async context =>
+        SetAction(async (context, cancellationToken) =>
         {
             var seedTestData = context.GetValue(testDataOption);
-            await ExecuteAsync(seedTestData);
+            await ExecuteAsync(seedTestData, cancellationToken);
         });
     }
 
-    private static async Task ExecuteAsync(bool seedTestData)
+    private static async Task ExecuteAsync(bool seedTestData, CancellationToken cancellationToken)
     {
-        Console.WriteLine("Connecting to local SQL Server (localhost,3433)...");
+        Console.WriteLine($"Connecting to local SQL Server ({LocalConnectionString})...");
 
         await using var context = CliDbContextFactory.Create(LocalConnectionString);
 
         Console.WriteLine("Dropping any existing FoundryGate database...");
-        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureDeletedAsync(cancellationToken);
 
         Console.WriteLine("Creating FoundryGate database from the current EF model...");
-        await context.Database.EnsureCreatedAsync();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
 
         Console.WriteLine("Seeding reference data...");
-        var referenceResults = await ReferenceDataSeeder.SeedAsync(context);
+        var referenceResults = await ReferenceDataSeeder.SeedAsync(context, cancellationToken);
         foreach (var (entityName, result) in referenceResults)
         {
             Console.WriteLine($"  {entityName}: +{result.Added} ~{result.Updated} -{result.Deleted}");
@@ -60,7 +60,7 @@ internal sealed class SetupCommand : Command
         if (seedTestData)
         {
             Console.WriteLine("Seeding demo test data...");
-            await TestDataSeeder.SeedAsync(context, TimeProvider.System);
+            await TestDataSeeder.SeedAsync(context, TimeProvider.System, cancellationToken: cancellationToken);
         }
 
         Console.WriteLine("Local setup complete.");

--- a/src/FoundryGate.Cli/Commands/Local/Setup/SetupCommand.cs
+++ b/src/FoundryGate.Cli/Commands/Local/Setup/SetupCommand.cs
@@ -1,0 +1,69 @@
+using System.CommandLine;
+using FoundryGate.Cli.Helpers;
+using FoundryGate.Data.Seeding;
+
+namespace FoundryGate.Cli.Commands.Local.Setup;
+
+/// <summary>
+/// One-command local dev bootstrap: drops and re-creates the local FoundryGate database straight
+/// from the current EF model (<c>EnsureCreated</c> — CONVENTIONS.md's "no EF migrations" schema
+/// pipeline), then seeds reference data and, optionally, Bogus demo data.
+/// </summary>
+internal sealed class SetupCommand : Command
+{
+    /// <summary>
+    /// Matches <c>src/FoundryGate.Api/appsettings.Development.json</c> and the <c>sql-server-db</c>
+    /// service in the repo's <c>docker-compose.yml</c> (port 3433, sa/Temp1234!) — the one local SQL
+    /// Server every FoundryGate developer/CI docker-compose stack already runs. Uses the literal
+    /// <c>127.0.0.1</c> rather than <c>localhost</c>: SqlClient's dual-stack connection attempt can
+    /// time out resolving <c>localhost</c> to the container's IPv6 loopback (which docker's port
+    /// mapping doesn't listen on) before falling back to IPv4, even though the port is reachable.
+    /// </summary>
+    internal const string LocalConnectionString =
+        "Server=127.0.0.1,3433;Database=FoundryGate;User Id=sa;Password=Temp1234!;TrustServerCertificate=True";
+
+    public SetupCommand() : base("setup", "Creates the local FoundryGate database (drop + EnsureCreated) and seeds it")
+    {
+        var testDataOption = new Option<bool>("--test-data")
+        {
+            Description = "Also seed Bogus-generated demo data (local/dev only)"
+        };
+
+        Add(testDataOption);
+
+        SetAction(async context =>
+        {
+            var seedTestData = context.GetValue(testDataOption);
+            await ExecuteAsync(seedTestData);
+        });
+    }
+
+    private static async Task ExecuteAsync(bool seedTestData)
+    {
+        Console.WriteLine("Connecting to local SQL Server (localhost,3433)...");
+
+        await using var context = CliDbContextFactory.Create(LocalConnectionString);
+
+        Console.WriteLine("Dropping any existing FoundryGate database...");
+        await context.Database.EnsureDeletedAsync();
+
+        Console.WriteLine("Creating FoundryGate database from the current EF model...");
+        await context.Database.EnsureCreatedAsync();
+
+        Console.WriteLine("Seeding reference data...");
+        var referenceResults = await ReferenceDataSeeder.SeedAsync(context);
+        foreach (var (entityName, result) in referenceResults)
+        {
+            Console.WriteLine($"  {entityName}: +{result.Added} ~{result.Updated} -{result.Deleted}");
+        }
+
+        if (seedTestData)
+        {
+            Console.WriteLine("Seeding demo test data...");
+            await TestDataSeeder.SeedAsync(context, TimeProvider.System);
+        }
+
+        Console.WriteLine("Local setup complete.");
+        Console.WriteLine($"Connection string: {LocalConnectionString}");
+    }
+}

--- a/src/FoundryGate.Cli/FoundryGate.Cli.csproj
+++ b/src/FoundryGate.Cli/FoundryGate.Cli.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FoundryGate.Cli/Helpers/CliDbContextFactory.cs
+++ b/src/FoundryGate.Cli/Helpers/CliDbContextFactory.cs
@@ -1,0 +1,27 @@
+using FoundryGate.Data;
+using FoundryGate.Data.Interceptors;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Cli.Helpers;
+
+/// <summary>
+/// Builds a standalone <see cref="AppDbContext"/> against a connection string, wired with the same
+/// <see cref="TimestampInterceptor"/> the API/Functions hosts get via
+/// <c>ServiceCollectionExtensions.AddFoundryGateData</c>. The Cli is not a DI host, so this is a
+/// direct equivalent of that extension rather than a call through it.
+/// </summary>
+internal static class CliDbContextFactory
+{
+    public static AppDbContext Create(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        var interceptor = new TimestampInterceptor(TimeProvider.System);
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer(connectionString)
+            .AddInterceptors(interceptor)
+            .Options;
+
+        return new AppDbContext(options);
+    }
+}

--- a/src/FoundryGate.Cli/Program.cs
+++ b/src/FoundryGate.Cli/Program.cs
@@ -1,5 +1,11 @@
 using System.CommandLine;
+using FoundryGate.Cli.Commands.Db;
+using FoundryGate.Cli.Commands.Ip;
+using FoundryGate.Cli.Commands.Local;
 
 var rootCommand = new RootCommand("FoundryGate CLI");
+rootCommand.Add(new DbCommand());
+rootCommand.Add(new LocalCommand());
+rootCommand.Add(new IpCommand());
 
 return await rootCommand.Parse(args).InvokeAsync();

--- a/src/FoundryGate.Database/dbo/Tables/AuditLogs.sql
+++ b/src/FoundryGate.Database/dbo/Tables/AuditLogs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [dbo].[AuditLogs] (
+    [AuditLogId]    INT               IDENTITY (1, 1) NOT NULL,
+    [ActorUserId]   INT               NULL,
+    [Action]        NVARCHAR (100)    NOT NULL,
+    [TargetType]    NVARCHAR (50)     NOT NULL,
+    [TargetId]      NVARCHAR (100)    NOT NULL,
+    [Details]       NVARCHAR (MAX)    NOT NULL,
+    [OccurredDate]  DATETIMEOFFSET (7) NOT NULL
+);
+GO
+
+ALTER TABLE [dbo].[AuditLogs]
+    ADD CONSTRAINT [PK_AuditLogs] PRIMARY KEY CLUSTERED ([AuditLogId] ASC);
+GO
+
+ALTER TABLE [dbo].[AuditLogs]
+    ADD CONSTRAINT [FK_AuditLogs_Users_ActorUserId] FOREIGN KEY ([ActorUserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_AuditLogs_ActorUserId]
+    ON [dbo].[AuditLogs]([ActorUserId] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/GroupMembers.sql
+++ b/src/FoundryGate.Database/dbo/Tables/GroupMembers.sql
@@ -1,0 +1,33 @@
+CREATE TABLE [dbo].[GroupMembers] (
+    [GroupId]        INT               NOT NULL,
+    [UserId]         INT               NOT NULL,
+    [AddedDate]      DATETIMEOFFSET (7) NOT NULL,
+    [AddedByUserId]  INT               NULL
+);
+GO
+
+ALTER TABLE [dbo].[GroupMembers]
+    ADD CONSTRAINT [PK_GroupMembers] PRIMARY KEY CLUSTERED ([GroupId] ASC, [UserId] ASC);
+GO
+
+ALTER TABLE [dbo].[GroupMembers]
+    ADD CONSTRAINT [FK_GroupMembers_Groups_GroupId] FOREIGN KEY ([GroupId]) REFERENCES [dbo].[Groups] ([GroupId]) ON DELETE CASCADE;
+GO
+
+ALTER TABLE [dbo].[GroupMembers]
+    ADD CONSTRAINT [FK_GroupMembers_Users_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+ALTER TABLE [dbo].[GroupMembers]
+    ADD CONSTRAINT [FK_GroupMembers_Users_AddedByUserId] FOREIGN KEY ([AddedByUserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+-- GroupId is the leading column of the clustered PK above, so it does not need its own
+-- index; UserId and AddedByUserId are not covered by that prefix and need theirs.
+CREATE NONCLUSTERED INDEX [IX_GroupMembers_UserId]
+    ON [dbo].[GroupMembers]([UserId] ASC);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_GroupMembers_AddedByUserId]
+    ON [dbo].[GroupMembers]([AddedByUserId] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/Groups.sql
+++ b/src/FoundryGate.Database/dbo/Tables/Groups.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [dbo].[Groups] (
+    [GroupId]            INT               IDENTITY (1, 1) NOT NULL,
+    [GroupUnique]        UNIQUEIDENTIFIER  NOT NULL,
+    [Name]               NVARCHAR (200)    NOT NULL,
+    [Description]        NVARCHAR (1000)   NOT NULL,
+    [EntraGroupId]       NVARCHAR (64)     NOT NULL,
+    [IsEntraSynced]      BIT               NOT NULL,
+    [MonthlyTokenQuota]  BIGINT            NULL,
+    [IsUnlimited]        BIT               NOT NULL,
+    [CreatedDate]        DATETIMEOFFSET (7) NOT NULL
+);
+GO
+
+ALTER TABLE [dbo].[Groups]
+    ADD CONSTRAINT [PK_Groups] PRIMARY KEY CLUSTERED ([GroupId] ASC);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Groups_GroupUnique]
+    ON [dbo].[Groups]([GroupUnique] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/QuotaAllocations.sql
+++ b/src/FoundryGate.Database/dbo/Tables/QuotaAllocations.sql
@@ -1,0 +1,24 @@
+CREATE TABLE [dbo].[QuotaAllocations] (
+    [QuotaAllocationId]  INT               IDENTITY (1, 1) NOT NULL,
+    [UserId]             INT               NOT NULL,
+    [PeriodYear]         INT               NOT NULL,
+    [PeriodMonth]        INT               NOT NULL,
+    [AllocatedTokens]    BIGINT            NULL,
+    [TokensUsed]         BIGINT            NOT NULL,
+    [IsHardStopped]      BIT               NOT NULL,
+    [ResetDate]          DATETIMEOFFSET (7) NULL
+);
+GO
+
+ALTER TABLE [dbo].[QuotaAllocations]
+    ADD CONSTRAINT [PK_QuotaAllocations] PRIMARY KEY CLUSTERED ([QuotaAllocationId] ASC);
+GO
+
+ALTER TABLE [dbo].[QuotaAllocations]
+    ADD CONSTRAINT [FK_QuotaAllocations_Users_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[Users] ([UserId]) ON DELETE CASCADE;
+GO
+
+-- Covers the FK on UserId (it is the leading column), so no separate FK index is needed.
+CREATE UNIQUE NONCLUSTERED INDEX [IX_QuotaAllocations_UserId_PeriodYear_PeriodMonth]
+    ON [dbo].[QuotaAllocations]([UserId] ASC, [PeriodYear] ASC, [PeriodMonth] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/QuotaIncreaseRequests.sql
+++ b/src/FoundryGate.Database/dbo/Tables/QuotaIncreaseRequests.sql
@@ -1,0 +1,49 @@
+CREATE TABLE [dbo].[QuotaIncreaseRequests] (
+    [QuotaIncreaseRequestId]     INT               IDENTITY (1, 1) NOT NULL,
+    [QuotaIncreaseRequestUnique] UNIQUEIDENTIFIER  NOT NULL,
+    [UserId]                     INT               NOT NULL,
+    [RequestedByUserId]          INT               NOT NULL,
+    [PeriodYear]                 INT               NOT NULL,
+    [PeriodMonth]                INT               NOT NULL,
+    [CurrentQuota]               BIGINT            NULL,
+    [RequestedQuota]             BIGINT            NULL,
+    [Justification]              NVARCHAR (2000)   NOT NULL,
+    [StatusType]                 INT               NOT NULL,
+    [ReviewedByUserId]           INT               NULL,
+    [ReviewedDate]               DATETIMEOFFSET (7) NULL,
+    [ReviewNotes]                NVARCHAR (2000)   NOT NULL,
+    [CreatedDate]                DATETIMEOFFSET (7) NOT NULL
+);
+GO
+
+ALTER TABLE [dbo].[QuotaIncreaseRequests]
+    ADD CONSTRAINT [PK_QuotaIncreaseRequests] PRIMARY KEY CLUSTERED ([QuotaIncreaseRequestId] ASC);
+GO
+
+ALTER TABLE [dbo].[QuotaIncreaseRequests]
+    ADD CONSTRAINT [FK_QuotaIncreaseRequests_Users_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[Users] ([UserId]) ON DELETE CASCADE;
+GO
+
+ALTER TABLE [dbo].[QuotaIncreaseRequests]
+    ADD CONSTRAINT [FK_QuotaIncreaseRequests_Users_RequestedByUserId] FOREIGN KEY ([RequestedByUserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+ALTER TABLE [dbo].[QuotaIncreaseRequests]
+    ADD CONSTRAINT [FK_QuotaIncreaseRequests_Users_ReviewedByUserId] FOREIGN KEY ([ReviewedByUserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_QuotaIncreaseRequestUnique]
+    ON [dbo].[QuotaIncreaseRequests]([QuotaIncreaseRequestUnique] ASC);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_UserId]
+    ON [dbo].[QuotaIncreaseRequests]([UserId] ASC);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_RequestedByUserId]
+    ON [dbo].[QuotaIncreaseRequests]([RequestedByUserId] ASC);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_ReviewedByUserId]
+    ON [dbo].[QuotaIncreaseRequests]([ReviewedByUserId] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/SystemConfigurations.sql
+++ b/src/FoundryGate.Database/dbo/Tables/SystemConfigurations.sql
@@ -1,0 +1,19 @@
+CREATE TABLE [dbo].[SystemConfigurations] (
+    [Key]              NVARCHAR (200)     NOT NULL,
+    [Value]            NVARCHAR (4000)    NOT NULL,
+    [UpdatedDate]      DATETIMEOFFSET (7) NOT NULL,
+    [UpdatedByUserId]  INT                NULL
+);
+GO
+
+ALTER TABLE [dbo].[SystemConfigurations]
+    ADD CONSTRAINT [PK_SystemConfigurations] PRIMARY KEY CLUSTERED ([Key] ASC);
+GO
+
+ALTER TABLE [dbo].[SystemConfigurations]
+    ADD CONSTRAINT [FK_SystemConfigurations_Users_UpdatedByUserId] FOREIGN KEY ([UpdatedByUserId]) REFERENCES [dbo].[Users] ([UserId]);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_SystemConfigurations_UpdatedByUserId]
+    ON [dbo].[SystemConfigurations]([UpdatedByUserId] ASC);
+GO

--- a/src/FoundryGate.Database/dbo/Tables/Users.sql
+++ b/src/FoundryGate.Database/dbo/Tables/Users.sql
@@ -1,0 +1,28 @@
+CREATE TABLE [dbo].[Users] (
+    [UserId]              INT               IDENTITY (1, 1) NOT NULL,
+    [UserUnique]          UNIQUEIDENTIFIER  NOT NULL,
+    [EntraObjectId]       NVARCHAR (64)     NOT NULL,
+    [EmployeeId]          NVARCHAR (64)     NULL,
+    [DisplayName]         NVARCHAR (200)    NOT NULL,
+    [Email]               NVARCHAR (320)    NOT NULL,
+    [IsActive]            BIT               NOT NULL,
+    [IsUnlimited]         BIT               NOT NULL,
+    [MonthlyTokenQuota]   BIGINT            NULL,
+    [ApimSubscriptionId]  NVARCHAR (500)    NOT NULL,
+    [ApimSubscriptionKey] NVARCHAR (500)    NOT NULL,
+    [CreatedDate]         DATETIMEOFFSET (7) NOT NULL,
+    [LastSyncedDate]      DATETIMEOFFSET (7) NULL
+);
+GO
+
+ALTER TABLE [dbo].[Users]
+    ADD CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED ([UserId] ASC);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Users_EntraObjectId]
+    ON [dbo].[Users]([EntraObjectId] ASC);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Users_UserUnique]
+    ON [dbo].[Users]([UserUnique] ASC);
+GO

--- a/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
@@ -19,6 +19,11 @@ namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 /// that model is provider-agnostic; only physical SQL Server types like
 /// <c>nvarchar</c>/<c>uniqueidentifier</c> are SQLite-incompatible and therefore out of scope here).
 /// </para>
+/// <para>
+/// Documented gaps below are tracked in
+/// <see href="https://github.com/kolatts/foundry-gate/issues/100">#100</see>, not left as inline
+/// TODOs.
+/// </para>
 /// <para><b>Deliberate limits (documented, not accidental gaps):</b></para>
 /// <list type="bullet">
 /// <item>Checks table existence, the column name set, and column nullability only — NOT SQL data

--- a/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
@@ -1,0 +1,249 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Data.Conventions;
+
+/// <summary>
+/// Drift alarm between the EF entity model (schema source of truth per CONVENTIONS.md's "Schema
+/// pipeline") and the checked-in <c>FoundryGate.Database/dbo/Tables/*.sql</c> files DacFx builds
+/// into the deployed dacpac.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The "real" way to keep these in sync is DacFx schema-compare (<c>foundrygate db compare</c>,
+/// plans/23-database-tooling.md), but that API is Windows-only native tooling and isn't available
+/// in every environment these tests run in. This is a deliberately pragmatic substitute: a
+/// regex-level parser over the .sql files, not a real T-SQL parser, checked against
+/// <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/> reflection (via the SQLite in-memory
+/// context <see cref="InMemoryDatabaseTest"/> already builds — table/column/index/FK *structure* in
+/// that model is provider-agnostic; only physical SQL Server types like
+/// <c>nvarchar</c>/<c>uniqueidentifier</c> are SQLite-incompatible and therefore out of scope here).
+/// </para>
+/// <para><b>Deliberate limits (documented, not accidental gaps):</b></para>
+/// <list type="bullet">
+/// <item>Checks table existence, the column name set, and column nullability only — NOT SQL data
+/// types, lengths, or precision. A column that silently shrinks from <c>nvarchar(200)</c> to
+/// <c>nvarchar(50)</c> without a matching entity change will NOT be caught.</item>
+/// <item>For single-column foreign keys, checks that a same-named <c>FK_*</c> constraint exists and
+/// that its <c>ON DELETE CASCADE</c> presence matches the configured <c>DeleteBehavior</c>. Does not
+/// otherwise validate FK shape (principal column, etc.) or handle composite FKs (none exist in this
+/// model today).</item>
+/// <item>Checks that every index EF's model declares (explicit <c>[Index]</c> attributes and EF's
+/// own implicit per-FK indexes) has a same-named <c>CREATE INDEX</c> statement with a matching
+/// <c>UNIQUE</c> flag. Does not validate index column order/composition beyond that, and does not
+/// flag an extra index present in the .sql file but absent from the model.</item>
+/// <item>Parses via regex over raw file text, relying on the repo's existing SQL style (one
+/// statement per <c>GO</c> batch, bracket-quoted identifiers, one table per file named after the
+/// table). Hand-authored .sql that strays from that style can produce false positives/negatives
+/// here instead of a clean parser error — this is a drift *alarm*, not a schema validator.</item>
+/// </list>
+/// </remarks>
+public class SchemaParityTests : InMemoryDatabaseTest
+{
+    private static readonly Regex ColumnLineRegex = new(
+        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]\s+.+?\b(?<null>NOT NULL|NULL)\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ForeignKeyRegex = new(
+        @"ADD CONSTRAINT \[(?<name>FK_[A-Za-z0-9_]+)\] FOREIGN KEY \(\[(?<col>[A-Za-z0-9_]+)\]\) REFERENCES \[dbo\]\.\[[A-Za-z0-9_]+\] \(\[[A-Za-z0-9_]+\]\)(?<cascade> ON DELETE CASCADE)?",
+        RegexOptions.Compiled);
+
+    private static readonly Regex IndexRegex = new(
+        @"CREATE (?<unique>UNIQUE )?(NONCLUSTERED|CLUSTERED) INDEX \[(?<name>IX_[A-Za-z0-9_]+)\]",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void CheckedInSqlFiles_ShouldMatchEfModel()
+    {
+        string tablesDirectory = FindTablesDirectory();
+        var violations = new List<string>();
+
+        foreach (var entityType in Context.Model.GetEntityTypes())
+        {
+            string tableName = entityType.GetTableName()
+                ?? throw new InvalidOperationException($"{entityType.ClrType.Name} has no table name.");
+
+            string sqlPath = Path.Combine(tablesDirectory, $"{tableName}.sql");
+            if (!File.Exists(sqlPath))
+            {
+                violations.Add($"{tableName}: no dbo/Tables/{tableName}.sql file found (expected at {sqlPath})");
+                continue;
+            }
+
+            string sql = File.ReadAllText(sqlPath);
+            CheckColumns(entityType, tableName, sql, violations);
+            CheckForeignKeys(entityType, tableName, sql, violations);
+            CheckIndexes(entityType, tableName, sql, violations);
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"Found {violations.Count} schema drift violation(s) between the EF model and " +
+            $"FoundryGate.Database/dbo/Tables/*.sql:\n  - {string.Join("\n  - ", violations)}");
+    }
+
+    private static void CheckColumns(
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        string tableName,
+        string sql,
+        List<string> violations)
+    {
+        var sqlColumns = ParseColumns(sql);
+
+        foreach (var property in entityType.GetProperties())
+        {
+            string columnName = property.GetColumnName();
+            if (!sqlColumns.TryGetValue(columnName, out bool notNullInSql))
+            {
+                violations.Add($"{tableName}.{columnName}: column missing from {tableName}.sql");
+                continue;
+            }
+
+            bool notNullInModel = !property.IsNullable;
+            if (notNullInModel != notNullInSql)
+            {
+                violations.Add(
+                    $"{tableName}.{columnName}: model says {(notNullInModel ? "NOT NULL" : "NULL")} " +
+                    $"but {tableName}.sql says {(notNullInSql ? "NOT NULL" : "NULL")}");
+            }
+        }
+
+        var modelColumnNames = entityType.GetProperties().Select(p => p.GetColumnName()).ToHashSet();
+        foreach (string sqlColumnName in sqlColumns.Keys.Where(c => !modelColumnNames.Contains(c)))
+        {
+            violations.Add($"{tableName}.sql has column [{sqlColumnName}] with no matching EF model property");
+        }
+    }
+
+    private static void CheckForeignKeys(
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        string tableName,
+        string sql,
+        List<string> violations)
+    {
+        var sqlForeignKeys = ParseForeignKeys(sql);
+
+        foreach (var fk in entityType.GetForeignKeys())
+        {
+            if (fk.Properties.Count != 1)
+            {
+                // No composite FKs exist in this model today; skip defensively rather than guess a format.
+                continue;
+            }
+
+            string? fkName = fk.GetConstraintName();
+            if (fkName is null || !sqlForeignKeys.TryGetValue(fkName, out bool hasCascadeInSql))
+            {
+                violations.Add($"{tableName}: foreign key '{fkName ?? "(unnamed)"}' missing from {tableName}.sql");
+                continue;
+            }
+
+            bool expectCascade = fk.DeleteBehavior == DeleteBehavior.Cascade;
+            if (expectCascade != hasCascadeInSql)
+            {
+                violations.Add(
+                    $"{tableName}: FK {fkName} DeleteBehavior is {fk.DeleteBehavior} but {tableName}.sql " +
+                    $"{(hasCascadeInSql ? "has" : "is missing")} ON DELETE CASCADE");
+            }
+        }
+    }
+
+    private static void CheckIndexes(
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        string tableName,
+        string sql,
+        List<string> violations)
+    {
+        var sqlIndexes = ParseIndexes(sql);
+
+        foreach (var index in entityType.GetIndexes())
+        {
+            string? indexName = index.GetDatabaseName();
+            if (indexName is null || !sqlIndexes.TryGetValue(indexName, out bool isUniqueInSql))
+            {
+                violations.Add($"{tableName}: index '{indexName ?? "(unnamed)"}' missing from {tableName}.sql");
+                continue;
+            }
+
+            if (index.IsUnique != isUniqueInSql)
+            {
+                violations.Add(
+                    $"{tableName}: index {indexName} IsUnique is {index.IsUnique} in the model but " +
+                    $"{isUniqueInSql} in {tableName}.sql");
+            }
+        }
+    }
+
+    /// <summary>Column name -> whether the .sql file marks it NOT NULL (false = nullable).</summary>
+    private static Dictionary<string, bool> ParseColumns(string sql)
+    {
+        var columns = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        // Table body is everything between "CREATE TABLE [dbo].[...] (" and the matching ");" —
+        // column type parens (e.g. "IDENTITY (1, 1)") never appear immediately before a semicolon
+        // in this repo's SQL style, so a simple first-match works.
+        var tableMatch = Regex.Match(sql, @"CREATE TABLE \[dbo\]\.\[[A-Za-z0-9_]+\]\s*\((?<body>.*?)\)\s*;", RegexOptions.Singleline);
+        if (!tableMatch.Success)
+        {
+            return columns;
+        }
+
+        foreach (string line in tableMatch.Groups["body"].Value.Split('\n'))
+        {
+            Match match = ColumnLineRegex.Match(line);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            columns[match.Groups["name"].Value] = match.Groups["null"].Value == "NOT NULL";
+        }
+
+        return columns;
+    }
+
+    /// <summary>FK constraint name -> whether it carries ON DELETE CASCADE.</summary>
+    private static Dictionary<string, bool> ParseForeignKeys(string sql)
+    {
+        var foreignKeys = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        foreach (Match match in ForeignKeyRegex.Matches(sql))
+        {
+            foreignKeys[match.Groups["name"].Value] = match.Groups["cascade"].Success;
+        }
+
+        return foreignKeys;
+    }
+
+    /// <summary>Index name -> whether it is declared UNIQUE.</summary>
+    private static Dictionary<string, bool> ParseIndexes(string sql)
+    {
+        var indexes = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        foreach (Match match in IndexRegex.Matches(sql))
+        {
+            indexes[match.Groups["name"].Value] = match.Groups["unique"].Success;
+        }
+
+        return indexes;
+    }
+
+    /// <summary>Walks up from the test assembly's output directory to find the repo root (marked by
+    /// <c>FoundryGate.sln</c>), then returns <c>src/FoundryGate.Database/dbo/Tables</c> under it.</summary>
+    private static string FindTablesDirectory()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "FoundryGate.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        if (directory is null)
+        {
+            throw new InvalidOperationException(
+                $"Could not find FoundryGate.sln by walking up from {AppContext.BaseDirectory}.");
+        }
+
+        return Path.Combine(directory.FullName, "src", "FoundryGate.Database", "dbo", "Tables");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the database tooling epic's three sub-issues (#76), following CONVENTIONS.md's finalized "Schema pipeline" (which supersedes plans/23's original `dotnet ef migrations`/`db compare` design — EF entities are the schema source of truth, no EF Core migrations exist anywhere in this repo):

- **#77** — `src/FoundryGate.Database/dbo/Tables/*.sql`, one hand-authored file per entity, derived by inspection from the seven `FoundryGate.Data/Entities/*.cs` types + their co-located `IEntityTypeConfiguration`s: `int` identity PKs, `uniqueidentifier` `{Entity}Unique` columns with unique indexes, `datetimeoffset(7)`, `nvarchar` lengths from `[StringLength]`, FK `ON DELETE` clauses matching each entity's configured `DeleteBehavior`, and EF's implicit per-FK indexes. `dotnet build src/FoundryGate.Database` produces the dacpac clean (0 warnings). No `.sqlproj` item-group wiring was needed — `Microsoft.Build.Sql` globs `dbo/**/*.sql` by default.

- **#78** — `FoundryGate.Cli` commands via `System.CommandLine` (the prerelease already pinned in `Directory.Packages.props`):
  - `local setup [--test-data]` — drop + `EnsureCreated` against docker SQL, seed reference data, optionally seed Bogus demo data (#92's seeders)
  - `db deploy <dacpac> <connection-string> [--drop-objects] [--block-on-data-loss]` — DacFx `DacServices`; works against both SQL auth and `Authentication=Active Directory Default` connection strings without separate credential plumbing (DacServices reads the auth method from the connection string itself)
  - `db seed-reference <connection-string>` / `db seed-test <connection-string>`
  - `ip setup --env <env>` — **stub only**, prints guidance and exits 1; real implementation needs an Azure SQL Server resource that doesn't exist yet, tracked in #96

- **#79** — `.github/workflows/_deploy-database.yml`, a reusable `workflow_call` modeled on imagile-app's `_deploy-database.yml`: download dacpac + CLI artifacts → `azure/login` OIDC → IP whitelist step (calls the `ip setup` stub, `continue-on-error: true` with a comment pointing at #96) → 60s firewall wait → TCP 1433 probe → `db deploy --drop-objects` → `db seed-reference` → optional `db seed-test` (never for production — gated by a `run-seed-test` input the caller must explicitly opt into). Standalone-valid YAML today; will be consumed by #67's CI/CD epic once a `build-dacpac` job exists to feed it artifacts.

**Also fixes** the local SQL connection strings (CLI + `FoundryGate.Api/appsettings.Development.json`) from `Server=localhost,3433` to `Server=127.0.0.1,3433` — discovered mid-verification that SqlClient's dual-stack resolution of `localhost` can time out probing the docker container's IPv6 loopback (which the port mapping doesn't listen on) before falling back to IPv4, even though the port is reachable over plain TCP.

## Schema-parity test (verification centerpiece)

`src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs` reflects over `AppDbContext.Model` (via the same SQLite in-memory context every other Predeployment test uses — model *structure* is provider-agnostic, only physical SQL Server types like `nvarchar`/`uniqueidentifier` are SQLite-incompatible and out of scope here) and regex-parses the checked-in `.sql` files, asserting:

- every table exists as a same-named `.sql` file
- every model column exists in the file with matching nullability (and vice versa — extra SQL columns are flagged too)
- every single-column FK has a matching named `FK_*` constraint whose `ON DELETE CASCADE` presence matches the configured `DeleteBehavior`
- every model index (explicit `[Index]` + EF's implicit per-FK indexes) has a matching named `CREATE INDEX` with the same `UNIQUE` flag

**Documented limits** (in the class's XML doc): no SQL data type/length/precision checking, no composite-FK support (none exist today), no index column-order validation beyond the flag, and it's a regex parser over the repo's existing SQL style — not a real T-SQL parser. It's a drift *alarm*, not a schema validator, standing in for DacFx schema-compare (Windows-only native tooling, not available in every environment these tests run in).

I verified the test actually catches drift (not vacuously passing) by renaming a column in `Users.sql`, confirming the test failed with the expected violation messages, then reverting.

## Verification

- `dotnet build FoundryGate.sln` — 0 warnings, 0 errors, dacpac builds
- `dotnet test src/FoundryGate.Tests.Predeployment` — 66/66 passing
- `dotnet format FoundryGate.sln --verify-no-changes` — clean
- **Live docker proof**: `docker compose up -d` (SQL Server on port 3433) → `dotnet run --project src/FoundryGate.Cli -- local setup --test-data` succeeded end-to-end — verified via `sqlcmd` inside the container: all 7 tables created, row counts match `TestDataSeeder` exactly (8 users, 1 group, 3 members, 8 quota allocations, 1 pending request, 8 system config keys)
- **`db deploy` against a second database**: deployed the built dacpac to a fresh `FoundryGateDeployTest` database on the same docker SQL Server (independent of `local setup`'s `EnsureCreated` path), then ran `db seed-reference` and `db seed-test` against it to exercise the full CLI surface
- `docker compose down` — torn back down afterward

### Bonus: resolves #94

The `db deploy` run above is the first time the FK `DeleteBehavior` graph from #92 has been checked against anything other than SQLite in-memory. It deployed clean with **no** "multiple cascade paths" error. `sys.foreign_keys` on the deployed database confirms the exact intended shape:

```
FKName                                              ParentTable            RefTable  OnDelete
FK_AuditLogs_Users_ActorUserId                      AuditLogs              Users     NO_ACTION
FK_GroupMembers_Groups_GroupId                      GroupMembers           Groups    CASCADE
FK_GroupMembers_Users_AddedByUserId                 GroupMembers           Users     NO_ACTION
FK_GroupMembers_Users_UserId                        GroupMembers           Users     NO_ACTION
FK_QuotaAllocations_Users_UserId                    QuotaAllocations       Users     CASCADE
FK_QuotaIncreaseRequests_Users_RequestedByUserId    QuotaIncreaseRequests  Users     NO_ACTION
FK_QuotaIncreaseRequests_Users_ReviewedByUserId     QuotaIncreaseRequests  Users     NO_ACTION
FK_QuotaIncreaseRequests_Users_UserId                QuotaIncreaseRequests  Users     CASCADE
FK_SystemConfigurations_Users_UpdatedByUserId       SystemConfigurations   Users     NO_ACTION
```

I'll close #94 with this evidence once this PR is reviewed.

### Follow-up issue filed

- #96 — real `foundrygate ip setup` implementation, blocked on the Azure SQL Server resource landing via #43/#44's Bicep infra.

`plans/23-database-tooling.md` updated: a Status-update note at the top documents where the implementation departs from the original plan (no EF migrations/`db compare`, `System.CommandLine` not `Spectre.Console.Cli`, plural table file names), and the Verification checklist is filled in with actual results.

## Note on `.github/workflows/`

This PR touches `.github/workflows/_deploy-database.yml` — per CLAUDE.md this is allowed for maintainer-side work (the triage-bot prohibition applies to `claude-triage.yml`-driven PRs, not this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #77
Closes #78
Closes #79
