### PR TITLE
test(data): check SQL types, IDENTITY, PK/FK/index shape in SchemaParityTests

### DIFF
--- a/plans/23-database-tooling.md
+++ b/plans/23-database-tooling.md
@@ -24,10 +24,14 @@ Table file names below also use each table's actual (plural) name —
 `AppDbContext`'s `DbSet` names and the file-name-equals-table-name convention the parity test
 depends on.
 
-The parity test's documented gaps (no data type/length/precision checking, no composite-FK
-support, no index-composition validation beyond the `UNIQUE` flag) and the `db compare` deferral
-above are tracked as follow-up work in
-[#100](https://github.com/kolatts/foundry-gate/issues/100) rather than left as inline TODOs, per
+The parity test's originally documented gaps (no data type/length/precision checking, no
+composite-FK support, no index-composition validation beyond the `UNIQUE` flag) were closed by
+[#100](https://github.com/kolatts/foundry-gate/issues/100): the test now builds the EF model with
+the SQL Server provider (design-time model, no connection opened) and compares store types incl.
+length/precision, `IDENTITY`, PK name/columns/clustering, FK columns/principal/`ON DELETE`
+(composite-capable), index `UNIQUE`/columns/order/direction, plus extra indexes, FKs, and orphaned
+`.sql` files. The `db compare` deferral is tracked separately in
+[#103](https://github.com/kolatts/foundry-gate/issues/103) rather than left as an inline TODO, per
 CLAUDE.md's "everything is a GitHub issue" rule.
 
 ## Overview
@@ -241,7 +245,14 @@ A separate `db-deploy.yml` workflow (reusable, `workflow_call`) downloads the da
 - [ ] `Foundry Gate db compare` — **not implemented** (see the Status update note above): DacFx
       schema-compare is Windows-only and there is no live-database-to-compare-from in the
       EnsureCreated-based pipeline this repo actually uses. The `SchemaParityTests` Predeployment
-      test is the substitute drift check, and it runs cross-platform in CI.
+      test is the substitute drift check, and it runs cross-platform in CI. Tracked as a
+      developer-convenience follow-up in #103.
+- [x] `SchemaParityTests` type-level parity (#100) — verified it bites, not just passes: injected
+      five deliberate drifts at once (`Users.DisplayName` shrunk `NVARCHAR (200)` → `(50)`, a stray
+      `IX_Users_Email` index, `IX_QuotaAllocations_*` columns reordered + one `DESC`, `IDENTITY`
+      dropped from `Groups.GroupId`, `ON DELETE CASCADE` removed from
+      `FK_QuotaAllocations_Users_UserId`) and the single aggregate assertion reported exactly five
+      bullets naming each; reverted, 82/82 green.
 - [x] `foundrygate ip setup` is a documented stub (issues #96 tracks the real implementation) that
       prints guidance and exits 1 rather than doing anything; the reusable
       `.github/workflows/_deploy-database.yml` (#79) calls it with `continue-on-error: true` and a

--- a/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
@@ -31,17 +31,26 @@ namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 /// including length/precision/scale — <c>nvarchar(200)</c> vs <c>nvarchar(50)</c>,
 /// <c>nvarchar(max)</c>, <c>decimal(p,s)</c>, <c>bigint</c> vs <c>int</c>, etc. Comparison is
 /// case- and whitespace-insensitive, and SQL Server's implicit default precision is normalised
-/// (<c>DATETIMEOFFSET (7)</c> in the script equals EF's bare <c>datetimeoffset</c>).</item>
+/// (<c>DATETIMEOFFSET (7)</c> in the script equals EF's bare <c>datetimeoffset</c>). A column
+/// line that does not parse is reported as unparseable (quoting the line), never as
+/// "missing".</item>
+/// <item><c>DEFAULT</c> constraint <i>presence</i> per column matches the model
+/// (<c>HasDefaultValue</c>/<c>HasDefaultValueSql</c>); both the DacFx/SSDT placement
+/// (<c>CONSTRAINT [DF_x] DEFAULT ((1)) NOT NULL</c>) and EF's (<c>NOT NULL DEFAULT (...)</c>) are
+/// accepted. The default <i>expression</i> is not compared.</item>
 /// <item><c>IDENTITY</c> presence per column matches the model's SQL Server value-generation
 /// strategy (int <c>{Entity}Id</c> PKs are identity; composite/natural keys are not).</item>
-/// <item>Primary key constraint name, column composition and order, and clustering.</item>
+/// <item>Primary key constraint name, column composition and order, and clustering — declared
+/// either as <c>ALTER TABLE ... ADD CONSTRAINT [PK_*]</c> (this repo's style) or inline inside
+/// <c>CREATE TABLE</c> (what DacFx/SSDT scripting emits).</item>
 /// <item>Every foreign key (single- or multi-column) by constraint name: dependent columns,
 /// principal table and columns, and the <c>ON DELETE</c> action implied by its configured
 /// <see cref="DeleteBehavior"/>. Also flags FK constraints in the .sql file that the model does not
 /// declare.</item>
 /// <item>Every index EF's model declares (explicit <c>[Index]</c> attributes and EF's own implicit
-/// per-FK indexes) by database name: <c>UNIQUE</c> flag, column composition, column order, and
-/// sort direction. Also flags indexes in the .sql file that the model does not declare.</item>
+/// per-FK indexes) by database name: <c>UNIQUE</c> flag, <c>CLUSTERED</c>/<c>NONCLUSTERED</c>,
+/// column composition, column order, and sort direction. Also flags indexes in the .sql file that
+/// the model does not declare.</item>
 /// </list>
 /// <para><b>Deliberate remaining limits (documented, not accidental gaps):</b></para>
 /// <list type="bullet">
@@ -50,10 +59,10 @@ namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 /// table, one column per line). Hand-authored .sql that strays from that style can produce false
 /// positives/negatives here instead of a clean parser error — this is a drift <i>alarm</i>, not a
 /// schema validator.</item>
-/// <item>Does not check schema features the model does not use today: default/check constraints,
-/// computed columns, collations, filtered indexes, <c>INCLUDE</c> columns, fill factor, or
-/// per-index clustering. Adding any of those to an entity means extending this test in the same
-/// PR.</item>
+/// <item>Does not check schema features the model does not use today: default-constraint
+/// <i>expressions</i> (only presence is compared), check constraints, computed columns,
+/// collations, filtered indexes, <c>INCLUDE</c> columns, or fill factor. Adding any of those to an
+/// entity means extending this test in the same PR.</item>
 /// <item>Compares the model to the checked-in scripts only, never to a live database. DacFx
 /// schema-compare against a deployed database remains the authoritative (Windows-only) tool if
 /// that is ever needed.</item>
@@ -62,16 +71,43 @@ namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 public class SchemaParityTests
 {
     /// <summary>
+    /// A parenthesised expression with arbitrarily nested parens (.NET balancing groups), e.g. the
+    /// <c>((1))</c> or <c>(getutcdate())</c> DacFx emits for default constraints.
+    /// </summary>
+    private const string BalancedParens = @"\((?>[^()]+|\((?<depth>)|\)(?<-depth>))*(?(depth)(?!))\)";
+
+    /// <summary>Optional named <c>CONSTRAINT [DF_x]</c> prefix, then <c>DEFAULT (expr)</c>.</summary>
+    private const string DefaultClause = @"(?:CONSTRAINT \[[A-Za-z0-9_]+\]\s+)?DEFAULT\s*" + BalancedParens;
+
+    /// <summary>
     /// One column definition line inside the <c>CREATE TABLE (...)</c> body: name, store type
-    /// (with its optional parenthesised length/precision), optional <c>IDENTITY (...)</c>, then
-    /// the nullability keyword.
+    /// (with its optional parenthesised length/precision), optional <c>IDENTITY (...)</c>, an
+    /// optional default constraint either before the nullability keyword (DacFx/SSDT placement) or
+    /// after it (EF's own DDL placement), and the nullability keyword itself.
     /// </summary>
     private static readonly Regex ColumnLineRegex = new(
-        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]\s+(?<type>[A-Za-z0-9_]+(?:\s*\([^)]*\))?)\s+(?:(?<identity>IDENTITY(?:\s*\([^)]*\))?)\s+)?(?<null>NOT NULL|NULL)\b",
+        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]\s+(?<type>[A-Za-z0-9_]+(?:\s*\([^)]*\))?)" +
+        @"(?:\s+(?<identity>IDENTITY(?:\s*\([^)]*\))?))?" +
+        @"(?:\s+(?<default>" + DefaultClause + @"))?" +
+        @"\s+(?<null>NOT NULL|NULL)\b" +
+        @"(?:\s+(?<default>" + DefaultClause + @"))?",
         RegexOptions.Compiled);
 
+    /// <summary>
+    /// Anything that starts like a column definition. Lines matching this but not
+    /// <see cref="ColumnLineRegex"/> are reported as unparseable rather than silently skipped
+    /// (which would otherwise surface as a misleading "column missing").
+    /// </summary>
+    private static readonly Regex ColumnLineStartRegex = new(
+        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Matches both this repo's <c>ALTER TABLE ... ADD CONSTRAINT [PK_*]</c> style and an inline
+    /// <c>CONSTRAINT [PK_*] PRIMARY KEY</c> table constraint inside <c>CREATE TABLE</c>.
+    /// </summary>
     private static readonly Regex PrimaryKeyRegex = new(
-        @"ADD CONSTRAINT \[(?<name>PK_[A-Za-z0-9_]+)\] PRIMARY KEY (?<clustered>CLUSTERED|NONCLUSTERED)\s*\((?<cols>[^)]*)\)",
+        @"(?:ADD\s+)?CONSTRAINT \[(?<name>PK_[A-Za-z0-9_]+)\] PRIMARY KEY (?<clustered>CLUSTERED|NONCLUSTERED)\s*\((?<cols>[^)]*)\)",
         RegexOptions.Compiled);
 
     private static readonly Regex ForeignKeyRegex = new(
@@ -159,14 +195,26 @@ public class SchemaParityTests
         string sql,
         List<string> violations)
     {
-        var sqlColumns = ParseColumns(sql);
+        (var sqlColumns, var unparsedLines) = ParseColumns(sql);
+
+        foreach ((string unparsedName, string unparsedLine) in unparsedLines)
+        {
+            violations.Add(
+                $"{tableName}.sql: column line for [{unparsedName}] could not be parsed by the parity regex " +
+                $"(expected '[Name] TYPE [IDENTITY (..)] [CONSTRAINT [DF_x] DEFAULT (..)] NULL|NOT NULL'): '{unparsedLine}'");
+        }
 
         foreach (var property in entityType.GetProperties())
         {
             string columnName = property.GetColumnName();
             if (!sqlColumns.TryGetValue(columnName, out SqlColumn? sqlColumn))
             {
-                violations.Add($"{tableName}.{columnName}: column missing from {tableName}.sql");
+                if (!unparsedLines.ContainsKey(columnName))
+                {
+                    // Already reported above as unparseable when the line exists but didn't parse.
+                    violations.Add($"{tableName}.{columnName}: column missing from {tableName}.sql");
+                }
+
                 continue;
             }
 
@@ -196,6 +244,17 @@ public class SchemaParityTests
                     $"{tableName}.{columnName}: model {(identityInModel ? "is" : "is not")} an IDENTITY column " +
                     $"but {tableName}.sql {(sqlColumn.IsIdentity ? "declares" : "does not declare")} IDENTITY");
             }
+
+            // Annotation check, not GetDefaultValue(): that API falls back to the CLR default for every
+            // non-nullable value type, which would flag every int/bool/Guid column as "has default".
+            bool defaultInModel = property.FindAnnotation(RelationalAnnotationNames.DefaultValue) is not null
+                || property.GetDefaultValueSql() is not null;
+            if (defaultInModel != sqlColumn.HasDefault)
+            {
+                violations.Add(
+                    $"{tableName}.{columnName}: model {(defaultInModel ? "has" : "has no")} default value " +
+                    $"but {tableName}.sql {(sqlColumn.HasDefault ? "declares" : "does not declare")} a DEFAULT constraint");
+            }
         }
 
         var modelColumnNames = entityType.GetProperties().Select(p => p.GetColumnName()).ToHashSet(StringComparer.Ordinal);
@@ -222,7 +281,9 @@ public class SchemaParityTests
         Match match = PrimaryKeyRegex.Match(sql);
         if (!match.Success)
         {
-            violations.Add($"{tableName}: no 'ADD CONSTRAINT [PK_*] PRIMARY KEY' statement found in {tableName}.sql");
+            violations.Add(
+                $"{tableName}: no PRIMARY KEY constraint found in {tableName}.sql (neither " +
+                "'ALTER TABLE ... ADD CONSTRAINT [PK_*] PRIMARY KEY' nor an inline 'CONSTRAINT [PK_*] PRIMARY KEY' in CREATE TABLE)");
             return;
         }
 
@@ -332,6 +393,15 @@ public class SchemaParityTests
                     $"{sqlIndex.IsUnique} in {tableName}.sql");
             }
 
+            // SQL Server's default for a secondary index is nonclustered; EF leaves IsClustered() null unless overridden.
+            bool clusteredInModel = index.IsClustered() ?? false;
+            if (clusteredInModel != sqlIndex.IsClustered)
+            {
+                violations.Add(
+                    $"{tableName}: index {indexName} is {(clusteredInModel ? "CLUSTERED" : "NONCLUSTERED")} in the model but " +
+                    $"{(sqlIndex.IsClustered ? "CLUSTERED" : "NONCLUSTERED")} in {tableName}.sql");
+            }
+
             var modelColumns = index.Properties
                 .Select((p, i) => new SqlIndexColumn(p.GetColumnName(), IsDescending(index, i)))
                 .ToList();
@@ -395,10 +465,14 @@ public class SchemaParityTests
     private static string FormatColumns(IEnumerable<SqlIndexColumn> columns) =>
         $"({string.Join(", ", columns.Select(c => $"[{c.Name}] {(c.IsDescending ? "DESC" : "ASC")}"))})";
 
-    /// <summary>Column name -> parsed definition from the CREATE TABLE body.</summary>
-    private static Dictionary<string, SqlColumn> ParseColumns(string sql)
+    /// <summary>
+    /// Column name -> parsed definition from the CREATE TABLE body, plus column name -> raw line
+    /// for any line that starts like a column definition but did not parse.
+    /// </summary>
+    private static (Dictionary<string, SqlColumn> Columns, Dictionary<string, string> UnparsedLines) ParseColumns(string sql)
     {
         var columns = new Dictionary<string, SqlColumn>(StringComparer.Ordinal);
+        var unparsedLines = new Dictionary<string, string>(StringComparer.Ordinal);
 
         // Table body is everything between "CREATE TABLE [dbo].[...] (" and the matching ");" —
         // column type parens (e.g. "IDENTITY (1, 1)") never appear immediately before a semicolon
@@ -406,7 +480,7 @@ public class SchemaParityTests
         Match tableMatch = TableBodyRegex.Match(sql);
         if (!tableMatch.Success)
         {
-            return columns;
+            return (columns, unparsedLines);
         }
 
         foreach (string line in tableMatch.Groups["body"].Value.Split('\n'))
@@ -414,16 +488,23 @@ public class SchemaParityTests
             Match match = ColumnLineRegex.Match(line);
             if (!match.Success)
             {
+                Match start = ColumnLineStartRegex.Match(line);
+                if (start.Success)
+                {
+                    unparsedLines[start.Groups["name"].Value] = line.Trim();
+                }
+
                 continue;
             }
 
             columns[match.Groups["name"].Value] = new SqlColumn(
                 match.Groups["type"].Value,
                 match.Groups["null"].Value == "NOT NULL",
-                match.Groups["identity"].Success);
+                match.Groups["identity"].Success,
+                match.Groups["default"].Success);
         }
 
-        return columns;
+        return (columns, unparsedLines);
     }
 
     /// <summary>FK constraint name -> parsed shape.</summary>
@@ -452,6 +533,7 @@ public class SchemaParityTests
         {
             indexes[match.Groups["name"].Value] = new SqlIndex(
                 match.Groups["unique"].Success,
+                match.Groups["clustered"].Value == "CLUSTERED",
                 ParseColumnList(match.Groups["cols"].Value));
         }
 
@@ -483,7 +565,7 @@ public class SchemaParityTests
         return Path.Combine(directory.FullName, "src", "FoundryGate.Database", "dbo", "Tables");
     }
 
-    private sealed record SqlColumn(string Type, bool NotNull, bool IsIdentity);
+    private sealed record SqlColumn(string Type, bool NotNull, bool IsIdentity, bool HasDefault);
 
     private sealed record SqlForeignKey(
         List<string> Columns,
@@ -491,7 +573,7 @@ public class SchemaParityTests
         List<string> PrincipalColumns,
         string OnDelete);
 
-    private sealed record SqlIndex(bool IsUnique, List<SqlIndexColumn> Columns);
+    private sealed record SqlIndex(bool IsUnique, bool IsClustered, List<SqlIndexColumn> Columns);
 
     private sealed record SqlIndexColumn(string Name, bool IsDescending);
 }

--- a/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Conventions/SchemaParityTests.cs
@@ -1,5 +1,8 @@
 using System.Text.RegularExpressions;
+using FoundryGate.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 
@@ -13,60 +16,96 @@ namespace FoundryGate.Tests.Predeployment.Data.Conventions;
 /// The "real" way to keep these in sync is DacFx schema-compare (<c>foundrygate db compare</c>,
 /// plans/23-database-tooling.md), but that API is Windows-only native tooling and isn't available
 /// in every environment these tests run in. This is a deliberately pragmatic substitute: a
-/// regex-level parser over the .sql files, not a real T-SQL parser, checked against
-/// <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/> reflection (via the SQLite in-memory
-/// context <see cref="InMemoryDatabaseTest"/> already builds — table/column/index/FK *structure* in
-/// that model is provider-agnostic; only physical SQL Server types like
-/// <c>nvarchar</c>/<c>uniqueidentifier</c> are SQLite-incompatible and therefore out of scope here).
+/// regex-level parser over the .sql files, not a real T-SQL parser, checked against the relational
+/// metadata of an <see cref="AppDbContext"/> model built with the <b>SQL Server</b> provider. No
+/// connection is ever opened — the design-time <see cref="IModel"/> is computed purely from the
+/// entity classes plus the provider's type mappings, which is exactly what makes physical store types
+/// (<c>nvarchar(200)</c>, <c>uniqueidentifier</c>, <c>IDENTITY</c>) available here without a
+/// database and without the SQLite in-memory harness the other convention tests use.
 /// </para>
-/// <para>
-/// Documented gaps below are tracked in
-/// <see href="https://github.com/kolatts/foundry-gate/issues/100">#100</see>, not left as inline
-/// TODOs.
-/// </para>
-/// <para><b>Deliberate limits (documented, not accidental gaps):</b></para>
+/// <para><b>What is checked (per table, aggregated into one bullet-list assertion):</b></para>
 /// <list type="bullet">
-/// <item>Checks table existence, the column name set, and column nullability only — NOT SQL data
-/// types, lengths, or precision. A column that silently shrinks from <c>nvarchar(200)</c> to
-/// <c>nvarchar(50)</c> without a matching entity change will NOT be caught.</item>
-/// <item>For single-column foreign keys, checks that a same-named <c>FK_*</c> constraint exists and
-/// that its <c>ON DELETE CASCADE</c> presence matches the configured <c>DeleteBehavior</c>. Does not
-/// otherwise validate FK shape (principal column, etc.) or handle composite FKs (none exist in this
-/// model today).</item>
-/// <item>Checks that every index EF's model declares (explicit <c>[Index]</c> attributes and EF's
-/// own implicit per-FK indexes) has a same-named <c>CREATE INDEX</c> statement with a matching
-/// <c>UNIQUE</c> flag. Does not validate index column order/composition beyond that, and does not
-/// flag an extra index present in the .sql file but absent from the model.</item>
+/// <item>A <c>dbo/Tables/{TableName}.sql</c> file exists for every entity, and every .sql file in
+/// that folder has a matching entity (no orphaned table scripts).</item>
+/// <item>Column set (both directions), <c>NULL</c>/<c>NOT NULL</c>, and the SQL store type
+/// including length/precision/scale — <c>nvarchar(200)</c> vs <c>nvarchar(50)</c>,
+/// <c>nvarchar(max)</c>, <c>decimal(p,s)</c>, <c>bigint</c> vs <c>int</c>, etc. Comparison is
+/// case- and whitespace-insensitive, and SQL Server's implicit default precision is normalised
+/// (<c>DATETIMEOFFSET (7)</c> in the script equals EF's bare <c>datetimeoffset</c>).</item>
+/// <item><c>IDENTITY</c> presence per column matches the model's SQL Server value-generation
+/// strategy (int <c>{Entity}Id</c> PKs are identity; composite/natural keys are not).</item>
+/// <item>Primary key constraint name, column composition and order, and clustering.</item>
+/// <item>Every foreign key (single- or multi-column) by constraint name: dependent columns,
+/// principal table and columns, and the <c>ON DELETE</c> action implied by its configured
+/// <see cref="DeleteBehavior"/>. Also flags FK constraints in the .sql file that the model does not
+/// declare.</item>
+/// <item>Every index EF's model declares (explicit <c>[Index]</c> attributes and EF's own implicit
+/// per-FK indexes) by database name: <c>UNIQUE</c> flag, column composition, column order, and
+/// sort direction. Also flags indexes in the .sql file that the model does not declare.</item>
+/// </list>
+/// <para><b>Deliberate remaining limits (documented, not accidental gaps):</b></para>
+/// <list type="bullet">
 /// <item>Parses via regex over raw file text, relying on the repo's existing SQL style (one
 /// statement per <c>GO</c> batch, bracket-quoted identifiers, one table per file named after the
-/// table). Hand-authored .sql that strays from that style can produce false positives/negatives
-/// here instead of a clean parser error — this is a drift *alarm*, not a schema validator.</item>
+/// table, one column per line). Hand-authored .sql that strays from that style can produce false
+/// positives/negatives here instead of a clean parser error — this is a drift <i>alarm</i>, not a
+/// schema validator.</item>
+/// <item>Does not check schema features the model does not use today: default/check constraints,
+/// computed columns, collations, filtered indexes, <c>INCLUDE</c> columns, fill factor, or
+/// per-index clustering. Adding any of those to an entity means extending this test in the same
+/// PR.</item>
+/// <item>Compares the model to the checked-in scripts only, never to a live database. DacFx
+/// schema-compare against a deployed database remains the authoritative (Windows-only) tool if
+/// that is ever needed.</item>
 /// </list>
 /// </remarks>
-public class SchemaParityTests : InMemoryDatabaseTest
+public class SchemaParityTests
 {
+    /// <summary>
+    /// One column definition line inside the <c>CREATE TABLE (...)</c> body: name, store type
+    /// (with its optional parenthesised length/precision), optional <c>IDENTITY (...)</c>, then
+    /// the nullability keyword.
+    /// </summary>
     private static readonly Regex ColumnLineRegex = new(
-        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]\s+.+?\b(?<null>NOT NULL|NULL)\b",
+        @"^\s*\[(?<name>[A-Za-z0-9_]+)\]\s+(?<type>[A-Za-z0-9_]+(?:\s*\([^)]*\))?)\s+(?:(?<identity>IDENTITY(?:\s*\([^)]*\))?)\s+)?(?<null>NOT NULL|NULL)\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex PrimaryKeyRegex = new(
+        @"ADD CONSTRAINT \[(?<name>PK_[A-Za-z0-9_]+)\] PRIMARY KEY (?<clustered>CLUSTERED|NONCLUSTERED)\s*\((?<cols>[^)]*)\)",
         RegexOptions.Compiled);
 
     private static readonly Regex ForeignKeyRegex = new(
-        @"ADD CONSTRAINT \[(?<name>FK_[A-Za-z0-9_]+)\] FOREIGN KEY \(\[(?<col>[A-Za-z0-9_]+)\]\) REFERENCES \[dbo\]\.\[[A-Za-z0-9_]+\] \(\[[A-Za-z0-9_]+\]\)(?<cascade> ON DELETE CASCADE)?",
+        @"ADD CONSTRAINT \[(?<name>FK_[A-Za-z0-9_]+)\] FOREIGN KEY\s*\((?<cols>[^)]*)\) REFERENCES \[dbo\]\.\[(?<ptable>[A-Za-z0-9_]+)\]\s*\((?<pcols>[^)]*)\)(?:\s+ON DELETE (?<ondelete>CASCADE|SET NULL|SET DEFAULT|NO ACTION))?",
         RegexOptions.Compiled);
 
     private static readonly Regex IndexRegex = new(
-        @"CREATE (?<unique>UNIQUE )?(NONCLUSTERED|CLUSTERED) INDEX \[(?<name>IX_[A-Za-z0-9_]+)\]",
+        @"CREATE (?<unique>UNIQUE )?(?<clustered>NONCLUSTERED|CLUSTERED) INDEX \[(?<name>IX_[A-Za-z0-9_]+)\]\s+ON \[dbo\]\.\[[A-Za-z0-9_]+\]\s*\((?<cols>[^)]*)\)",
         RegexOptions.Compiled);
+
+    /// <summary>One entry in a bracket-quoted column list, e.g. <c>[UserId] ASC</c>.</summary>
+    private static readonly Regex ColumnListEntryRegex = new(
+        @"\[(?<col>[A-Za-z0-9_]+)\](?:\s+(?<dir>ASC|DESC))?",
+        RegexOptions.Compiled);
+
+    private static readonly Regex TableBodyRegex = new(
+        @"CREATE TABLE \[dbo\]\.\[[A-Za-z0-9_]+\]\s*\((?<body>.*?)\)\s*;",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
 
     [Fact]
     public void CheckedInSqlFiles_ShouldMatchEfModel()
     {
         string tablesDirectory = FindTablesDirectory();
+        IModel model = BuildSqlServerModel();
         var violations = new List<string>();
+        var modelTableNames = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var entityType in Context.Model.GetEntityTypes())
+        foreach (var entityType in model.GetEntityTypes())
         {
             string tableName = entityType.GetTableName()
                 ?? throw new InvalidOperationException($"{entityType.ClrType.Name} has no table name.");
+            modelTableNames.Add(tableName);
 
             string sqlPath = Path.Combine(tablesDirectory, $"{tableName}.sql");
             if (!File.Exists(sqlPath))
@@ -77,8 +116,17 @@ public class SchemaParityTests : InMemoryDatabaseTest
 
             string sql = File.ReadAllText(sqlPath);
             CheckColumns(entityType, tableName, sql, violations);
+            CheckPrimaryKey(entityType, tableName, sql, violations);
             CheckForeignKeys(entityType, tableName, sql, violations);
             CheckIndexes(entityType, tableName, sql, violations);
+        }
+
+        foreach (string orphanFile in Directory.EnumerateFiles(tablesDirectory, "*.sql")
+            .Select(path => Path.GetFileNameWithoutExtension(path) ?? string.Empty)
+            .Where(name => name.Length > 0 && !modelTableNames.Contains(name))
+            .Order(StringComparer.Ordinal))
+        {
+            violations.Add($"{orphanFile}.sql exists in dbo/Tables but no EF entity maps to table [{orphanFile}]");
         }
 
         Assert.True(
@@ -87,8 +135,26 @@ public class SchemaParityTests : InMemoryDatabaseTest
             $"FoundryGate.Database/dbo/Tables/*.sql:\n  - {string.Join("\n  - ", violations)}");
     }
 
+    /// <summary>
+    /// Builds the SQL Server-provider model without touching a database: model construction only
+    /// runs entity discovery and the provider's type mapping, so the connection string is never
+    /// used. The host name is deliberately unresolvable to make that unmissable if it ever changes.
+    /// The <i>design-time</i> model is used (not <see cref="DbContext.Model"/>) because the runtime
+    /// model is read-optimised and strips the provider annotations this test reads, e.g.
+    /// <see cref="SqlServerKeyExtensions.IsClustered(IReadOnlyKey)"/>.
+    /// </summary>
+    private static IModel BuildSqlServerModel()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer("Server=schema-parity-test.invalid;Database=FoundryGate;Encrypt=False")
+            .Options;
+
+        using var context = new AppDbContext(options);
+        return context.GetService<IDesignTimeModel>().Model;
+    }
+
     private static void CheckColumns(
-        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        IEntityType entityType,
         string tableName,
         string sql,
         List<string> violations)
@@ -98,96 +164,246 @@ public class SchemaParityTests : InMemoryDatabaseTest
         foreach (var property in entityType.GetProperties())
         {
             string columnName = property.GetColumnName();
-            if (!sqlColumns.TryGetValue(columnName, out bool notNullInSql))
+            if (!sqlColumns.TryGetValue(columnName, out SqlColumn? sqlColumn))
             {
                 violations.Add($"{tableName}.{columnName}: column missing from {tableName}.sql");
                 continue;
             }
 
             bool notNullInModel = !property.IsNullable;
-            if (notNullInModel != notNullInSql)
+            if (notNullInModel != sqlColumn.NotNull)
             {
                 violations.Add(
                     $"{tableName}.{columnName}: model says {(notNullInModel ? "NOT NULL" : "NULL")} " +
-                    $"but {tableName}.sql says {(notNullInSql ? "NOT NULL" : "NULL")}");
+                    $"but {tableName}.sql says {(sqlColumn.NotNull ? "NOT NULL" : "NULL")}");
+            }
+
+            string modelType = NormalizeSqlType(property.GetColumnType());
+            string sqlType = NormalizeSqlType(sqlColumn.Type);
+            if (!string.Equals(modelType, sqlType, StringComparison.Ordinal))
+            {
+                violations.Add(
+                    $"{tableName}.{columnName}: model type is {modelType} but {tableName}.sql declares {sqlType}");
+            }
+
+            // Fully qualified: the test project also references the SQLite provider, whose same-named
+            // extension would otherwise make this call ambiguous.
+            bool identityInModel = SqlServerPropertyExtensions.GetValueGenerationStrategy(property)
+                == SqlServerValueGenerationStrategy.IdentityColumn;
+            if (identityInModel != sqlColumn.IsIdentity)
+            {
+                violations.Add(
+                    $"{tableName}.{columnName}: model {(identityInModel ? "is" : "is not")} an IDENTITY column " +
+                    $"but {tableName}.sql {(sqlColumn.IsIdentity ? "declares" : "does not declare")} IDENTITY");
             }
         }
 
-        var modelColumnNames = entityType.GetProperties().Select(p => p.GetColumnName()).ToHashSet();
+        var modelColumnNames = entityType.GetProperties().Select(p => p.GetColumnName()).ToHashSet(StringComparer.Ordinal);
         foreach (string sqlColumnName in sqlColumns.Keys.Where(c => !modelColumnNames.Contains(c)))
         {
             violations.Add($"{tableName}.sql has column [{sqlColumnName}] with no matching EF model property");
         }
     }
 
+    private static void CheckPrimaryKey(
+        IEntityType entityType,
+        string tableName,
+        string sql,
+        List<string> violations)
+    {
+        IKey? key = entityType.FindPrimaryKey();
+        if (key is null)
+        {
+            // Keyless entities have no PK to compare; none exist in this model today.
+            return;
+        }
+
+        string keyName = key.GetName() ?? "(unnamed)";
+        Match match = PrimaryKeyRegex.Match(sql);
+        if (!match.Success)
+        {
+            violations.Add($"{tableName}: no 'ADD CONSTRAINT [PK_*] PRIMARY KEY' statement found in {tableName}.sql");
+            return;
+        }
+
+        string sqlKeyName = match.Groups["name"].Value;
+        if (!string.Equals(keyName, sqlKeyName, StringComparison.Ordinal))
+        {
+            violations.Add($"{tableName}: model primary key is named {keyName} but {tableName}.sql declares {sqlKeyName}");
+        }
+
+        var modelColumns = key.Properties.Select(p => p.GetColumnName()).ToList();
+        var sqlColumns = ParseColumnList(match.Groups["cols"].Value).Select(c => c.Name).ToList();
+        if (!modelColumns.SequenceEqual(sqlColumns, StringComparer.Ordinal))
+        {
+            violations.Add(
+                $"{tableName}: primary key {sqlKeyName} columns are {FormatColumns(modelColumns)} in the model but " +
+                $"{FormatColumns(sqlColumns)} in {tableName}.sql");
+        }
+
+        // SQL Server's default for a PK is clustered; EF leaves IsClustered() null unless overridden.
+        bool clusteredInModel = key.IsClustered() ?? true;
+        bool clusteredInSql = match.Groups["clustered"].Value == "CLUSTERED";
+        if (clusteredInModel != clusteredInSql)
+        {
+            violations.Add(
+                $"{tableName}: primary key {sqlKeyName} is {(clusteredInModel ? "CLUSTERED" : "NONCLUSTERED")} in the model but " +
+                $"{(clusteredInSql ? "CLUSTERED" : "NONCLUSTERED")} in {tableName}.sql");
+        }
+    }
+
     private static void CheckForeignKeys(
-        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        IEntityType entityType,
         string tableName,
         string sql,
         List<string> violations)
     {
         var sqlForeignKeys = ParseForeignKeys(sql);
+        var modelForeignKeyNames = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var fk in entityType.GetForeignKeys())
         {
-            if (fk.Properties.Count != 1)
-            {
-                // No composite FKs exist in this model today; skip defensively rather than guess a format.
-                continue;
-            }
-
             string? fkName = fk.GetConstraintName();
-            if (fkName is null || !sqlForeignKeys.TryGetValue(fkName, out bool hasCascadeInSql))
+            if (fkName is null || !sqlForeignKeys.TryGetValue(fkName, out SqlForeignKey? sqlFk))
             {
                 violations.Add($"{tableName}: foreign key '{fkName ?? "(unnamed)"}' missing from {tableName}.sql");
                 continue;
             }
 
-            bool expectCascade = fk.DeleteBehavior == DeleteBehavior.Cascade;
-            if (expectCascade != hasCascadeInSql)
+            modelForeignKeyNames.Add(fkName);
+
+            var modelColumns = fk.Properties.Select(p => p.GetColumnName()).ToList();
+            if (!modelColumns.SequenceEqual(sqlFk.Columns, StringComparer.Ordinal))
             {
                 violations.Add(
-                    $"{tableName}: FK {fkName} DeleteBehavior is {fk.DeleteBehavior} but {tableName}.sql " +
-                    $"{(hasCascadeInSql ? "has" : "is missing")} ON DELETE CASCADE");
+                    $"{tableName}: FK {fkName} columns are {FormatColumns(modelColumns)} in the model but " +
+                    $"{FormatColumns(sqlFk.Columns)} in {tableName}.sql");
             }
+
+            string principalTable = fk.PrincipalEntityType.GetTableName() ?? "(no table)";
+            var principalColumns = fk.PrincipalKey.Properties.Select(p => p.GetColumnName()).ToList();
+            if (!string.Equals(principalTable, sqlFk.PrincipalTable, StringComparison.Ordinal)
+                || !principalColumns.SequenceEqual(sqlFk.PrincipalColumns, StringComparer.Ordinal))
+            {
+                violations.Add(
+                    $"{tableName}: FK {fkName} references [{principalTable}] {FormatColumns(principalColumns)} in the model but " +
+                    $"[{sqlFk.PrincipalTable}] {FormatColumns(sqlFk.PrincipalColumns)} in {tableName}.sql");
+            }
+
+            string expectedOnDelete = ToSqlOnDeleteAction(fk.DeleteBehavior);
+            if (!string.Equals(expectedOnDelete, sqlFk.OnDelete, StringComparison.Ordinal))
+            {
+                violations.Add(
+                    $"{tableName}: FK {fkName} DeleteBehavior is {fk.DeleteBehavior} (ON DELETE {expectedOnDelete}) but " +
+                    $"{tableName}.sql declares ON DELETE {sqlFk.OnDelete}");
+            }
+        }
+
+        foreach (string extraFk in sqlForeignKeys.Keys.Where(name => !modelForeignKeyNames.Contains(name)))
+        {
+            violations.Add($"{tableName}.sql declares foreign key {extraFk} that the EF model does not have");
         }
     }
 
     private static void CheckIndexes(
-        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        IEntityType entityType,
         string tableName,
         string sql,
         List<string> violations)
     {
         var sqlIndexes = ParseIndexes(sql);
+        var modelIndexNames = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var index in entityType.GetIndexes())
         {
             string? indexName = index.GetDatabaseName();
-            if (indexName is null || !sqlIndexes.TryGetValue(indexName, out bool isUniqueInSql))
+            if (indexName is null || !sqlIndexes.TryGetValue(indexName, out SqlIndex? sqlIndex))
             {
                 violations.Add($"{tableName}: index '{indexName ?? "(unnamed)"}' missing from {tableName}.sql");
                 continue;
             }
 
-            if (index.IsUnique != isUniqueInSql)
+            modelIndexNames.Add(indexName);
+
+            if (index.IsUnique != sqlIndex.IsUnique)
             {
                 violations.Add(
                     $"{tableName}: index {indexName} IsUnique is {index.IsUnique} in the model but " +
-                    $"{isUniqueInSql} in {tableName}.sql");
+                    $"{sqlIndex.IsUnique} in {tableName}.sql");
             }
+
+            var modelColumns = index.Properties
+                .Select((p, i) => new SqlIndexColumn(p.GetColumnName(), IsDescending(index, i)))
+                .ToList();
+            if (!modelColumns.SequenceEqual(sqlIndex.Columns))
+            {
+                violations.Add(
+                    $"{tableName}: index {indexName} columns are {FormatColumns(modelColumns)} in the model but " +
+                    $"{FormatColumns(sqlIndex.Columns)} in {tableName}.sql");
+            }
+        }
+
+        foreach (string extraIndex in sqlIndexes.Keys.Where(name => !modelIndexNames.Contains(name)))
+        {
+            violations.Add($"{tableName}.sql declares index {extraIndex} that the EF model does not have");
         }
     }
 
-    /// <summary>Column name -> whether the .sql file marks it NOT NULL (false = nullable).</summary>
-    private static Dictionary<string, bool> ParseColumns(string sql)
+    /// <summary>
+    /// EF encodes sort direction as: <see langword="null"/> = all ascending, empty list = all
+    /// descending, otherwise one flag per column.
+    /// </summary>
+    private static bool IsDescending(IIndex index, int columnOrdinal) =>
+        index.IsDescending switch
+        {
+            null => false,
+            { Count: 0 } => true,
+            var flags => flags[columnOrdinal],
+        };
+
+    private static string ToSqlOnDeleteAction(DeleteBehavior behavior) =>
+        behavior switch
+        {
+            DeleteBehavior.Cascade => "CASCADE",
+            DeleteBehavior.SetNull => "SET NULL",
+            // ClientSetNull/ClientCascade/ClientNoAction/NoAction/Restrict all map to the database
+            // doing nothing: SQL Server's default (and the script omitting ON DELETE) is NO ACTION.
+            _ => "NO ACTION",
+        };
+
+    /// <summary>
+    /// Lower-cases, strips whitespace, and folds SQL Server's implicit default precision so
+    /// EF's <c>datetimeoffset</c> equals the script's <c>DATETIMEOFFSET (7)</c>. Length/precision
+    /// that is NOT a server default (<c>nvarchar(200)</c>, <c>decimal(18,2)</c>) is preserved so
+    /// it is compared.
+    /// </summary>
+    private static string NormalizeSqlType(string type)
     {
-        var columns = new Dictionary<string, bool>(StringComparer.Ordinal);
+        string normalized = WhitespaceRegex.Replace(type, string.Empty).ToLowerInvariant();
+        return normalized switch
+        {
+            "datetimeoffset(7)" => "datetimeoffset",
+            "datetime2(7)" => "datetime2",
+            "time(7)" => "time",
+            _ => normalized,
+        };
+    }
+
+    private static string FormatColumns(IEnumerable<string> columns) =>
+        $"({string.Join(", ", columns.Select(c => $"[{c}]"))})";
+
+    private static string FormatColumns(IEnumerable<SqlIndexColumn> columns) =>
+        $"({string.Join(", ", columns.Select(c => $"[{c.Name}] {(c.IsDescending ? "DESC" : "ASC")}"))})";
+
+    /// <summary>Column name -> parsed definition from the CREATE TABLE body.</summary>
+    private static Dictionary<string, SqlColumn> ParseColumns(string sql)
+    {
+        var columns = new Dictionary<string, SqlColumn>(StringComparer.Ordinal);
 
         // Table body is everything between "CREATE TABLE [dbo].[...] (" and the matching ");" —
         // column type parens (e.g. "IDENTITY (1, 1)") never appear immediately before a semicolon
         // in this repo's SQL style, so a simple first-match works.
-        var tableMatch = Regex.Match(sql, @"CREATE TABLE \[dbo\]\.\[[A-Za-z0-9_]+\]\s*\((?<body>.*?)\)\s*;", RegexOptions.Singleline);
+        Match tableMatch = TableBodyRegex.Match(sql);
         if (!tableMatch.Success)
         {
             return columns;
@@ -201,37 +417,52 @@ public class SchemaParityTests : InMemoryDatabaseTest
                 continue;
             }
 
-            columns[match.Groups["name"].Value] = match.Groups["null"].Value == "NOT NULL";
+            columns[match.Groups["name"].Value] = new SqlColumn(
+                match.Groups["type"].Value,
+                match.Groups["null"].Value == "NOT NULL",
+                match.Groups["identity"].Success);
         }
 
         return columns;
     }
 
-    /// <summary>FK constraint name -> whether it carries ON DELETE CASCADE.</summary>
-    private static Dictionary<string, bool> ParseForeignKeys(string sql)
+    /// <summary>FK constraint name -> parsed shape.</summary>
+    private static Dictionary<string, SqlForeignKey> ParseForeignKeys(string sql)
     {
-        var foreignKeys = new Dictionary<string, bool>(StringComparer.Ordinal);
+        var foreignKeys = new Dictionary<string, SqlForeignKey>(StringComparer.Ordinal);
 
         foreach (Match match in ForeignKeyRegex.Matches(sql))
         {
-            foreignKeys[match.Groups["name"].Value] = match.Groups["cascade"].Success;
+            foreignKeys[match.Groups["name"].Value] = new SqlForeignKey(
+                ParseColumnList(match.Groups["cols"].Value).Select(c => c.Name).ToList(),
+                match.Groups["ptable"].Value,
+                ParseColumnList(match.Groups["pcols"].Value).Select(c => c.Name).ToList(),
+                match.Groups["ondelete"].Success ? match.Groups["ondelete"].Value : "NO ACTION");
         }
 
         return foreignKeys;
     }
 
-    /// <summary>Index name -> whether it is declared UNIQUE.</summary>
-    private static Dictionary<string, bool> ParseIndexes(string sql)
+    /// <summary>Index name -> parsed shape.</summary>
+    private static Dictionary<string, SqlIndex> ParseIndexes(string sql)
     {
-        var indexes = new Dictionary<string, bool>(StringComparer.Ordinal);
+        var indexes = new Dictionary<string, SqlIndex>(StringComparer.Ordinal);
 
         foreach (Match match in IndexRegex.Matches(sql))
         {
-            indexes[match.Groups["name"].Value] = match.Groups["unique"].Success;
+            indexes[match.Groups["name"].Value] = new SqlIndex(
+                match.Groups["unique"].Success,
+                ParseColumnList(match.Groups["cols"].Value));
         }
 
         return indexes;
     }
+
+    /// <summary>Parses <c>[A] ASC, [B] DESC</c> (direction optional; SQL Server defaults to ASC).</summary>
+    private static List<SqlIndexColumn> ParseColumnList(string columnList) =>
+        ColumnListEntryRegex.Matches(columnList)
+            .Select(m => new SqlIndexColumn(m.Groups["col"].Value, m.Groups["dir"].Value == "DESC"))
+            .ToList();
 
     /// <summary>Walks up from the test assembly's output directory to find the repo root (marked by
     /// <c>FoundryGate.sln</c>), then returns <c>src/FoundryGate.Database/dbo/Tables</c> under it.</summary>
@@ -251,4 +482,16 @@ public class SchemaParityTests : InMemoryDatabaseTest
 
         return Path.Combine(directory.FullName, "src", "FoundryGate.Database", "dbo", "Tables");
     }
+
+    private sealed record SqlColumn(string Type, bool NotNull, bool IsIdentity);
+
+    private sealed record SqlForeignKey(
+        List<string> Columns,
+        string PrincipalTable,
+        List<string> PrincipalColumns,
+        string OnDelete);
+
+    private sealed record SqlIndex(bool IsUnique, List<SqlIndexColumn> Columns);
+
+    private sealed record SqlIndexColumn(string Name, bool IsDescending);
 }


### PR DESCRIPTION
## Summary

Closes #100 via **option 1** (extend the cross-platform parity test). `SchemaParityTests.CheckedInSqlFiles_ShouldMatchEfModel` now builds the `AppDbContext` model with the **SQL Server provider** (design-time `IModel` via `IDesignTimeModel` — no connection is ever opened; the connection string host is a deliberately unresolvable `.invalid`) instead of the SQLite in-memory harness, so real store types and provider annotations are available. Per table it now checks:

| Area | Before | Now |
|---|---|---|
| Columns | name set (both directions), NULL/NOT NULL | + store type incl. length/precision/scale (`nvarchar(200)` vs `(50)`, `nvarchar(max)`, `decimal(p,s)`, `bigint` vs `int`), case/whitespace-insensitive, `DATETIMEOFFSET (7)` folded to `datetimeoffset`; + `IDENTITY` presence vs `SqlServerValueGenerationStrategy` |
| Primary key | — | constraint name, column composition/order, CLUSTERED/NONCLUSTERED |
| Foreign keys | single-column only: name exists, `ON DELETE CASCADE` flag | composite-capable: dependent columns, principal table + columns, `ON DELETE` action derived from `DeleteBehavior` (`CASCADE` / `SET NULL` / `NO ACTION`); + FKs in the .sql absent from the model |
| Indexes | name exists, `UNIQUE` flag | + column composition, order, ASC/DESC; + indexes in the .sql absent from the model |
| Files | one .sql per entity | + orphaned .sql files with no mapped entity |

Single aggregate bullet-list assertion kept; XML doc rewritten into "what is checked" + "deliberate remaining limits" (regex parser tied to the repo's SQL style; no default/check constraints, computed columns, collations, filtered/INCLUDE indexes — none exist in the model today; compares to scripts, not a live DB). No exclusions were needed — the seven checked-in scripts already matched the model at type level, so **no .sql changes** in this PR.

`plans/23-database-tooling.md` status note + verification checklist updated accordingly.

## Verification

- `dotnet build FoundryGate.sln -c Release` — 0 warnings, 0 errors
- `dotnet test src/FoundryGate.Tests.Predeployment -c Release --no-build` — **82/82** passing (same count as main: this extends the existing aggregate fact rather than adding a second one)
- `dotnet format FoundryGate.sln --verify-no-changes` — clean
- Cross-platform: no SQLite/DacFx/Windows dependency added; `Microsoft.EntityFrameworkCore.SqlServer` already flows transitively from `FoundryGate.Data`

### Proof the new checks bite (then reverted)

Injected five deliberate drifts into the .sql files at once:

1. `Users.DisplayName` shrunk `NVARCHAR (200)` → `NVARCHAR (50)`
2. Stray `CREATE NONCLUSTERED INDEX [IX_Users_Email]` appended to `Users.sql`
3. `IX_QuotaAllocations_UserId_PeriodYear_PeriodMonth` columns reordered to `([PeriodYear] ASC, [UserId] ASC, [PeriodMonth] DESC)`
4. `IDENTITY (1, 1)` removed from `Groups.GroupId`
5. `ON DELETE CASCADE` removed from `FK_QuotaAllocations_Users_UserId`

The single assertion failed with exactly these five bullets:

```
Found 5 schema drift violation(s) between the EF model and FoundryGate.Database/dbo/Tables/*.sql:
  - Groups.GroupId: model is an IDENTITY column but Groups.sql does not declare IDENTITY
  - QuotaAllocations: FK FK_QuotaAllocations_Users_UserId DeleteBehavior is Cascade (ON DELETE CASCADE) but QuotaAllocations.sql declares ON DELETE NO ACTION
  - QuotaAllocations: index IX_QuotaAllocations_UserId_PeriodYear_PeriodMonth columns are ([UserId] ASC, [PeriodYear] ASC, [PeriodMonth] ASC) in the model but ([PeriodYear] ASC, [UserId] ASC, [PeriodMonth] DESC) in QuotaAllocations.sql
  - Users.DisplayName: model type is nvarchar(200) but Users.sql declares nvarchar(50)
  - Users.sql declares index IX_Users_Email that the EF model does not have
```

`git checkout -- src/FoundryGate.Database` restored the scripts; 82/82 green again.

## Deferred (option 2)

`foundrygate db compare` (DacFx `SchemaComparison`, Windows-only) was **not** implemented — it's a developer convenience for *regenerating* the scripts, not a CI gate, and the parity test now covers every drift class we've seen without needing it. Tracked as #103 for when hand-authoring tables becomes a recurring chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtuGhG69SaSuVfx92RwwNk