### PR TITLE
feat(infra): control plane modules (SQL, Container Apps, SWA, Functions, Key Vault, RBAC) behind deployControlPlane

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.mdx
+++ b/docs-site/src/content/docs/reference/configuration.mdx
@@ -28,19 +28,29 @@ Blank values (`""`) are deliberate placeholders. The system will not function co
 
 ## API environment variables / appsettings
 
-These are set as Container App environment variables (sourced from Key Vault references for secrets).
+Set as Container App environment variables by `infra/modules/control-plane.bicep` — the
+Bicep is the source of truth for names and values, and the
+[Infrastructure Reference](/foundry-gate/reference/infrastructure/) lists them per host.
+None of them is a secret: SQL uses Entra authentication, so even the connection string is
+plain configuration. Secrets, when one is ever needed, are set out of band in Key Vault
+and referenced from appsettings as `@KeyVault(SecretName)`.
 
 | Key | Source | Description |
 |---|---|---|
-| `ConnectionStrings__Foundry Gate` | Key Vault secret | Azure SQL connection string |
-| `AzureAd__TenantId` | Config / env var | Entra tenant ID for bearer token validation |
-| `AzureAd__ClientId` | Config / env var | Entra App Registration client ID |
-| `AzureAd__Audience` | Config / env var | Token audience (usually `api://{clientId}`) |
-| `Azure__ApimResourceGroup` | Config / env var | Resource group containing the APIM instance |
-| `Azure__ApimServiceName` | Config / env var | APIM service name (short name, not full resource ID) |
-| `Azure__FoundrySubscriptionId` | Config / env var | Azure subscription ID containing Foundry |
-| `Azure__FoundryResourceGroup` | Config / env var | Resource group containing the Foundry account |
-| `Azure__FoundryAccountName` | Config / env var | Foundry account name (short name) |
+| `ASPNETCORE_ENVIRONMENT` | env var | `qa` or `prod` (lowercase; `local` is docker-only) |
+| `AZURE_CLIENT_ID` | env var | Client id of the API's user-assigned managed identity — selects it in the token credential chain |
+| `Azure__KeyVaultUrl` | env var | Key Vault URI for `@KeyVault()` reference resolution; absent locally, which skips resolution |
+| `ConnectionStrings__FoundryGate` | env var | Azure SQL connection string, `Authentication=Active Directory Default` (no password) |
+| `AzureAd__Instance` | env var | Entra cloud instance (`https://login.microsoftonline.com/` in the public cloud) |
+| `AzureAd__TenantId` | env var | Entra tenant ID for bearer token validation |
+| `AzureAd__ClientId` | env var | Entra App Registration client ID |
+| `AzureAd__Audience` | env var | Token audience (usually `api://{clientId}`) |
+| `Cors__AllowedOrigins__0` | env var | The Static Web App origin allowed to call `/api/v1` |
+| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | env var | OpenTelemetry → Azure Monitor; off in `appsettings.local.json` |
+| `Gateway__SubscriptionId`, `Gateway__ResourceGroup`, `Gateway__ApimName`, `Gateway__ApimGatewayUrl` | env var | Where the APIM instance lives — for subscription create/rotate/delete and alias named-value edits |
+| `Gateway__FoundryAccountNames__{i}` | env var | Foundry account names in pool order (index 0 = primary) — for model deployment management |
+| `Gateway__LogAnalyticsWorkspaceId` / `Gateway__LogAnalyticsWorkspaceResourceId` | env var | Workspace GUID (what the Log Analytics query API calls the workspace id) / ARM resource id |
+| `Gateway__KeyEncryptionKeyUri` | env var | Versionless Key Vault key URI for wrapping APIM subscription keys at rest |
 | `Azure__KeyVaultUri` | Config / env var | Key Vault URI for key wrapping (APIM key encryption) |
 | `Graph__ClientId` | Config / env var | App registration client ID for Graph SDK (may differ from AzureAd__ClientId) |
 | `Graph__ClientSecret` | Key Vault secret | Client secret for Graph app-only credentials |
@@ -49,9 +59,12 @@ These are set as Container App environment variables (sourced from Key Vault ref
 
 ## Function App settings
 
-Azure Functions shares the SQL connection string and Azure identity settings but adds:
+Azure Functions (Flex Consumption) gets the same `Azure__*`, `ConnectionStrings__*`,
+`OpenTelemetry__*` and `Gateway__*` settings as the API, with its own identity in
+`AZURE_CLIENT_ID`, plus:
 
 | Key | Description |
 |---|---|
-| `Azure__MonitorWorkspaceId` | Log Analytics workspace ID used by `UsageSyncFunction` to query token metrics |
-| `AzureWebJobsStorage` | Storage account connection string (required by Functions runtime) |
+| `AZURE_FUNCTIONS_ENVIRONMENT` / `DOTNET_ENVIRONMENT` | `qa` or `prod` — the Functions host reads the first, the isolated worker's generic host the second |
+| `AzureWebJobsStorage__accountName` / `AzureWebJobsStorage__credential=managedidentity` / `AzureWebJobsStorage__clientId` | Identity-based host storage. There is no storage connection string: shared-key access is disabled on the account |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Functions host telemetry |

--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -46,13 +46,28 @@ Two invariants for re-runs:
    parameter files ship with `false`; override to `true` on the command line for the very
    first deployment of a new environment only. Model lifecycle after that belongs to the
    control plane, not Bicep.
-2. **Pass the current API image.** The Container App's image is a parameter
-   (`apiContainerImage`, read from the `FG_API_IMAGE` environment variable by the param
-   files). On the bootstrap run it is empty and a public placeholder image is used, because
-   the registry is created by the same deployment and holds nothing yet. Every later infra
-   run must set `FG_API_IMAGE` to the tag currently running (the api-deploy workflow's
-   `az containerapp update --image` is what moves it forward), or the re-run resets the app
-   to the placeholder.
+2. **Pass the current API image — always.** The Container App's image is a parameter
+   (`apiContainerImage`), and the param files read it from the `FG_API_IMAGE` environment
+   variable **with no default**, so `build-params` fails loudly rather than silently
+   swapping the API for a placeholder page. On the bootstrap run the registry is created by
+   the same deployment and holds nothing yet, so pass the public placeholder explicitly:
+   `FG_API_IMAGE=mcr.microsoft.com/k8se/quickstart:latest`. The Container App module
+   recognises it and switches to **port 80 with `/health`-only probes** (that image listens
+   on :80 and serves only `/` and `/health` — verified under docker). Every later infra run
+   sets `FG_API_IMAGE` to the tag currently running (the api-deploy workflow's
+   `az containerapp update --image` is what moves it forward):
+
+   ```bash
+   FG_API_IMAGE=$(az containerapp show -n ca-foundrygate-api-dev -g rg-foundrygate-dev \
+     --query properties.template.containers[0].image -o tsv)
+   ```
+
+   The `containerAppIsBootstrapImage` output reports which mode the app is in.
+
+Prod additionally requires `FG_SQL_ADMIN_GROUP_OBJECT_ID` and `FG_SQL_ADMIN_GROUP_NAME`
+(a dedicated production SQL admin group — with Entra-only auth, group membership *is* the
+access model, so prod deliberately fails to build until that group exists rather than
+pointing at the dev group; see [#109](https://github.com/kolatts/foundry-gate/issues/109)).
 
 ## Naming convention
 
@@ -97,7 +112,7 @@ workflows resolve resources from these patterns — changing one is a contract c
 | `storage-account.bicep` | Functions storage, shared keys off, `function-deployments` container |
 | `static-web-app.bicep` | SWA (Free/Standard), `provider: Custom` |
 | `control-plane-rbac.bicep` | all role assignments below |
-| `container-app.bicep` | Container Apps environment (logs via diagnostic setting — no workspace key) + the API app |
+| `container-app.bicep` | Container Apps environment (logs via diagnostic setting — no workspace key) + the API app; bootstrap-image detection (port 80, `/health`-only probes) |
 | `function-app.bicep` | Flex Consumption plan + Function App, identity-based storage |
 
 ## Control-plane parameters
@@ -106,13 +121,13 @@ workflows resolve resources from these patterns — changing one is a contract c
 |---|---|---|---|
 | `deployControlPlane` | `true` | `true` | default `false` (gateway only) |
 | `appEnvironment` | `qa` | `prod` | `ASPNETCORE_ENVIRONMENT` — lowercase `qa`/`prod`; `local` is docker-only |
-| `sqlAdminGroupObjectId` / `sqlAdminGroupName` | Entra group | Entra group | SQL server administrator (Entra-only auth; no SQL login exists) |
-| `sqlDatabaseSku` / `sqlServerless` | `GP_S_Gen5` ×1, serverless, 60-min auto-pause | `GP_Gen5_2`, provisioned | |
+| `sqlAdminGroupObjectId` / `sqlAdminGroupName` | `SG_IMAGILE_SQL_ADMINS` | `$FG_SQL_ADMIN_GROUP_OBJECT_ID` / `$FG_SQL_ADMIN_GROUP_NAME` (required) | SQL server administrator (Entra-only auth; no SQL login exists) |
+| `sqlDatabaseSku` | `GP_S_Gen5` ×1 — serverless, 60-min auto-pause | `GP_Gen5_2`, provisioned | serverless is derived from the SKU name (`GP_S_*`) |
 | `sqlBackupStorageRedundancy` | `Local` | `Geo` | |
 | `entraTenantId` | tenant | tenant | `AzureAd__TenantId` |
 | `entraApiClientId` | `$FG_ENTRA_API_CLIENT_ID` | same | `AzureAd__ClientId`; zero GUID until the app registration exists |
 | `entraApiAudience` | `api://{clientId}` | same | `AzureAd__Audience` |
-| `apiContainerImage` | `$FG_API_IMAGE` | same | see re-run invariant 2 |
+| `apiContainerImage` | `$FG_API_IMAGE` (required) | same | see re-run invariant 2 |
 | `containerAppMinReplicas` / `MaxReplicas` | 1 / 2 | 1 / 3 | min 1 — the admin API is the UI's only backend |
 | `staticWebAppSku` / `staticWebAppLocation` | `Free` / `eastus2` | `Standard` / `eastus2` | SWA is only offered in a handful of regions |
 | `functionsRuntimeVersion` | `10.0` | `10.0` | .NET isolated worker |
@@ -172,7 +187,8 @@ Core configuration paths (`__` = section separator). None of them is a secret.
 | `AzureAd__Instance` / `TenantId` / `ClientId` / `Audience` | bearer-token validation |
 | `Cors__AllowedOrigins__0` (API) | `https://<static web app hostname>` |
 | `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | `true` / App Insights connection string |
-| `Gateway__SubscriptionId`, `Gateway__ResourceGroup`, `Gateway__ApimName`, `Gateway__ApimGatewayUrl`, `Gateway__LogAnalyticsWorkspaceId`, `Gateway__KeyEncryptionKeyUri`, `Gateway__FoundryAccountNames__{i}` | gateway addressing for the APIM key service, Foundry deployment service and reconciliation ([#108](https://github.com/kolatts/foundry-gate/issues/108)) |
+| `Gateway__SubscriptionId`, `Gateway__ResourceGroup`, `Gateway__ApimName`, `Gateway__ApimGatewayUrl`, `Gateway__KeyEncryptionKeyUri`, `Gateway__FoundryAccountNames__{i}` | gateway addressing for the APIM key service, Foundry deployment service and reconciliation ([#108](https://github.com/kolatts/foundry-gate/issues/108)) |
+| `Gateway__LogAnalyticsWorkspaceId` / `Gateway__LogAnalyticsWorkspaceResourceId` | the workspace **GUID** (`customerId` — what `LogsQueryClient.QueryWorkspaceAsync` and `/v1/workspaces/{id}/query` mean by "workspace id") / the ARM resource id (`QueryResourceAsync`, management plane) |
 | `AzureWebJobsStorage__accountName` / `__credential=managedidentity` / `__clientId` (Functions) | identity-based host storage |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` (Functions) | host telemetry |
 
@@ -186,9 +202,9 @@ empty strings when `deployControlPlane = false`.
 |---|---|
 | `resourceGroupName` | every workflow |
 | `apimGatewayUrl`, `apimName`, `apimPrincipalId`, `anthropicApiUrl`, `openaiApiUrl`, `productIds`, `defaultProductId` | CLI setup docs, control plane |
-| `logAnalyticsWorkspaceId`, `logAnalyticsWorkspaceName`, `appInsightsConnectionString` | monitoring, reconciliation |
+| `logAnalyticsWorkspaceId` (ARM id), `logAnalyticsWorkspaceCustomerId` (GUID), `logAnalyticsWorkspaceName`, `appInsightsConnectionString` | monitoring, reconciliation |
 | `foundryAccountNames` | control plane |
-| `controlPlaneDeployed` | workflow branching |
+| `controlPlaneDeployed`, `containerAppIsBootstrapImage` | workflow branching (the api-deploy workflow's first push replaces the placeholder) |
 | `sqlServerName`, `sqlServerFqdn`, `sqlDatabaseName`, `sqlEntraConnectionString`, `sqlAdminGroupName` | `_deploy-database.yml` (`sql-server-name`, `sql-database-name`), CLI `ip setup` |
 | `keyVaultName`, `keyVaultUri`, `keyEncryptionKeyUri` | out-of-band secret management |
 | `containerRegistryName`, `containerRegistryLoginServer` | api-deploy (`docker push`, image tag) |
@@ -196,6 +212,23 @@ empty strings when `deployControlPlane = false`.
 | `functionAppName`, `functionAppHostname`, `functionsStorageAccountName` | functions-deploy |
 | `staticWebAppName`, `staticWebAppHostname` | ui-deploy (deployment token lookup), CORS, Entra redirect URI |
 | `apiIdentityName` / `ClientId` / `PrincipalId`, `functionsIdentityName` / `ClientId` / `PrincipalId` | contained DB users, Graph permission grants |
+
+## Health probes and serverless auto-pause
+
+The API exposes `/health` (hermetic liveness) and `/health/ready` (adds an
+`AppDbContext` connectivity check). The Container App wires them as:
+
+| Probe | Path | Why |
+|---|---|---|
+| Startup | `/health/ready` (30 × 5 s) | a wrong connection string or identity fails the deploy right there; the window covers a paused serverless database resuming |
+| Liveness | `/health` (30 s) | restart only on a hung process |
+| Readiness | `/health` (15 s) | **deliberately not** `/health/ready`: with `minReplicas: 1` a DB-touching readiness probe would open a SQL connection every 15 s and the dev serverless database would never reach its 60-minute auto-pause |
+
+The trade-off is explicit: for a single-replica admin API, "database down" surfacing as
+500s instead of 503s is not worth an always-on vCore in dev. The dev budget line on
+[Cost & Capacity](/foundry-gate/reference/cost-and-capacity/) (serverless, auto-pause)
+depends on this stance — and on periodic Functions jobs keeping their cadence above the
+pause delay. In the bootstrap-image mode all three probes use `/health` on port 80.
 
 ## Firewall model for Azure SQL
 

--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -1,0 +1,213 @@
+---
+title: Infrastructure Reference
+description: Every Azure resource FoundryGate's Bicep creates, how it is named, the parameters that shape it, the role assignments between them, and the outputs the deploy pipeline consumes.
+---
+
+Everything FoundryGate needs in Azure is one subscription-scope Bicep template,
+`infra/main.bicep`, deployed with `az deployment sub create`. It has two halves:
+
+- **Gateway data plane** — API Management v2, the Azure AI Foundry accounts and their model
+  deployments, the backend pools, quota-tier products and policies, Log Analytics and
+  Application Insights. Always deployed. Documented in
+  [Architecture → Feasibility](/foundry-gate/architecture/feasibility/) and the policy files
+  under `infra/policies/`.
+- **Control plane** — the FoundryGate app that manages the gateway: the API on Container
+  Apps, the Blazor UI on Static Web Apps, background jobs on Functions Flex Consumption,
+  Azure SQL, Key Vault, a container registry, two managed identities and the role
+  assignments between them. Deployed only when `deployControlPlane = true`
+  (`dev.bicepparam` and `prod.bicepparam` set it; `test.bicepparam` is gateway-only).
+
+Every resource lands in one resource group per environment, `rg-foundrygate-{env}`, and
+carries the tags `workload=foundrygate`, `environment`, `managed-by=bicep`, `repo`, an
+`fg-role` (`gateway` | `foundry` | `monitoring` | `control-plane`) and, on control-plane
+resources, an `fg-component` (`api` | `sql` | `keyvault` | `registry` | `functions` |
+`storage` | `ui`). Cost and inventory queries filter on those.
+
+## Deploying
+
+```bash
+# Gateway only (what the team validated live first):
+az deployment sub create --location eastus2 \
+  --template-file infra/main.bicep --parameters infra/parameters/test.bicepparam
+
+# Full stack, dev:
+az deployment sub create --location eastus2 --name foundrygate-dev \
+  --template-file infra/main.bicep --parameters infra/parameters/dev.bicepparam
+
+# Preview any change without touching anything:
+az deployment sub what-if --location eastus2 \
+  --template-file infra/main.bicep --parameters infra/parameters/dev.bicepparam
+```
+
+Two invariants for re-runs:
+
+1. **`createModelDeployments = false` after day 0.** Anthropic (Claude) model deployments
+   are create-once under ARM — re-PUTing an existing one drives it to `Failed`. The
+   parameter files ship with `false`; override to `true` on the command line for the very
+   first deployment of a new environment only. Model lifecycle after that belongs to the
+   control plane, not Bicep.
+2. **Pass the current API image.** The Container App's image is a parameter
+   (`apiContainerImage`, read from the `FG_API_IMAGE` environment variable by the param
+   files). On the bootstrap run it is empty and a public placeholder image is used, because
+   the registry is created by the same deployment and holds nothing yet. Every later infra
+   run must set `FG_API_IMAGE` to the tag currently running (the api-deploy workflow's
+   `az containerapp update --image` is what moves it forward), or the re-run resets the app
+   to the placeholder.
+
+## Naming convention
+
+`{env}` is `environmentName` (`test`, `dev`, `prod`); `{suffix}` is `nameSuffix`, needed
+only where the name is a global DNS label. The CLI `ip setup` command and the deploy
+workflows resolve resources from these patterns — changing one is a contract change.
+
+| Resource | Name | Notes |
+|---|---|---|
+| Resource group | `rg-foundrygate-{env}` | |
+| Log Analytics workspace | `log-foundrygate-{env}` | shared by gateway and control plane |
+| Application Insights | `appi-foundrygate-{env}` | |
+| API Management | `apim-foundrygate-{env}-{suffix}` | v2 tier |
+| Foundry account | `fg{env}-{suffix}-{region}` | one per `foundryRegions` entry, e.g. `fgdev-e7k2-eus2` |
+| Azure SQL server | `sql-foundrygate-{env}-{suffix}` | FQDN `<name>.database.windows.net` |
+| Azure SQL database | `sqldb-foundrygate-{env}` | |
+| Key Vault | `kv-fg-{env}-{suffix}` | 24-char limit forces the short form |
+| Container registry | `crfoundrygate{env}{suffix}` | alphanumeric only |
+| Container Apps environment | `cae-foundrygate-{env}` | |
+| API container app | `ca-foundrygate-api-{env}` | |
+| API identity | `id-foundrygate-api-{env}` | user-assigned |
+| Functions identity | `id-foundrygate-func-{env}` | user-assigned |
+| Function App | `func-foundrygate-{env}-{suffix}` | Flex Consumption |
+| Functions plan | `asp-foundrygate-func-{env}` | `FC1` |
+| Functions storage | `stfg{env}{suffix}` | 3–24 lowercase alphanumeric; shared-key access off |
+| Static Web App | `stapp-foundrygate-{env}` | |
+
+## Modules
+
+| Module | Creates |
+|---|---|
+| `monitoring.bicep` | Log Analytics (62-day retention — two full quota months) + App Insights |
+| `foundry.bicep` | one AIServices account + chained model deployments; keys disabled |
+| `foundry-rbac.bicep` | APIM identity → Cognitive Services User on each account |
+| `apim.bicep` | APIM v2, App Insights logger, `GatewayLlmLogs` diagnostic |
+| `ai-gateway.bicep` | backends, priority pool + breakers, front-door APIs, tier products, alias named values |
+| `control-plane.bicep` | orchestrates everything below; owns the control-plane naming |
+| `managed-identities.bicep` | the two user-assigned identities |
+| `key-vault.bicep` | RBAC-mode vault, soft delete, optional purge protection, optional `fg-apim-key-encryption` RSA-3072 key |
+| `sql.bicep` | Entra-only SQL server, `AllowAllWindowsAzureIps` firewall rule, database |
+| `container-registry.bicep` | Basic ACR, admin user disabled |
+| `storage-account.bicep` | Functions storage, shared keys off, `function-deployments` container |
+| `static-web-app.bicep` | SWA (Free/Standard), `provider: Custom` |
+| `control-plane-rbac.bicep` | all role assignments below |
+| `container-app.bicep` | Container Apps environment (logs via diagnostic setting — no workspace key) + the API app |
+| `function-app.bicep` | Flex Consumption plan + Function App, identity-based storage |
+
+## Control-plane parameters
+
+| Parameter | dev | prod | Purpose |
+|---|---|---|---|
+| `deployControlPlane` | `true` | `true` | default `false` (gateway only) |
+| `appEnvironment` | `qa` | `prod` | `ASPNETCORE_ENVIRONMENT` — lowercase `qa`/`prod`; `local` is docker-only |
+| `sqlAdminGroupObjectId` / `sqlAdminGroupName` | Entra group | Entra group | SQL server administrator (Entra-only auth; no SQL login exists) |
+| `sqlDatabaseSku` / `sqlServerless` | `GP_S_Gen5` ×1, serverless, 60-min auto-pause | `GP_Gen5_2`, provisioned | |
+| `sqlBackupStorageRedundancy` | `Local` | `Geo` | |
+| `entraTenantId` | tenant | tenant | `AzureAd__TenantId` |
+| `entraApiClientId` | `$FG_ENTRA_API_CLIENT_ID` | same | `AzureAd__ClientId`; zero GUID until the app registration exists |
+| `entraApiAudience` | `api://{clientId}` | same | `AzureAd__Audience` |
+| `apiContainerImage` | `$FG_API_IMAGE` | same | see re-run invariant 2 |
+| `containerAppMinReplicas` / `MaxReplicas` | 1 / 2 | 1 / 3 | min 1 — the admin API is the UI's only backend |
+| `staticWebAppSku` / `staticWebAppLocation` | `Free` / `eastus2` | `Standard` / `eastus2` | SWA is only offered in a handful of regions |
+| `functionsRuntimeVersion` | `10.0` | `10.0` | .NET isolated worker |
+| `keyVaultPurgeProtection` | `false` | `true` | irreversible once on |
+| `keyVaultSoftDeleteRetentionInDays` | 7 | 90 | |
+| `createKeyEncryptionKey` | `true` | `true` | RSA key for wrapping APIM subscription keys at rest |
+
+Nothing in a parameter file is a secret: SQL is Entra-only, storage is identity-based,
+registry pulls are identity-based, and the App Insights connection string is a module
+output. Entra object ids and client ids are identifiers, not credentials.
+
+## Role assignments
+
+All scoped to the individual resource, never the resource group; names are
+`guid(scope, principal, role)` so re-runs are idempotent.
+
+| Identity | Role | Scope | Why |
+|---|---|---|---|
+| API | Key Vault Secrets User | Key Vault | `@KeyVault()` reference resolution at startup |
+| API | Key Vault Crypto User | Key Vault | wrap/unwrap APIM subscription keys with `fg-apim-key-encryption` |
+| API | AcrPull | registry | pull the API image |
+| API | API Management Service Contributor | APIM instance | create/rotate/delete developer subscriptions, move between tier products, edit `fg-model-map-*` named values |
+| API | Cognitive Services Contributor | each Foundry account | model deployment lifecycle |
+| API | Log Analytics Reader | workspace | usage queries for the admin dashboard |
+| Functions | Key Vault Secrets User | Key Vault | |
+| Functions | Log Analytics Reader | workspace | reconciliation reads `ApiManagementGatewayLlmLog` |
+| Functions | Storage Blob Data Owner | storage | host state + Flex deployment container |
+| Functions | Storage Queue Data Contributor | storage | queue triggers/outputs |
+| Functions | Storage Table Data Contributor | storage | table bindings |
+| APIM (system-assigned) | Cognitive Services User | each Foundry account | gateway → model backends, no account keys |
+
+Not expressible in Bicep — operator steps tracked in
+[#109](https://github.com/kolatts/foundry-gate/issues/109):
+
+- The CI/OIDC principal must be a **member of the SQL Entra admin group** or the dacpac
+  deploy cannot connect (there is no password fallback by design).
+- **Contained database users** for `id-foundrygate-api-{env}` and
+  `id-foundrygate-func-{env}` (`CREATE USER ... FROM EXTERNAL PROVIDER` +
+  `db_datareader`/`db_datawriter`) are created after the dacpac deploy
+  ([#106](https://github.com/kolatts/foundry-gate/issues/106)).
+- Runtime creation of **Claude** deployments needs Marketplace/SaaS permissions beyond
+  Cognitive Services Contributor ([#107](https://github.com/kolatts/foundry-gate/issues/107)).
+- Graph application permissions for the Entra sync go on the API identity's service
+  principal — no client secret ([#110](https://github.com/kolatts/foundry-gate/issues/110)).
+
+## What the hosts are told
+
+Set as Container App environment variables and Function App settings; keys are ASP.NET
+Core configuration paths (`__` = section separator). None of them is a secret.
+
+| Key | Value |
+|---|---|
+| `ASPNETCORE_ENVIRONMENT` (API) / `AZURE_FUNCTIONS_ENVIRONMENT` + `DOTNET_ENVIRONMENT` (Functions) | `qa` or `prod` |
+| `AZURE_CLIENT_ID` | the host's user-assigned identity client id — selects it in `AppTokenCredential` |
+| `Azure__KeyVaultUrl` | `https://kv-fg-{env}-{suffix}.vault.azure.net/` |
+| `ConnectionStrings__FoundryGate` | `Server=tcp:<fqdn>,1433;Database=sqldb-foundrygate-{env};Authentication=Active Directory Default;Encrypt=True;...` |
+| `AzureAd__Instance` / `TenantId` / `ClientId` / `Audience` | bearer-token validation |
+| `Cors__AllowedOrigins__0` (API) | `https://<static web app hostname>` |
+| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | `true` / App Insights connection string |
+| `Gateway__SubscriptionId`, `Gateway__ResourceGroup`, `Gateway__ApimName`, `Gateway__ApimGatewayUrl`, `Gateway__LogAnalyticsWorkspaceId`, `Gateway__KeyEncryptionKeyUri`, `Gateway__FoundryAccountNames__{i}` | gateway addressing for the APIM key service, Foundry deployment service and reconciliation ([#108](https://github.com/kolatts/foundry-gate/issues/108)) |
+| `AzureWebJobsStorage__accountName` / `__credential=managedidentity` / `__clientId` (Functions) | identity-based host storage |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` (Functions) | host telemetry |
+
+## Outputs contract
+
+Read with `az deployment sub show --name <deployment> --query properties.outputs`. The
+deploy workflows consume these rather than re-deriving names. Control-plane outputs are
+empty strings when `deployControlPlane = false`.
+
+| Output | Used by |
+|---|---|
+| `resourceGroupName` | every workflow |
+| `apimGatewayUrl`, `apimName`, `apimPrincipalId`, `anthropicApiUrl`, `openaiApiUrl`, `productIds`, `defaultProductId` | CLI setup docs, control plane |
+| `logAnalyticsWorkspaceId`, `logAnalyticsWorkspaceName`, `appInsightsConnectionString` | monitoring, reconciliation |
+| `foundryAccountNames` | control plane |
+| `controlPlaneDeployed` | workflow branching |
+| `sqlServerName`, `sqlServerFqdn`, `sqlDatabaseName`, `sqlEntraConnectionString`, `sqlAdminGroupName` | `_deploy-database.yml` (`sql-server-name`, `sql-database-name`), CLI `ip setup` |
+| `keyVaultName`, `keyVaultUri`, `keyEncryptionKeyUri` | out-of-band secret management |
+| `containerRegistryName`, `containerRegistryLoginServer` | api-deploy (`docker push`, image tag) |
+| `containerAppsEnvironmentName`, `containerAppName`, `containerAppFqdn` | api-deploy (`az containerapp update`), postdeployment tests |
+| `functionAppName`, `functionAppHostname`, `functionsStorageAccountName` | functions-deploy |
+| `staticWebAppName`, `staticWebAppHostname` | ui-deploy (deployment token lookup), CORS, Entra redirect URI |
+| `apiIdentityName` / `ClientId` / `PrincipalId`, `functionsIdentityName` / `ClientId` / `PrincipalId` | contained DB users, Graph permission grants |
+
+## Firewall model for Azure SQL
+
+Public endpoint, Entra-only authentication, and two kinds of firewall rule:
+
+- `AllowAllWindowsAzureIps` (`0.0.0.0`–`0.0.0.0`) — declared in Bicep; lets Container Apps
+  and Functions connect without a VNet.
+- Runner and developer IP rules — created at deploy time by `foundrygate ip setup --env
+  {env}` ([#96](https://github.com/kolatts/foundry-gate/issues/96)) against
+  `sql-foundrygate-{env}-{suffix}` in `rg-foundrygate-{env}`. Deliberately **not** declared
+  in Bicep: an incremental deployment leaves undeclared child resources alone, so a re-run
+  never wipes a rule the pipeline just added.
+
+Private endpoints (spec §11 for prod) are a later hardening step and would replace the
+first rule, not the second.

--- a/fable-refactor-log.md
+++ b/fable-refactor-log.md
@@ -224,6 +224,8 @@ same template per subscription — because Claude Global Standard quota is poole
 per-subscription per-model, extra subscriptions (not extra same-subscription
 deployments) are what multiply Claude headroom. Cross-subscription cost/inventory
 queries filter on workload+environment+fg-role uniformly.
+**Extended (#43/#44, PR #111):** control-plane resources carry `fg-role=control-plane`
+plus `fg-component` (api|sql|keyvault|registry|functions|storage|ui).
 **Why:** Asked for explicitly by the user mid-session; also required for the cost
 rate-card work (#84) to attribute Claude Marketplace meters across stacks.
 - **E-009:** APIM backend pools reject `url`/`protocol` on the pool resource (only

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,12 +1,15 @@
-// FoundryGate — gateway data plane (subscription scope).
+// FoundryGate — full stack (subscription scope).
 // Provisions: resource group, monitoring, Foundry accounts + model deployments per
-// region, APIM (StandardV2), and the AI gateway layer (backends, pools, APIs,
-// product, policies). The FoundryGate control-plane app (API/UI/SQL) is provisioned
-// separately; this file is deliberately deployable on its own so a fork can stand up
-// the data plane first and prove traffic flows before any app code exists.
+// region, APIM (StandardV2), the AI gateway layer (backends, pools, APIs, products,
+// policies) and — behind `deployControlPlane` — the FoundryGate control plane (API on
+// Container Apps, Blazor UI on Static Web Apps, Functions Flex Consumption, Azure SQL,
+// Key Vault, registry, role assignments; see modules/control-plane.bicep).
+// The gateway data plane is deliberately deployable on its own (deployControlPlane=false,
+// the default) so a fork can stand it up first and prove traffic flows before any app
+// code exists; parameters/test.bicepparam is exactly that shape.
 targetScope = 'subscription'
 
-@description('Deployment environment name, used in resource names (e.g. test, prod).')
+@description('Deployment environment name, used in resource names (e.g. test, dev, prod). Lowercase alphanumeric — it lands in storage/registry names.')
 param environmentName string
 
 @description('Primary Azure region for shared resources (APIM, monitoring).')
@@ -144,6 +147,75 @@ param productModelAliases object = {
 @description('Create model deployments (first run). Set false on re-runs — Anthropic deployments are create-once under ARM; see modules/foundry.bicep.')
 param createModelDeployments bool = true
 
+// ---- Control plane (#43/#44) -----------------------------------------------------
+// Off by default so the gateway-only deployment keeps working unchanged; dev/prod param
+// files turn it on. When on, sqlAdminGroupObjectId/sqlAdminGroupName and
+// entraApiClientId are effectively required (Bicep has no conditional-required, so an
+// empty group id fails at deploy time inside modules/sql.bicep rather than here).
+@description('Deploy the control plane (SQL, Container Apps API, Static Web App, Functions, Key Vault, registry, RBAC) alongside the gateway.')
+param deployControlPlane bool = false
+
+@allowed(['qa', 'prod'])
+@description('ASPNETCORE_ENVIRONMENT for the control-plane hosts (lowercase per CONVENTIONS.md). Distinct from environmentName, which only names resources.')
+param appEnvironment string = 'qa'
+
+@description('Object id of the Entra security group that administers Azure SQL (Entra-only auth). The CI/OIDC principal that runs the dacpac deploy must be a member — a manual step, see docs reference/infrastructure.')
+param sqlAdminGroupObjectId string = ''
+
+@description('Display name of that group (becomes the SQL server admin login name).')
+param sqlAdminGroupName string = ''
+
+@description('Azure SQL database SKU: { name, tier, family?, capacity? }. Default is serverless (dev); prod.bicepparam uses provisioned General Purpose.')
+param sqlDatabaseSku object = {
+  name: 'GP_S_Gen5'
+  tier: 'GeneralPurpose'
+  family: 'Gen5'
+  capacity: 1
+}
+
+@description('True when sqlDatabaseSku is serverless (enables auto-pause + min vCores).')
+param sqlServerless bool = true
+
+@allowed(['Local', 'Zone', 'Geo', 'GeoZone'])
+param sqlBackupStorageRedundancy string = 'Local'
+
+@description('Entra tenant the API validates bearer tokens against (AzureAd__TenantId).')
+param entraTenantId string = tenant().tenantId
+
+@description('Client id of the FoundryGate.Api app registration (AzureAd__ClientId).')
+param entraApiClientId string = ''
+
+@description('Token audience (AzureAd__Audience). Empty = api://{entraApiClientId}.')
+param entraApiAudience string = ''
+
+@description('API image, e.g. crfoundrygatedeve7k2.azurecr.io/foundrygate-api:<sha>. Empty = public placeholder for the bootstrap deploy (the registry is created by this same run). Deploy workflows MUST pass the current tag on every infra re-run or the app is reset to the placeholder.')
+param apiContainerImage string = ''
+
+@minValue(1)
+param containerAppMinReplicas int = 1
+
+@minValue(1)
+param containerAppMaxReplicas int = 3
+
+@allowed(['Free', 'Standard'])
+param staticWebAppSku string = 'Free'
+
+@description('Static Web Apps region (limited set: eastus2, centralus, westus2, westeurope, eastasia).')
+param staticWebAppLocation string = 'eastus2'
+
+@description('Functions .NET isolated runtime version.')
+param functionsRuntimeVersion string = '10.0'
+
+@description('Key Vault purge protection — irreversible once on; true for prod.')
+param keyVaultPurgeProtection bool = false
+
+@minValue(7)
+@maxValue(90)
+param keyVaultSoftDeleteRetentionInDays int = 7
+
+@description('Create the Key Vault RSA key the API wraps APIM subscription keys with (#95).')
+param createKeyEncryptionKey bool = true
+
 // Standard tags on every resource. Scale model: one FoundryGate stack per environment
 // per subscription; additional REGIONS scale inside a stack (foundryRegions → pool
 // members, all tagged fg-role=foundry); additional SUBSCRIPTIONS scale by deploying
@@ -261,9 +333,50 @@ module gateway 'modules/ai-gateway.bicep' = {
   dependsOn: [foundryRbac]
 }
 
-// Everything a control plane needs to attach: gateway addresses, the tier products that
-// developer subscriptions scope to, the workspace holding billing-grade token logs,
-// and the identities/names for further role assignments.
+// The app that manages the gateway. Attaches to the gateway/monitoring resources above by
+// name (role assignments on APIM, each Foundry account and the workspace), so it runs
+// after the gateway layer is in place.
+module controlPlane 'modules/control-plane.bicep' = if (deployControlPlane) {
+  name: 'foundrygate-control-plane'
+  scope: rg
+  params: {
+    environmentName: environmentName
+    location: location
+    nameSuffix: nameSuffix
+    tags: standardTags
+    appEnvironment: appEnvironment
+    workspaceId: monitoring.outputs.workspaceId
+    workspaceName: monitoring.outputs.workspaceName
+    appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
+    apimName: apim.outputs.apimName
+    apimGatewayUrl: apim.outputs.gatewayUrl
+    foundryAccountNames: [for (region, i) in foundryRegions: foundry[i].outputs.accountName]
+    sqlAdminGroupObjectId: sqlAdminGroupObjectId
+    sqlAdminGroupName: sqlAdminGroupName
+    sqlDatabaseSku: sqlDatabaseSku
+    sqlServerless: sqlServerless
+    sqlBackupStorageRedundancy: sqlBackupStorageRedundancy
+    entraTenantId: entraTenantId
+    entraApiClientId: entraApiClientId
+    entraApiAudience: entraApiAudience
+    apiContainerImage: apiContainerImage
+    containerAppMinReplicas: containerAppMinReplicas
+    containerAppMaxReplicas: containerAppMaxReplicas
+    staticWebAppSku: staticWebAppSku
+    staticWebAppLocation: staticWebAppLocation
+    functionsRuntimeVersion: functionsRuntimeVersion
+    keyVaultPurgeProtection: keyVaultPurgeProtection
+    keyVaultSoftDeleteRetentionInDays: keyVaultSoftDeleteRetentionInDays
+    createKeyEncryptionKey: createKeyEncryptionKey
+  }
+  dependsOn: [gateway]
+}
+
+// ---- Outputs: the contract the deploy workflows and the CLI consume -------------
+// Gateway: addresses, the tier products that developer subscriptions scope to, the
+// workspace holding billing-grade token logs, and the identities/names for further role
+// assignments.
+output resourceGroupName string = rg.name
 output apimGatewayUrl string = apim.outputs.gatewayUrl
 output apimName string = apim.outputs.apimName
 output apimPrincipalId string = apim.outputs.principalId
@@ -272,5 +385,35 @@ output openaiApiUrl string = gateway.outputs.openaiApiUrl
 output productIds array = gateway.outputs.productIds
 output defaultProductId string = gateway.outputs.defaultProductId
 output logAnalyticsWorkspaceId string = monitoring.outputs.workspaceId
-output resourceGroupName string = rg.name
+output logAnalyticsWorkspaceName string = monitoring.outputs.workspaceName
+output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString
 output foundryAccountNames array = [for (region, i) in foundryRegions: foundry[i].outputs.accountName]
+
+// Control plane: empty strings when deployControlPlane=false. Names follow the convention
+// documented in modules/control-plane.bicep; the deploy workflows read these outputs
+// (az deployment sub show --query properties.outputs) rather than re-deriving names.
+output controlPlaneDeployed bool = deployControlPlane
+output sqlServerName string = deployControlPlane ? controlPlane!.outputs.sqlServerName : ''
+output sqlServerFqdn string = deployControlPlane ? controlPlane!.outputs.sqlServerFqdn : ''
+output sqlDatabaseName string = deployControlPlane ? controlPlane!.outputs.sqlDatabaseName : ''
+output sqlEntraConnectionString string = deployControlPlane ? controlPlane!.outputs.sqlEntraConnectionString : ''
+output sqlAdminGroupName string = deployControlPlane ? controlPlane!.outputs.sqlAdminGroupName : ''
+output keyVaultName string = deployControlPlane ? controlPlane!.outputs.keyVaultName : ''
+output keyVaultUri string = deployControlPlane ? controlPlane!.outputs.keyVaultUri : ''
+output keyEncryptionKeyUri string = deployControlPlane ? controlPlane!.outputs.keyEncryptionKeyUri : ''
+output containerRegistryName string = deployControlPlane ? controlPlane!.outputs.containerRegistryName : ''
+output containerRegistryLoginServer string = deployControlPlane ? controlPlane!.outputs.containerRegistryLoginServer : ''
+output containerAppsEnvironmentName string = deployControlPlane ? controlPlane!.outputs.containerAppsEnvironmentName : ''
+output containerAppName string = deployControlPlane ? controlPlane!.outputs.containerAppName : ''
+output containerAppFqdn string = deployControlPlane ? controlPlane!.outputs.containerAppFqdn : ''
+output functionAppName string = deployControlPlane ? controlPlane!.outputs.functionAppName : ''
+output functionAppHostname string = deployControlPlane ? controlPlane!.outputs.functionAppHostname : ''
+output functionsStorageAccountName string = deployControlPlane ? controlPlane!.outputs.functionsStorageAccountName : ''
+output staticWebAppName string = deployControlPlane ? controlPlane!.outputs.staticWebAppName : ''
+output staticWebAppHostname string = deployControlPlane ? controlPlane!.outputs.staticWebAppHostname : ''
+output apiIdentityName string = deployControlPlane ? controlPlane!.outputs.apiIdentityName : ''
+output apiIdentityClientId string = deployControlPlane ? controlPlane!.outputs.apiIdentityClientId : ''
+output apiIdentityPrincipalId string = deployControlPlane ? controlPlane!.outputs.apiIdentityPrincipalId : ''
+output functionsIdentityName string = deployControlPlane ? controlPlane!.outputs.functionsIdentityName : ''
+output functionsIdentityClientId string = deployControlPlane ? controlPlane!.outputs.functionsIdentityClientId : ''
+output functionsIdentityPrincipalId string = deployControlPlane ? controlPlane!.outputs.functionsIdentityPrincipalId : ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -165,7 +165,7 @@ param sqlAdminGroupObjectId string = ''
 @description('Display name of that group (becomes the SQL server admin login name).')
 param sqlAdminGroupName string = ''
 
-@description('Azure SQL database SKU: { name, tier, family?, capacity? }. Default is serverless (dev); prod.bicepparam uses provisioned General Purpose.')
+@description('Azure SQL database SKU: { name, tier, family?, capacity? }. GP_S_* names are serverless (auto-pause derived from the name); default is serverless for dev, prod.bicepparam uses provisioned General Purpose.')
 param sqlDatabaseSku object = {
   name: 'GP_S_Gen5'
   tier: 'GeneralPurpose'
@@ -173,10 +173,8 @@ param sqlDatabaseSku object = {
   capacity: 1
 }
 
-@description('True when sqlDatabaseSku is serverless (enables auto-pause + min vCores).')
-param sqlServerless bool = true
-
 @allowed(['Local', 'Zone', 'Geo', 'GeoZone'])
+@description('Azure SQL backup storage redundancy: Local for dev, Geo for prod.')
 param sqlBackupStorageRedundancy string = 'Local'
 
 @description('Entra tenant the API validates bearer tokens against (AzureAd__TenantId).')
@@ -188,16 +186,19 @@ param entraApiClientId string = ''
 @description('Token audience (AzureAd__Audience). Empty = api://{entraApiClientId}.')
 param entraApiAudience string = ''
 
-@description('API image, e.g. crfoundrygatedeve7k2.azurecr.io/foundrygate-api:<sha>. Empty = public placeholder for the bootstrap deploy (the registry is created by this same run). Deploy workflows MUST pass the current tag on every infra re-run or the app is reset to the placeholder.')
+@description('API image, e.g. crfoundrygatedeve7k2.azurecr.io/foundrygate-api:<sha>. For the bootstrap deploy (registry created by this same run, nothing pushed yet) pass mcr.microsoft.com/k8se/quickstart:latest explicitly — the Container App module then switches to port 80 and /health-only probes. Every later infra run must pass the running tag; the param files read it from FG_API_IMAGE with no default so a forgotten variable fails build-params instead of silently resetting the app.')
 param apiContainerImage string = ''
 
 @minValue(1)
+@description('Container App minimum replicas. 1 keeps the admin API warm (it is the Blazor UI\'s only backend).')
 param containerAppMinReplicas int = 1
 
 @minValue(1)
+@description('Container App maximum replicas (HTTP concurrency scale rule, 50 concurrent requests per replica).')
 param containerAppMaxReplicas int = 3
 
 @allowed(['Free', 'Standard'])
+@description('Static Web App tier: Free for dev, Standard for prod (custom domain, SLA).')
 param staticWebAppSku string = 'Free'
 
 @description('Static Web Apps region (limited set: eastus2, centralus, westus2, westeurope, eastasia).')
@@ -211,6 +212,7 @@ param keyVaultPurgeProtection bool = false
 
 @minValue(7)
 @maxValue(90)
+@description('Key Vault soft-delete retention in days: 7 for dev (fast purge after teardown), 90 for prod.')
 param keyVaultSoftDeleteRetentionInDays int = 7
 
 @description('Create the Key Vault RSA key the API wraps APIM subscription keys with (#95).')
@@ -347,6 +349,7 @@ module controlPlane 'modules/control-plane.bicep' = if (deployControlPlane) {
     appEnvironment: appEnvironment
     workspaceId: monitoring.outputs.workspaceId
     workspaceName: monitoring.outputs.workspaceName
+    workspaceCustomerId: monitoring.outputs.workspaceCustomerId
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     apimName: apim.outputs.apimName
     apimGatewayUrl: apim.outputs.gatewayUrl
@@ -354,7 +357,6 @@ module controlPlane 'modules/control-plane.bicep' = if (deployControlPlane) {
     sqlAdminGroupObjectId: sqlAdminGroupObjectId
     sqlAdminGroupName: sqlAdminGroupName
     sqlDatabaseSku: sqlDatabaseSku
-    sqlServerless: sqlServerless
     sqlBackupStorageRedundancy: sqlBackupStorageRedundancy
     entraTenantId: entraTenantId
     entraApiClientId: entraApiClientId
@@ -386,34 +388,38 @@ output productIds array = gateway.outputs.productIds
 output defaultProductId string = gateway.outputs.defaultProductId
 output logAnalyticsWorkspaceId string = monitoring.outputs.workspaceId
 output logAnalyticsWorkspaceName string = monitoring.outputs.workspaceName
+@description('Workspace GUID (customerId) — the "workspace id" the Log Analytics query API expects; logAnalyticsWorkspaceId above is the ARM resource id.')
+output logAnalyticsWorkspaceCustomerId string = monitoring.outputs.workspaceCustomerId
 output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString
 output foundryAccountNames array = [for (region, i) in foundryRegions: foundry[i].outputs.accountName]
 
-// Control plane: empty strings when deployControlPlane=false. Names follow the convention
-// documented in modules/control-plane.bicep; the deploy workflows read these outputs
-// (az deployment sub show --query properties.outputs) rather than re-deriving names.
+// Control plane: empty strings when deployControlPlane=false (safe-dereference on the
+// conditional module, so these cannot drift from the module's own condition). Names follow
+// the convention documented in modules/control-plane.bicep; the deploy workflows read these
+// outputs (az deployment sub show --query properties.outputs) rather than re-deriving names.
 output controlPlaneDeployed bool = deployControlPlane
-output sqlServerName string = deployControlPlane ? controlPlane!.outputs.sqlServerName : ''
-output sqlServerFqdn string = deployControlPlane ? controlPlane!.outputs.sqlServerFqdn : ''
-output sqlDatabaseName string = deployControlPlane ? controlPlane!.outputs.sqlDatabaseName : ''
-output sqlEntraConnectionString string = deployControlPlane ? controlPlane!.outputs.sqlEntraConnectionString : ''
-output sqlAdminGroupName string = deployControlPlane ? controlPlane!.outputs.sqlAdminGroupName : ''
-output keyVaultName string = deployControlPlane ? controlPlane!.outputs.keyVaultName : ''
-output keyVaultUri string = deployControlPlane ? controlPlane!.outputs.keyVaultUri : ''
-output keyEncryptionKeyUri string = deployControlPlane ? controlPlane!.outputs.keyEncryptionKeyUri : ''
-output containerRegistryName string = deployControlPlane ? controlPlane!.outputs.containerRegistryName : ''
-output containerRegistryLoginServer string = deployControlPlane ? controlPlane!.outputs.containerRegistryLoginServer : ''
-output containerAppsEnvironmentName string = deployControlPlane ? controlPlane!.outputs.containerAppsEnvironmentName : ''
-output containerAppName string = deployControlPlane ? controlPlane!.outputs.containerAppName : ''
-output containerAppFqdn string = deployControlPlane ? controlPlane!.outputs.containerAppFqdn : ''
-output functionAppName string = deployControlPlane ? controlPlane!.outputs.functionAppName : ''
-output functionAppHostname string = deployControlPlane ? controlPlane!.outputs.functionAppHostname : ''
-output functionsStorageAccountName string = deployControlPlane ? controlPlane!.outputs.functionsStorageAccountName : ''
-output staticWebAppName string = deployControlPlane ? controlPlane!.outputs.staticWebAppName : ''
-output staticWebAppHostname string = deployControlPlane ? controlPlane!.outputs.staticWebAppHostname : ''
-output apiIdentityName string = deployControlPlane ? controlPlane!.outputs.apiIdentityName : ''
-output apiIdentityClientId string = deployControlPlane ? controlPlane!.outputs.apiIdentityClientId : ''
-output apiIdentityPrincipalId string = deployControlPlane ? controlPlane!.outputs.apiIdentityPrincipalId : ''
-output functionsIdentityName string = deployControlPlane ? controlPlane!.outputs.functionsIdentityName : ''
-output functionsIdentityClientId string = deployControlPlane ? controlPlane!.outputs.functionsIdentityClientId : ''
-output functionsIdentityPrincipalId string = deployControlPlane ? controlPlane!.outputs.functionsIdentityPrincipalId : ''
+output containerAppIsBootstrapImage bool = controlPlane.?outputs.containerAppIsBootstrapImage ?? false
+output sqlServerName string = controlPlane.?outputs.sqlServerName ?? ''
+output sqlServerFqdn string = controlPlane.?outputs.sqlServerFqdn ?? ''
+output sqlDatabaseName string = controlPlane.?outputs.sqlDatabaseName ?? ''
+output sqlEntraConnectionString string = controlPlane.?outputs.sqlEntraConnectionString ?? ''
+output sqlAdminGroupName string = controlPlane.?outputs.sqlAdminGroupName ?? ''
+output keyVaultName string = controlPlane.?outputs.keyVaultName ?? ''
+output keyVaultUri string = controlPlane.?outputs.keyVaultUri ?? ''
+output keyEncryptionKeyUri string = controlPlane.?outputs.keyEncryptionKeyUri ?? ''
+output containerRegistryName string = controlPlane.?outputs.containerRegistryName ?? ''
+output containerRegistryLoginServer string = controlPlane.?outputs.containerRegistryLoginServer ?? ''
+output containerAppsEnvironmentName string = controlPlane.?outputs.containerAppsEnvironmentName ?? ''
+output containerAppName string = controlPlane.?outputs.containerAppName ?? ''
+output containerAppFqdn string = controlPlane.?outputs.containerAppFqdn ?? ''
+output functionAppName string = controlPlane.?outputs.functionAppName ?? ''
+output functionAppHostname string = controlPlane.?outputs.functionAppHostname ?? ''
+output functionsStorageAccountName string = controlPlane.?outputs.functionsStorageAccountName ?? ''
+output staticWebAppName string = controlPlane.?outputs.staticWebAppName ?? ''
+output staticWebAppHostname string = controlPlane.?outputs.staticWebAppHostname ?? ''
+output apiIdentityName string = controlPlane.?outputs.apiIdentityName ?? ''
+output apiIdentityClientId string = controlPlane.?outputs.apiIdentityClientId ?? ''
+output apiIdentityPrincipalId string = controlPlane.?outputs.apiIdentityPrincipalId ?? ''
+output functionsIdentityName string = controlPlane.?outputs.functionsIdentityName ?? ''
+output functionsIdentityClientId string = controlPlane.?outputs.functionsIdentityClientId ?? ''
+output functionsIdentityPrincipalId string = controlPlane.?outputs.functionsIdentityPrincipalId ?? ''

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -6,12 +6,22 @@
 // CONVENTIONS.md's storage/identity rules exist to avoid. Same workspace as the gateway's
 // ApiManagementGatewayLlmLog, so one KQL join covers gateway + control plane.
 //
-// The image is a parameter because the registry is created by the same deployment: on the
-// very first run nothing has been pushed yet, so the default is a public placeholder that
-// answers on 8080 and lets the app (and its probes) provision. The deploy workflows own the
-// image afterwards — they MUST pass the current tag on every infra run (see the
-// apiContainerImage description in main.bicep), or a re-run resets the app to the
-// placeholder.
+// BOOTSTRAP IMAGE. The registry is created by the same deployment, so on the very first
+// run nothing has been pushed yet and the app is provisioned with a public placeholder
+// (`mcr.microsoft.com/k8se/quickstart:latest`). That image listens on :80 and serves ONLY
+// `/` and `/health` (verified under docker 2026-09-01: /health 200, /health/ready 404), so
+// while it is in use the ingress port AND every probe path follow it — otherwise the first
+// revision fails its startup probe and never provisions. The deploy workflows own the
+// image afterwards and MUST pass the running tag on every infra run (main.bicep
+// apiContainerImage); a re-run without it resets the app to the placeholder.
+//
+// PROBE STANCE. Startup = /health/ready (opens a SQL connection: a misconfigured
+// connection string or identity fails the deploy right there, which is when you want to
+// know). Liveness and readiness = /health (hermetic). Readiness deliberately does NOT hit
+// the database: with minReplicas 1 a DB-touching readiness probe every 15 s would keep a
+// serverless Azure SQL database from ever reaching its auto-pause delay, making the dev
+// tier's auto-pause decorative — and for a single-replica admin API, "DB down" surfacing
+// as 500s instead of 503s is not worth an always-on vCore.
 param containerAppsEnvironmentName string
 param containerAppName string
 param location string
@@ -26,18 +36,18 @@ param identityId string
 @description('Login server of the registry the image is pulled from with the identity above.')
 param registryLoginServer string
 
-@description('Fully-qualified image reference. Empty = public placeholder for the bootstrap deploy.')
+@description('Fully-qualified image reference. Empty, or the public placeholder, = bootstrap mode (port 80, /health-only probes).')
 param containerImage string = ''
 
-@description('Port the API listens on (ASPNETCORE_URLS is set to match in modules/control-plane.bicep).')
+@description('Port the real API listens on (ASPNETCORE_URLS is set to match in modules/control-plane.bicep). Ignored in bootstrap mode.')
 param targetPort int = 8080
 
 @minValue(1)
 @description('Minimum replicas. 1 keeps the API warm: it is the admin plane and the Blazor UI\'s only backend, so cold starts are user-visible.')
-param minReplicas int = 1
+param minReplicas int
 
 @minValue(1)
-param maxReplicas int = 3
+param maxReplicas int
 
 @description('vCPU per replica, as a decimal string (Consumption profile pairs: 0.25/0.5Gi, 0.5/1Gi, 1/2Gi ...). The default matches the published cost model (docs reference/cost-and-capacity).')
 param cpu string = '0.25'
@@ -47,7 +57,11 @@ param memory string = '0.5Gi'
 param environmentVariables array = []
 
 var placeholderImage = 'mcr.microsoft.com/k8se/quickstart:latest'
-var image = empty(containerImage) ? placeholderImage : containerImage
+var isBootstrap = empty(containerImage) || containerImage == placeholderImage
+var image = isBootstrap ? placeholderImage : containerImage
+var port = isBootstrap ? 80 : targetPort
+var livenessPath = '/health'
+var startupPath = isBootstrap ? '/health' : '/health/ready'
 
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2025-01-01' = {
   name: containerAppsEnvironmentName
@@ -96,7 +110,7 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
       activeRevisionsMode: 'Single'
       ingress: {
         external: true
-        targetPort: targetPort
+        targetPort: port
         transport: 'auto'
         allowInsecure: false
         traffic: [
@@ -122,25 +136,25 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             memory: memory
           }
           env: environmentVariables
-          // /health is hermetic liveness (no dependencies); /health/ready adds the
-          // AppDbContext connectivity check — see FoundryGate.Api HealthCheckExtensions.
           probes: [
             {
+              // Generous window: a paused serverless database takes up to ~a minute to
+              // resume on the first connection this probe makes.
               type: 'Startup'
-              httpGet: { path: '/health', port: targetPort, scheme: 'HTTP' }
+              httpGet: { path: startupPath, port: port, scheme: 'HTTP' }
               initialDelaySeconds: 5
               periodSeconds: 5
-              failureThreshold: 12
+              failureThreshold: 30
             }
             {
               type: 'Liveness'
-              httpGet: { path: '/health', port: targetPort, scheme: 'HTTP' }
+              httpGet: { path: livenessPath, port: port, scheme: 'HTTP' }
               periodSeconds: 30
               failureThreshold: 3
             }
             {
               type: 'Readiness'
-              httpGet: { path: '/health/ready', port: targetPort, scheme: 'HTTP' }
+              httpGet: { path: livenessPath, port: port, scheme: 'HTTP' }
               periodSeconds: 15
               failureThreshold: 3
             }
@@ -168,3 +182,5 @@ output containerAppsEnvironmentId string = containerAppsEnvironment.id
 output containerAppName string = containerApp.name
 output containerAppId string = containerApp.id
 output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn
+@description('True when the app is running the public placeholder image (bootstrap run).')
+output isBootstrapImage bool = isBootstrap

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -1,0 +1,170 @@
+// Container Apps environment + the FoundryGate.Api app.
+//
+// Logs go to the shared Log Analytics workspace through a diagnostic setting
+// (`destination: 'azure-monitor'`) rather than the environment's own `log-analytics`
+// destination, which needs the workspace SHARED KEY in the template — the one thing
+// CONVENTIONS.md's storage/identity rules exist to avoid. Same workspace as the gateway's
+// ApiManagementGatewayLlmLog, so one KQL join covers gateway + control plane.
+//
+// The image is a parameter because the registry is created by the same deployment: on the
+// very first run nothing has been pushed yet, so the default is a public placeholder that
+// answers on 8080 and lets the app (and its probes) provision. The deploy workflows own the
+// image afterwards — they MUST pass the current tag on every infra run (see the
+// apiContainerImage description in main.bicep), or a re-run resets the app to the
+// placeholder.
+param containerAppsEnvironmentName string
+param containerAppName string
+param location string
+param tags object = {}
+
+@description('Resource id of the shared Log Analytics workspace (modules/monitoring.bicep).')
+param workspaceId string
+
+@description('Resource id of the API user-assigned identity (pulls the image, reads Key Vault, talks to SQL/APIM/Foundry).')
+param identityId string
+
+@description('Login server of the registry the image is pulled from with the identity above.')
+param registryLoginServer string
+
+@description('Fully-qualified image reference. Empty = public placeholder for the bootstrap deploy.')
+param containerImage string = ''
+
+@description('Port the API listens on (ASPNETCORE_URLS is set to match in modules/control-plane.bicep).')
+param targetPort int = 8080
+
+@minValue(1)
+@description('Minimum replicas. 1 keeps the API warm: it is the admin plane and the Blazor UI\'s only backend, so cold starts are user-visible.')
+param minReplicas int = 1
+
+@minValue(1)
+param maxReplicas int = 3
+
+@description('vCPU per replica, as a decimal string (Consumption profile pairs: 0.25/0.5Gi, 0.5/1Gi, 1/2Gi ...). The default matches the published cost model (docs reference/cost-and-capacity).')
+param cpu string = '0.25'
+param memory string = '0.5Gi'
+
+@description('Environment variables: [{ name, value }]. No secretRef entries — the control plane resolves @KeyVault() references itself via its identity.')
+param environmentVariables array = []
+
+var placeholderImage = 'mcr.microsoft.com/k8se/quickstart:latest'
+var image = empty(containerImage) ? placeholderImage : containerImage
+
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2025-01-01' = {
+  name: containerAppsEnvironmentName
+  location: location
+  tags: union(tags, { 'fg-component': 'api' })
+  properties: {
+    appLogsConfiguration: {
+      destination: 'azure-monitor'
+    }
+    workloadProfiles: [
+      {
+        name: 'Consumption'
+        workloadProfileType: 'Consumption'
+      }
+    ]
+    zoneRedundant: false
+  }
+}
+
+resource environmentLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'foundrygate-containerapps-logs'
+  scope: containerAppsEnvironment
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      { category: 'ContainerAppConsoleLogs', enabled: true }
+      { category: 'ContainerAppSystemLogs', enabled: true }
+    ]
+  }
+}
+
+resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
+  name: containerAppName
+  location: location
+  tags: union(tags, { 'fg-component': 'api' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    workloadProfileName: 'Consumption'
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: targetPort
+        transport: 'auto'
+        allowInsecure: false
+        traffic: [
+          { latestRevision: true, weight: 100 }
+        ]
+      }
+      // Identity-based pull: no registry password anywhere. The entry is ignored while the
+      // placeholder image (a different server) is in use.
+      registries: [
+        {
+          server: registryLoginServer
+          identity: identityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'foundrygate-api'
+          image: image
+          resources: {
+            cpu: json(cpu)
+            memory: memory
+          }
+          env: environmentVariables
+          // /health is hermetic liveness (no dependencies); /health/ready adds the
+          // AppDbContext connectivity check — see FoundryGate.Api HealthCheckExtensions.
+          probes: [
+            {
+              type: 'Startup'
+              httpGet: { path: '/health', port: targetPort, scheme: 'HTTP' }
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 12
+            }
+            {
+              type: 'Liveness'
+              httpGet: { path: '/health', port: targetPort, scheme: 'HTTP' }
+              periodSeconds: 30
+              failureThreshold: 3
+            }
+            {
+              type: 'Readiness'
+              httpGet: { path: '/health/ready', port: targetPort, scheme: 'HTTP' }
+              periodSeconds: 15
+              failureThreshold: 3
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
+        rules: [
+          {
+            name: 'http-concurrency'
+            http: {
+              metadata: { concurrentRequests: '50' }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output containerAppsEnvironmentName string = containerAppsEnvironment.name
+output containerAppsEnvironmentId string = containerAppsEnvironment.id
+output containerAppName string = containerApp.name
+output containerAppId string = containerApp.id
+output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -1,0 +1,25 @@
+// Container registry for the API image. Pull is by the API's user-assigned identity
+// (AcrPull, modules/control-plane-rbac.bicep); the admin user stays disabled so no
+// registry password exists. One registry per environment (it lives in the environment's
+// resource group, so destroying the environment takes its images with it).
+param registryName string
+param location string
+param tags object = {}
+
+@allowed(['Basic', 'Standard', 'Premium'])
+param sku string = 'Basic'
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
+  name: registryName
+  location: location
+  tags: union(tags, { 'fg-component': 'registry' })
+  sku: { name: sku }
+  properties: {
+    adminUserEnabled: false
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output registryName string = registry.name
+output registryId string = registry.id
+output loginServer string = registry.properties.loginServer

--- a/infra/modules/control-plane-rbac.bicep
+++ b/infra/modules/control-plane-rbac.bicep
@@ -33,17 +33,18 @@ param apimName string
 param foundryAccountNames array
 param workspaceName string
 
-// Built-in role definition ids.
+// Built-in role definition ids — every GUID verified against `az role definition list`
+// (2026-09-01); what-if cannot catch a wrong one (RoleDefinitionDoesNotExist at deploy).
 var roles = {
   keyVaultSecretsUser: '4633458b-17de-408a-b874-0445c86b69e6'
   keyVaultCryptoUser: '12338af0-0e69-4776-bea7-57ae8d297424'
   acrPull: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
   apimServiceContributor: '312a565d-c81f-4fd8-895a-4e21e48d571c'
   cognitiveServicesContributor: '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68'
-  logAnalyticsReader: '73c42c96-874c-492f-b3fb-9d5a4d9d0a5b'
+  logAnalyticsReader: '73c42c96-874c-492b-b04d-ab87d138a893'
   storageBlobDataOwner: 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
   storageQueueDataContributor: '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
-  storageTableDataContributor: '0a9a7e1f-b9d0-4cc4-a60d-0319b160aebd'
+  storageTableDataContributor: '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 }
 
 func roleId(id string) string => subscriptionResourceId('Microsoft.Authorization/roleDefinitions', id)

--- a/infra/modules/control-plane-rbac.bicep
+++ b/infra/modules/control-plane-rbac.bicep
@@ -1,0 +1,189 @@
+// Role assignments wiring the control-plane identities to the resources they operate on.
+// Everything is scoped to the individual resource (never the resource group), and every
+// assignment name is guid(scope, principal, role) so re-runs are idempotent.
+//
+// API identity (FoundryGate.Api):
+//   Key Vault Secrets User           @KeyVault() reference resolution at startup
+//   Key Vault Crypto User            wrap/unwrap APIM subscription keys with the KEK (#95)
+//   AcrPull                          pull the API image
+//   API Management Service Contributor (APIM instance)
+//                                    create / rotate / delete developer subscriptions and
+//                                    move them between tier products; edit fg-model-map-*
+//                                    named values (#86)
+//   Cognitive Services Contributor   (each Foundry account) model deployment lifecycle (#61)
+//   Log Analytics Reader             (workspace) usage queries for the admin dashboard
+//
+// Functions identity (FoundryGate.Functions):
+//   Key Vault Secrets User
+//   Log Analytics Reader             (workspace) reconciliation reads
+//                                    ApiManagementGatewayLlmLog (#84)
+//   Storage Blob Data Owner          Functions host state + Flex deployment container
+//   Storage Queue Data Contributor   queue triggers/outputs (CONVENTIONS.md typed queues)
+//   Storage Table Data Contributor   table bindings
+//
+// NOT here, by design: SQL access (contained users via T-SQL — see modules/sql.bicep), and
+// the Marketplace/SaaS permissions a runtime Claude deployment create needs (#13 direction
+// update) — tracked separately, since they are subscription-scope and outside this RG.
+param apiPrincipalId string
+param functionsPrincipalId string
+param keyVaultName string
+param registryName string
+param storageAccountName string
+param apimName string
+param foundryAccountNames array
+param workspaceName string
+
+// Built-in role definition ids.
+var roles = {
+  keyVaultSecretsUser: '4633458b-17de-408a-b874-0445c86b69e6'
+  keyVaultCryptoUser: '12338af0-0e69-4776-bea7-57ae8d297424'
+  acrPull: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+  apimServiceContributor: '312a565d-c81f-4fd8-895a-4e21e48d571c'
+  cognitiveServicesContributor: '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68'
+  logAnalyticsReader: '73c42c96-874c-492f-b3fb-9d5a4d9d0a5b'
+  storageBlobDataOwner: 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+  storageQueueDataContributor: '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+  storageTableDataContributor: '0a9a7e1f-b9d0-4cc4-a60d-0319b160aebd'
+}
+
+func roleId(id string) string => subscriptionResourceId('Microsoft.Authorization/roleDefinitions', id)
+
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+  name: keyVaultName
+}
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: registryName
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+  name: apimName
+}
+
+resource foundryAccounts 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = [
+  for name in foundryAccountNames: {
+    name: name
+  }
+]
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: workspaceName
+}
+
+// ---- API identity ----------------------------------------------------------------
+resource apiKeyVaultSecrets 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, apiPrincipalId, roles.keyVaultSecretsUser)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: roleId(roles.keyVaultSecretsUser)
+    principalId: apiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource apiKeyVaultCrypto 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, apiPrincipalId, roles.keyVaultCryptoUser)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: roleId(roles.keyVaultCryptoUser)
+    principalId: apiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource apiAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(registry.id, apiPrincipalId, roles.acrPull)
+  scope: registry
+  properties: {
+    roleDefinitionId: roleId(roles.acrPull)
+    principalId: apiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource apiApimContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(apim.id, apiPrincipalId, roles.apimServiceContributor)
+  scope: apim
+  properties: {
+    roleDefinitionId: roleId(roles.apimServiceContributor)
+    principalId: apiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource apiFoundryContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for (name, i) in foundryAccountNames: {
+    name: guid(foundryAccounts[i].id, apiPrincipalId, roles.cognitiveServicesContributor)
+    scope: foundryAccounts[i]
+    properties: {
+      roleDefinitionId: roleId(roles.cognitiveServicesContributor)
+      principalId: apiPrincipalId
+      principalType: 'ServicePrincipal'
+    }
+  }
+]
+
+resource apiLogAnalyticsReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(workspace.id, apiPrincipalId, roles.logAnalyticsReader)
+  scope: workspace
+  properties: {
+    roleDefinitionId: roleId(roles.logAnalyticsReader)
+    principalId: apiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// ---- Functions identity ----------------------------------------------------------
+resource functionsKeyVaultSecrets 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, functionsPrincipalId, roles.keyVaultSecretsUser)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: roleId(roles.keyVaultSecretsUser)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource functionsLogAnalyticsReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(workspace.id, functionsPrincipalId, roles.logAnalyticsReader)
+  scope: workspace
+  properties: {
+    roleDefinitionId: roleId(roles.logAnalyticsReader)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource functionsStorageBlobOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, functionsPrincipalId, roles.storageBlobDataOwner)
+  scope: storage
+  properties: {
+    roleDefinitionId: roleId(roles.storageBlobDataOwner)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource functionsStorageQueueContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, functionsPrincipalId, roles.storageQueueDataContributor)
+  scope: storage
+  properties: {
+    roleDefinitionId: roleId(roles.storageQueueDataContributor)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource functionsStorageTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, functionsPrincipalId, roles.storageTableDataContributor)
+  scope: storage
+  properties: {
+    roleDefinitionId: roleId(roles.storageTableDataContributor)
+    principalId: functionsPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/modules/control-plane.bicep
+++ b/infra/modules/control-plane.bicep
@@ -1,0 +1,279 @@
+// FoundryGate control plane (resource-group scope): the app that manages the gateway —
+// API on Container Apps, Blazor UI on Static Web Apps, background jobs on Functions Flex
+// Consumption, Azure SQL (Entra-only), Key Vault, the container registry, and the role
+// assignments that let the two managed identities operate the gateway data plane.
+//
+// This is an ORCHESTRATION module: it owns the naming convention and the wiring between
+// leaf modules and nothing else. It exists (rather than main.bicep calling the leaf modules
+// directly) because the control plane is optional — main.bicep deploys it behind
+// `deployControlPlane`, and one conditional module means one nullable reference per output
+// there instead of nullable cross-references between eight conditional modules here.
+// Everything inside is unconditional and ordered by real dependencies:
+//
+//   identities ─┬─> key vault ─┐
+//               ├─> registry  ─┤
+//               ├─> storage   ─┼─> rbac ─┬─> container app (pulls image via AcrPull)
+//               ├─> sql       ─┤         └─> function app  (reads deployment container)
+//               └─> static web app (hostname feeds the API's CORS origin)
+//
+// NAMING (all inside rg-foundrygate-{env}; {suffix} = nameSuffix, needed only where the
+// name is a global DNS label). The CLI `ip setup` (#96) and the deploy workflows resolve
+// resources from these patterns, so changing one is a contract change:
+//   sql-foundrygate-{env}-{suffix}     Azure SQL logical server  (FQDN: <name>.database.windows.net)
+//   sqldb-foundrygate-{env}            database
+//   kv-fg-{env}-{suffix}               Key Vault  (24-char limit forces the short form)
+//   crfoundrygate{env}{suffix}         container registry (alphanumeric only)
+//   cae-foundrygate-{env}              Container Apps environment
+//   ca-foundrygate-api-{env}           API container app
+//   id-foundrygate-api-{env}           API user-assigned identity
+//   id-foundrygate-func-{env}          Functions user-assigned identity
+//   func-foundrygate-{env}-{suffix}    Function App
+//   asp-foundrygate-func-{env}         Flex Consumption plan
+//   stfg{env}{suffix}                  Functions storage account (3-24 lowercase alphanumeric)
+//   stapp-foundrygate-{env}            Static Web App
+param environmentName string
+param location string
+param nameSuffix string
+param tags object = {}
+
+@allowed(['qa', 'prod'])
+@description('ASPNETCORE_ENVIRONMENT for the hosts — lowercase qa|prod per CONVENTIONS.md (local is docker-only). Distinct from environmentName, which only names resources.')
+param appEnvironment string
+
+// ---- Shared gateway/monitoring resources this module attaches to ----------------
+param workspaceId string
+param workspaceName string
+param appInsightsConnectionString string
+param apimName string
+param apimGatewayUrl string
+param foundryAccountNames array
+
+// ---- SQL ------------------------------------------------------------------------
+param sqlAdminGroupObjectId string
+param sqlAdminGroupName string
+param sqlDatabaseSku object
+param sqlServerless bool
+param sqlBackupStorageRedundancy string
+
+// ---- Entra (API app registration) -----------------------------------------------
+param entraTenantId string
+param entraApiClientId string
+@description('Token audience; defaults to api://{entraApiClientId} when empty.')
+param entraApiAudience string = ''
+
+// ---- Hosting --------------------------------------------------------------------
+param apiContainerImage string
+param containerAppMinReplicas int
+param containerAppMaxReplicas int
+param staticWebAppSku string
+param staticWebAppLocation string
+param functionsRuntimeVersion string
+param keyVaultPurgeProtection bool
+param keyVaultSoftDeleteRetentionInDays int
+param createKeyEncryptionKey bool
+
+var controlPlaneTags = union(tags, { 'fg-role': 'control-plane' })
+var audience = empty(entraApiAudience) ? 'api://${entraApiClientId}' : entraApiAudience
+var apiPort = 8080
+
+var names = {
+  sqlServer: 'sql-foundrygate-${environmentName}-${nameSuffix}'
+  sqlDatabase: 'sqldb-foundrygate-${environmentName}'
+  keyVault: 'kv-fg-${environmentName}-${nameSuffix}'
+  registry: 'crfoundrygate${environmentName}${nameSuffix}'
+  containerAppsEnvironment: 'cae-foundrygate-${environmentName}'
+  containerApp: 'ca-foundrygate-api-${environmentName}'
+  functionApp: 'func-foundrygate-${environmentName}-${nameSuffix}'
+  functionsPlan: 'asp-foundrygate-func-${environmentName}'
+  storage: take('stfg${environmentName}${nameSuffix}', 24)
+  staticWebApp: 'stapp-foundrygate-${environmentName}'
+}
+
+module identities 'managed-identities.bicep' = {
+  name: 'foundrygate-cp-identities'
+  params: {
+    environmentName: environmentName
+    location: location
+    tags: controlPlaneTags
+  }
+}
+
+module keyVault 'key-vault.bicep' = {
+  name: 'foundrygate-cp-keyvault'
+  params: {
+    keyVaultName: names.keyVault
+    location: location
+    tags: controlPlaneTags
+    enablePurgeProtection: keyVaultPurgeProtection
+    softDeleteRetentionInDays: keyVaultSoftDeleteRetentionInDays
+    createKeyEncryptionKey: createKeyEncryptionKey
+  }
+}
+
+module registry 'container-registry.bicep' = {
+  name: 'foundrygate-cp-registry'
+  params: {
+    registryName: names.registry
+    location: location
+    tags: controlPlaneTags
+  }
+}
+
+module storage 'storage-account.bicep' = {
+  name: 'foundrygate-cp-storage'
+  params: {
+    storageAccountName: names.storage
+    location: location
+    tags: controlPlaneTags
+  }
+}
+
+module sql 'sql.bicep' = {
+  name: 'foundrygate-cp-sql'
+  params: {
+    sqlServerName: names.sqlServer
+    sqlDatabaseName: names.sqlDatabase
+    location: location
+    tags: controlPlaneTags
+    entraAdminGroupObjectId: sqlAdminGroupObjectId
+    entraAdminGroupName: sqlAdminGroupName
+    databaseSku: sqlDatabaseSku
+    serverless: sqlServerless
+    backupStorageRedundancy: sqlBackupStorageRedundancy
+  }
+}
+
+module staticWebApp 'static-web-app.bicep' = {
+  name: 'foundrygate-cp-staticwebapp'
+  params: {
+    staticWebAppName: names.staticWebApp
+    location: staticWebAppLocation
+    tags: controlPlaneTags
+    sku: staticWebAppSku
+  }
+}
+
+// Role assignments BEFORE the hosts: the Container App pulls with AcrPull at creation and
+// the Function App reads its deployment container with Blob Data Owner at creation.
+module rbac 'control-plane-rbac.bicep' = {
+  name: 'foundrygate-cp-rbac'
+  params: {
+    apiPrincipalId: identities.outputs.apiIdentityPrincipalId
+    functionsPrincipalId: identities.outputs.functionsIdentityPrincipalId
+    keyVaultName: keyVault.outputs.keyVaultName
+    registryName: registry.outputs.registryName
+    storageAccountName: storage.outputs.storageAccountName
+    apimName: apimName
+    foundryAccountNames: foundryAccountNames
+    workspaceName: workspaceName
+  }
+}
+
+// Configuration the API and Functions share. Keys are the ASP.NET Core configuration paths
+// (double underscore = section separator) of FoundryGate.Api/Configuration/AppSettings.cs.
+// The connection string is Entra-auth and therefore not a secret; nothing here is.
+var sharedAppConfig = [
+  { name: 'Azure__KeyVaultUrl', value: keyVault.outputs.keyVaultUri }
+  { name: 'ConnectionStrings__FoundryGate', value: sql.outputs.entraConnectionString }
+  { name: 'OpenTelemetry__Enabled', value: 'true' }
+  { name: 'OpenTelemetry__ConnectionString', value: appInsightsConnectionString }
+  // Gateway addressing, so the control plane never needs resource ids typed into
+  // SystemConfiguration by hand. Consumed by the APIM key service (#36/#37), the Foundry
+  // deployment service (#61) and the reconciliation function (#84).
+  { name: 'Gateway__SubscriptionId', value: subscription().subscriptionId }
+  { name: 'Gateway__ResourceGroup', value: resourceGroup().name }
+  { name: 'Gateway__ApimName', value: apimName }
+  { name: 'Gateway__ApimGatewayUrl', value: apimGatewayUrl }
+  { name: 'Gateway__LogAnalyticsWorkspaceId', value: workspaceId }
+  { name: 'Gateway__KeyEncryptionKeyUri', value: keyVault.outputs.keyEncryptionKeyUri }
+]
+
+var foundryAccountConfig = [
+  for (name, i) in foundryAccountNames: { name: 'Gateway__FoundryAccountNames__${i}', value: name }
+]
+
+module containerApp 'container-app.bicep' = {
+  name: 'foundrygate-cp-containerapp'
+  params: {
+    containerAppsEnvironmentName: names.containerAppsEnvironment
+    containerAppName: names.containerApp
+    location: location
+    tags: controlPlaneTags
+    workspaceId: workspaceId
+    identityId: identities.outputs.apiIdentityId
+    registryLoginServer: registry.outputs.loginServer
+    containerImage: apiContainerImage
+    targetPort: apiPort
+    minReplicas: containerAppMinReplicas
+    maxReplicas: containerAppMaxReplicas
+    environmentVariables: concat(
+      [
+        { name: 'ASPNETCORE_ENVIRONMENT', value: appEnvironment }
+        { name: 'ASPNETCORE_URLS', value: 'http://+:${apiPort}' }
+        { name: 'AZURE_CLIENT_ID', value: identities.outputs.apiIdentityClientId }
+        // https://login.microsoftonline.com/ in the public cloud; sovereign-cloud forks get theirs.
+        { name: 'AzureAd__Instance', value: environment().authentication.loginEndpoint }
+        { name: 'AzureAd__TenantId', value: entraTenantId }
+        { name: 'AzureAd__ClientId', value: entraApiClientId }
+        { name: 'AzureAd__Audience', value: audience }
+        { name: 'Cors__AllowedOrigins__0', value: 'https://${staticWebApp.outputs.defaultHostname}' }
+      ],
+      sharedAppConfig,
+      foundryAccountConfig
+    )
+  }
+  dependsOn: [rbac]
+}
+
+module functionApp 'function-app.bicep' = {
+  name: 'foundrygate-cp-functionapp'
+  params: {
+    functionAppName: names.functionApp
+    planName: names.functionsPlan
+    location: location
+    tags: controlPlaneTags
+    identityId: identities.outputs.functionsIdentityId
+    identityClientId: identities.outputs.functionsIdentityClientId
+    storageAccountName: storage.outputs.storageAccountName
+    deploymentContainerName: storage.outputs.deploymentContainerName
+    appInsightsConnectionString: appInsightsConnectionString
+    runtimeVersion: functionsRuntimeVersion
+    appSettings: concat(
+      [
+        // The Functions host reads AZURE_FUNCTIONS_ENVIRONMENT; the isolated worker's
+        // generic host reads DOTNET_ENVIRONMENT. Both get the same lowercase value.
+        { name: 'AZURE_FUNCTIONS_ENVIRONMENT', value: appEnvironment }
+        { name: 'DOTNET_ENVIRONMENT', value: appEnvironment }
+        { name: 'AZURE_CLIENT_ID', value: identities.outputs.functionsIdentityClientId }
+      ],
+      sharedAppConfig,
+      foundryAccountConfig
+    )
+  }
+  dependsOn: [rbac]
+}
+
+output sqlServerName string = sql.outputs.sqlServerName
+output sqlServerFqdn string = sql.outputs.sqlServerFqdn
+output sqlDatabaseName string = sql.outputs.sqlDatabaseName
+output sqlEntraConnectionString string = sql.outputs.entraConnectionString
+output sqlAdminGroupName string = sqlAdminGroupName
+output keyVaultName string = keyVault.outputs.keyVaultName
+output keyVaultUri string = keyVault.outputs.keyVaultUri
+output keyEncryptionKeyUri string = keyVault.outputs.keyEncryptionKeyUri
+output containerRegistryName string = registry.outputs.registryName
+output containerRegistryLoginServer string = registry.outputs.loginServer
+output containerAppsEnvironmentName string = containerApp.outputs.containerAppsEnvironmentName
+output containerAppName string = containerApp.outputs.containerAppName
+output containerAppFqdn string = containerApp.outputs.containerAppFqdn
+output functionAppName string = functionApp.outputs.functionAppName
+output functionAppHostname string = functionApp.outputs.functionAppHostname
+output functionsStorageAccountName string = storage.outputs.storageAccountName
+output staticWebAppName string = staticWebApp.outputs.staticWebAppName
+output staticWebAppHostname string = staticWebApp.outputs.defaultHostname
+output apiIdentityName string = identities.outputs.apiIdentityName
+output apiIdentityClientId string = identities.outputs.apiIdentityClientId
+output apiIdentityPrincipalId string = identities.outputs.apiIdentityPrincipalId
+output functionsIdentityName string = identities.outputs.functionsIdentityName
+output functionsIdentityClientId string = identities.outputs.functionsIdentityClientId
+output functionsIdentityPrincipalId string = identities.outputs.functionsIdentityPrincipalId

--- a/infra/modules/control-plane.bicep
+++ b/infra/modules/control-plane.bicep
@@ -41,8 +41,11 @@ param tags object = {}
 param appEnvironment string
 
 // ---- Shared gateway/monitoring resources this module attaches to ----------------
+@description('ARM resource id of the Log Analytics workspace (diagnostic settings, RBAC scope).')
 param workspaceId string
 param workspaceName string
+@description('Workspace GUID (customerId) — what the Log Analytics query API calls the workspace id.')
+param workspaceCustomerId string
 param appInsightsConnectionString string
 param apimName string
 param apimGatewayUrl string
@@ -52,7 +55,6 @@ param foundryAccountNames array
 param sqlAdminGroupObjectId string
 param sqlAdminGroupName string
 param sqlDatabaseSku object
-param sqlServerless bool
 param sqlBackupStorageRedundancy string
 
 // ---- Entra (API app registration) -----------------------------------------------
@@ -138,7 +140,6 @@ module sql 'sql.bicep' = {
     entraAdminGroupObjectId: sqlAdminGroupObjectId
     entraAdminGroupName: sqlAdminGroupName
     databaseSku: sqlDatabaseSku
-    serverless: sqlServerless
     backupStorageRedundancy: sqlBackupStorageRedundancy
   }
 }
@@ -184,7 +185,11 @@ var sharedAppConfig = [
   { name: 'Gateway__ResourceGroup', value: resourceGroup().name }
   { name: 'Gateway__ApimName', value: apimName }
   { name: 'Gateway__ApimGatewayUrl', value: apimGatewayUrl }
-  { name: 'Gateway__LogAnalyticsWorkspaceId', value: workspaceId }
+  // Two different "workspace ids" on purpose: the GUID is what the query API wants
+  // (LogsQueryClient.QueryWorkspaceAsync, /v1/workspaces/{id}/query); the ARM id is for
+  // QueryResourceAsync and anything management-plane. #108 binds both.
+  { name: 'Gateway__LogAnalyticsWorkspaceId', value: workspaceCustomerId }
+  { name: 'Gateway__LogAnalyticsWorkspaceResourceId', value: workspaceId }
   { name: 'Gateway__KeyEncryptionKeyUri', value: keyVault.outputs.keyEncryptionKeyUri }
 ]
 
@@ -266,6 +271,7 @@ output containerRegistryLoginServer string = registry.outputs.loginServer
 output containerAppsEnvironmentName string = containerApp.outputs.containerAppsEnvironmentName
 output containerAppName string = containerApp.outputs.containerAppName
 output containerAppFqdn string = containerApp.outputs.containerAppFqdn
+output containerAppIsBootstrapImage bool = containerApp.outputs.isBootstrapImage
 output functionAppName string = functionApp.outputs.functionAppName
 output functionAppHostname string = functionApp.outputs.functionAppHostname
 output functionsStorageAccountName string = storage.outputs.storageAccountName

--- a/infra/modules/function-app.bicep
+++ b/infra/modules/function-app.bicep
@@ -1,0 +1,120 @@
+// Azure Functions on the Flex Consumption plan (scale-to-zero, no always-on cost) for the
+// background jobs: usage reconciliation from ApiManagementGatewayLlmLog (#84), monthly
+// reset (#38), Entra sync (#40/#41).
+//
+// Identity everywhere: the host reaches its storage account with the user-assigned
+// identity (AzureWebJobsStorage__credential=managedidentity), the deployment package is
+// read from the storage container with the same identity, and Key Vault references resolve
+// through it (keyVaultReferenceIdentity). Storage shared-key access is OFF
+// (modules/storage-account.bicep), so nothing here could fall back to a key.
+//
+// Flex Consumption differences from the classic Consumption plan, for whoever edits this:
+// no WEBSITE_RUN_FROM_PACKAGE / FUNCTIONS_WORKER_RUNTIME / linuxFxVersion — runtime and
+// deployment source live in functionAppConfig; `Azure/functions-action` publishes to the
+// deployment container.
+param functionAppName string
+param planName string
+param location string
+param tags object = {}
+
+@description('Resource id of the Functions user-assigned identity.')
+param identityId string
+
+@description('Client id of that identity — AZURE_CLIENT_ID for AppTokenCredential and AzureWebJobsStorage__clientId for the host.')
+param identityClientId string
+
+@description('Storage account (shared-key access disabled) backing the Functions host and holding the deployment container.')
+param storageAccountName string
+
+@description('Blob container the package is deployed into.')
+param deploymentContainerName string
+
+@description('Application Insights connection string (shared monitoring stack).')
+param appInsightsConnectionString string
+
+@description('.NET isolated worker runtime version.')
+param runtimeVersion string = '10.0'
+
+@minValue(40)
+@maxValue(1000)
+param maximumInstanceCount int = 100
+
+@allowed([2048, 4096])
+param instanceMemoryMB int = 2048
+
+@description('Additional app settings: [{ name, value }]. Merged after the host settings below.')
+param appSettings array = []
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource plan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: planName
+  location: location
+  tags: union(tags, { 'fg-component': 'functions' })
+  kind: 'functionapp'
+  sku: {
+    tier: 'FlexConsumption'
+    name: 'FC1'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: functionAppName
+  location: location
+  tags: union(tags, { 'fg-component': 'functions' })
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    keyVaultReferenceIdentity: identityId
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storage.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'UserAssignedIdentity'
+            userAssignedIdentityResourceId: identityId
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: maximumInstanceCount
+        instanceMemoryMB: instanceMemoryMB
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: runtimeVersion
+      }
+    }
+    siteConfig: {
+      minTlsVersion: '1.2'
+      ftpsState: 'Disabled'
+      appSettings: concat(
+        [
+          { name: 'AzureWebJobsStorage__accountName', value: storage.name }
+          { name: 'AzureWebJobsStorage__credential', value: 'managedidentity' }
+          { name: 'AzureWebJobsStorage__clientId', value: identityClientId }
+          { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+        ],
+        appSettings
+      )
+    }
+  }
+}
+
+output functionAppName string = functionApp.name
+output functionAppId string = functionApp.id
+output functionAppHostname string = functionApp.properties.defaultHostName
+output planName string = plan.name

--- a/infra/modules/function-app.bicep
+++ b/infra/modules/function-app.bicep
@@ -33,7 +33,7 @@ param deploymentContainerName string
 param appInsightsConnectionString string
 
 @description('.NET isolated worker runtime version.')
-param runtimeVersion string = '10.0'
+param runtimeVersion string
 
 @minValue(40)
 @maxValue(1000)

--- a/infra/modules/key-vault.bicep
+++ b/infra/modules/key-vault.bicep
@@ -1,0 +1,69 @@
+// Key Vault for the control plane: RBAC authorization mode (no access policies), soft
+// delete always on, purge protection param-driven (irreversible once enabled — on for
+// prod, off for dev so a torn-down dev vault can be purged and its name reused).
+//
+// Deliberately creates NO secrets. A Bicep-managed secret is re-PUT with its template
+// value on every deploy, which would overwrite whatever an operator set out of band; and
+// the control plane has no genuinely required secret today — SQL is Entra-only, storage is
+// identity-based, Graph access should be granted to the API's managed identity rather than
+// a client secret. Secrets that do become necessary are set out of band and referenced
+// from appsettings as @KeyVault(SecretName) (CONVENTIONS.md §Configuration & auth).
+//
+// The optional key `fg-apim-key-encryption` is the wrapping key for APIM subscription keys
+// stored in SQL (#95, spec §11 "Key Vault key wrapping"); the API identity gets Key Vault
+// Crypto User on the vault (modules/control-plane-rbac.bicep) so it can wrap/unwrap.
+param keyVaultName string
+param location string
+param tags object = {}
+
+@description('Purge protection. Irreversible once on; recommended for prod, off for dev so the vault can be purged after a teardown.')
+param enablePurgeProtection bool = false
+
+@minValue(7)
+@maxValue(90)
+@description('Soft-delete retention in days (7 for dev, 90 for prod).')
+param softDeleteRetentionInDays int = 7
+
+@description('Create the RSA wrapping key used to encrypt APIM subscription keys at rest (#95).')
+param createKeyEncryptionKey bool = true
+
+@description('Name of the wrapping key. Referenced by the API through the keyEncryptionKeyUri output.')
+param keyEncryptionKeyName string = 'fg-apim-key-encryption'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
+  name: keyVaultName
+  location: location
+  tags: union(tags, { 'fg-component': 'keyvault' })
+  properties: {
+    tenantId: tenant().tenantId
+    sku: { family: 'A', name: 'standard' }
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: softDeleteRetentionInDays
+    // ARM rejects an explicit `false` here once the property has ever been set; null
+    // leaves it unset, which is the only representation of "off".
+    enablePurgeProtection: enablePurgeProtection ? true : null
+    publicNetworkAccess: 'Enabled'
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass: 'AzureServices'
+    }
+  }
+}
+
+resource keyEncryptionKey 'Microsoft.KeyVault/vaults/keys@2024-11-01' = if (createKeyEncryptionKey) {
+  parent: keyVault
+  name: keyEncryptionKeyName
+  properties: {
+    kty: 'RSA'
+    keySize: 3072
+    keyOps: ['wrapKey', 'unwrapKey']
+    attributes: { enabled: true }
+  }
+}
+
+output keyVaultName string = keyVault.name
+output keyVaultId string = keyVault.id
+output keyVaultUri string = keyVault.properties.vaultUri
+@description('Versionless key URI of the APIM key-wrapping key (empty when not created). Versionless so key rotation needs no redeploy.')
+output keyEncryptionKeyUri string = createKeyEncryptionKey ? keyEncryptionKey!.properties.keyUri : ''

--- a/infra/modules/key-vault.bicep
+++ b/infra/modules/key-vault.bicep
@@ -17,15 +17,15 @@ param location string
 param tags object = {}
 
 @description('Purge protection. Irreversible once on; recommended for prod, off for dev so the vault can be purged after a teardown.')
-param enablePurgeProtection bool = false
+param enablePurgeProtection bool
 
 @minValue(7)
 @maxValue(90)
 @description('Soft-delete retention in days (7 for dev, 90 for prod).')
-param softDeleteRetentionInDays int = 7
+param softDeleteRetentionInDays int
 
 @description('Create the RSA wrapping key used to encrypt APIM subscription keys at rest (#95).')
-param createKeyEncryptionKey bool = true
+param createKeyEncryptionKey bool
 
 @description('Name of the wrapping key. Referenced by the API through the keyEncryptionKeyUri output.')
 param keyEncryptionKeyName string = 'fg-apim-key-encryption'

--- a/infra/modules/managed-identities.bicep
+++ b/infra/modules/managed-identities.bicep
@@ -1,0 +1,30 @@
+// User-assigned managed identities for the control-plane hosts (API on Container Apps,
+// background jobs on Functions). User-assigned rather than system-assigned so the role
+// assignments can be granted BEFORE the hosts exist — the Container App needs AcrPull at
+// creation time to pull its image, and the Flex Consumption Function App needs blob access
+// to its deployment container at creation time. Program.cs reads AZURE_CLIENT_ID to pick
+// the identity (CONVENTIONS.md: AppTokenCredential-style chain, not DefaultAzureCredential).
+param environmentName string
+param location string
+param tags object = {}
+
+resource apiIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: 'id-foundrygate-api-${environmentName}'
+  location: location
+  tags: union(tags, { 'fg-component': 'api' })
+}
+
+resource functionsIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: 'id-foundrygate-func-${environmentName}'
+  location: location
+  tags: union(tags, { 'fg-component': 'functions' })
+}
+
+output apiIdentityId string = apiIdentity.id
+output apiIdentityName string = apiIdentity.name
+output apiIdentityClientId string = apiIdentity.properties.clientId
+output apiIdentityPrincipalId string = apiIdentity.properties.principalId
+output functionsIdentityId string = functionsIdentity.id
+output functionsIdentityName string = functionsIdentity.name
+output functionsIdentityClientId string = functionsIdentity.properties.clientId
+output functionsIdentityPrincipalId string = functionsIdentity.properties.principalId

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -25,7 +25,10 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
+@description('ARM resource id of the workspace (diagnostic settings, role assignments, LogsQueryClient.QueryResourceAsync).')
 output workspaceId string = law.id
 output workspaceName string = law.name
+@description('The workspace GUID ("workspace id" in the Log Analytics query API — LogsQueryClient.QueryWorkspaceAsync, /v1/workspaces/{id}/query). Not the ARM id.')
+output workspaceCustomerId string = law.properties.customerId
 output appInsightsId string = appInsights.id
 output appInsightsConnectionString string = appInsights.properties.ConnectionString

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -26,5 +26,6 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 }
 
 output workspaceId string = law.id
+output workspaceName string = law.name
 output appInsightsId string = appInsights.id
 output appInsightsConnectionString string = appInsights.properties.ConnectionString

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -1,0 +1,107 @@
+// Azure SQL logical server + the single FoundryGate database (CONVENTIONS.md: one
+// database, one DbContext, no sharding).
+//
+// AUTH: Entra-only. `azureADOnlyAuthentication: true` with an Entra security GROUP as the
+// server administrator, and no SQL login/password anywhere (CONVENTIONS.md mandates
+// `Authentication=Active Directory Default`; this supersedes the "SQL admin
+// login/password" wording in #43/#44). Membership of that group is what grants admin
+// access, so two things cannot be expressed in Bicep and are operator/pipeline steps:
+//   1. Put the deploying/CI principal (the OIDC app registration) in the admin group so
+//      the dacpac deploy (`_deploy-database.yml`) can connect.
+//   2. Create contained users for the API and Functions managed identities inside the
+//      database (`CREATE USER [id-foundrygate-api-<env>] FROM EXTERNAL PROVIDER` +
+//      db_datareader/db_datawriter) — a post-dacpac step in the db deploy.
+//
+// FIREWALL: only the "Allow Azure services" rule is declared here (0.0.0.0-0.0.0.0), which
+// is what lets Container Apps / Functions connect without a VNet. Runner/developer IP rules
+// are created at deploy time by the CLI `ip setup` command (#96) and are NOT declared here
+// on purpose: undeclared child resources are left alone by an incremental deployment, so a
+// re-run never wipes a rule the pipeline just added.
+param sqlServerName string
+param sqlDatabaseName string
+param location string
+param tags object = {}
+
+@description('Object id of the Entra security group that administers the server (Entra-only auth; no SQL login exists).')
+param entraAdminGroupObjectId string
+
+@description('Display name of that group — becomes the server admin login name.')
+param entraAdminGroupName string
+
+@description('Database SKU: { name, tier, family?, capacity? }. Serverless dev default GP_S_Gen5 x1; prod uses provisioned General Purpose (see parameters/prod.bicepparam).')
+param databaseSku object = {
+  name: 'GP_S_Gen5'
+  tier: 'GeneralPurpose'
+  family: 'Gen5'
+  capacity: 1
+}
+
+@description('True when databaseSku is a serverless SKU (GP_S_*): enables auto-pause + min vCores.')
+param serverless bool = true
+
+@description('Serverless only: minutes of inactivity before auto-pause (-1 disables auto-pause).')
+param autoPauseDelayMinutes int = 60
+
+@description('Serverless only: minimum vCores while active, as a decimal string (0.5 is the floor for 1 max vCore).')
+param serverlessMinCapacity string = '0.5'
+
+@allowed(['Local', 'Zone', 'Geo', 'GeoZone'])
+@description('Backup storage redundancy. Local for dev, Geo for prod.')
+param backupStorageRedundancy string = 'Local'
+
+@description('Max database size in bytes (default 32 GB).')
+param maxSizeBytes int = 34359738368
+
+param zoneRedundant bool = false
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: sqlServerName
+  location: location
+  tags: union(tags, { 'fg-component': 'sql' })
+  properties: {
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      principalType: 'Group'
+      login: entraAdminGroupName
+      sid: entraAdminGroupObjectId
+      tenantId: tenant().tenantId
+      azureADOnlyAuthentication: true
+    }
+  }
+}
+
+// "Allow Azure services and resources to access this server" — the magic 0.0.0.0 rule.
+resource allowAzureServices 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'AllowAllWindowsAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: sqlDatabaseName
+  location: location
+  tags: union(tags, { 'fg-component': 'sql' })
+  sku: databaseSku
+  properties: {
+    collation: 'SQL_Latin1_General_CP1_CI_AS'
+    maxSizeBytes: maxSizeBytes
+    zoneRedundant: zoneRedundant
+    requestedBackupStorageRedundancy: backupStorageRedundancy
+    autoPauseDelay: serverless ? autoPauseDelayMinutes : null
+    minCapacity: serverless ? json(serverlessMinCapacity) : null
+  }
+}
+
+output sqlServerName string = sqlServer.name
+output sqlServerId string = sqlServer.id
+output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
+output sqlDatabaseName string = database.name
+@description('Entra-auth connection string (no secret in it). Same shape _deploy-database.yml computes for the dacpac deploy.')
+output entraConnectionString string = 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Database=${database.name};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -7,16 +7,22 @@
 // login/password" wording in #43/#44). Membership of that group is what grants admin
 // access, so two things cannot be expressed in Bicep and are operator/pipeline steps:
 //   1. Put the deploying/CI principal (the OIDC app registration) in the admin group so
-//      the dacpac deploy (`_deploy-database.yml`) can connect.
+//      the dacpac deploy (`_deploy-database.yml`) can connect (#109).
 //   2. Create contained users for the API and Functions managed identities inside the
 //      database (`CREATE USER [id-foundrygate-api-<env>] FROM EXTERNAL PROVIDER` +
-//      db_datareader/db_datawriter) — a post-dacpac step in the db deploy.
+//      db_datareader/db_datawriter) — a post-dacpac step in the db deploy (#106).
 //
 // FIREWALL: only the "Allow Azure services" rule is declared here (0.0.0.0-0.0.0.0), which
 // is what lets Container Apps / Functions connect without a VNet. Runner/developer IP rules
 // are created at deploy time by the CLI `ip setup` command (#96) and are NOT declared here
 // on purpose: undeclared child resources are left alone by an incremental deployment, so a
 // re-run never wipes a rule the pipeline just added.
+//
+// AUTO-PAUSE: serverless SKUs (GP_S_*) get autoPauseDelay/minCapacity, derived from the
+// SKU name so a provisioned SKU can never be sent serverless-only properties. Whether the
+// database actually pauses depends on nothing touching it for that long — the API's
+// readiness probe deliberately does not (modules/container-app.bicep); periodic Functions
+// jobs (#84) should keep their cadence above the pause delay or accept an always-on vCore.
 param sqlServerName string
 param sqlDatabaseName string
 param location string
@@ -28,16 +34,8 @@ param entraAdminGroupObjectId string
 @description('Display name of that group — becomes the server admin login name.')
 param entraAdminGroupName string
 
-@description('Database SKU: { name, tier, family?, capacity? }. Serverless dev default GP_S_Gen5 x1; prod uses provisioned General Purpose (see parameters/prod.bicepparam).')
-param databaseSku object = {
-  name: 'GP_S_Gen5'
-  tier: 'GeneralPurpose'
-  family: 'Gen5'
-  capacity: 1
-}
-
-@description('True when databaseSku is a serverless SKU (GP_S_*): enables auto-pause + min vCores.')
-param serverless bool = true
+@description('Database SKU: { name, tier, family?, capacity? }. GP_S_* names are serverless (auto-pause enabled); anything else is provisioned.')
+param databaseSku object
 
 @description('Serverless only: minutes of inactivity before auto-pause (-1 disables auto-pause).')
 param autoPauseDelayMinutes int = 60
@@ -53,6 +51,8 @@ param backupStorageRedundancy string = 'Local'
 param maxSizeBytes int = 34359738368
 
 param zoneRedundant bool = false
+
+var serverless = startsWith(databaseSku.name, 'GP_S_')
 
 resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
   name: sqlServerName
@@ -103,5 +103,6 @@ output sqlServerName string = sqlServer.name
 output sqlServerId string = sqlServer.id
 output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
 output sqlDatabaseName string = database.name
+output serverless bool = serverless
 @description('Entra-auth connection string (no secret in it). Same shape _deploy-database.yml computes for the dacpac deploy.')
 output entraConnectionString string = 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Database=${database.name};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -12,7 +12,7 @@ param location string
 param tags object = {}
 
 @allowed(['Free', 'Standard'])
-param sku string = 'Free'
+param sku string
 
 resource staticWebApp 'Microsoft.Web/staticSites@2024-04-01' = {
   name: staticWebAppName

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -1,0 +1,31 @@
+// Static Web App hosting the Blazor WASM admin UI. Free tier for dev; Standard for prod
+// when a custom domain / SLA is wanted. Deployed by the SWA deploy action with the site's
+// deployment token (`provider: 'Custom'` — no GitHub repository binding on the resource,
+// which would otherwise try to write its own workflow file into the repo).
+//
+// The default hostname is what the API allows in CORS (Cors__AllowedOrigins__0), so this
+// module runs before the Container App in modules/control-plane.bicep.
+param staticWebAppName string
+
+@description('Static Web Apps is only offered in a handful of regions (eastus2, centralus, westus2, westeurope, eastasia); pass one of those, not necessarily the stack location.')
+param location string
+param tags object = {}
+
+@allowed(['Free', 'Standard'])
+param sku string = 'Free'
+
+resource staticWebApp 'Microsoft.Web/staticSites@2024-04-01' = {
+  name: staticWebAppName
+  location: location
+  tags: union(tags, { 'fg-component': 'ui' })
+  sku: { name: sku, tier: sku }
+  properties: {
+    provider: 'Custom'
+    stagingEnvironmentPolicy: 'Enabled'
+    allowConfigFileUpdates: true
+  }
+}
+
+output staticWebAppName string = staticWebApp.name
+output staticWebAppId string = staticWebApp.id
+output defaultHostname string = staticWebApp.properties.defaultHostname

--- a/infra/modules/storage-account.bicep
+++ b/infra/modules/storage-account.bicep
@@ -1,0 +1,57 @@
+// Functions runtime storage (CONVENTIONS.md §Storage accounts: Functions runtime and
+// high-volume non-relational data only; SQL is the system of record). Shared-key access is
+// disabled — the Functions host connects with its user-assigned identity
+// (AzureWebJobsStorage__accountName + __credential=managedidentity) and the Flex
+// Consumption deployment container is read with the same identity, so no storage key ever
+// appears in app settings. Blob/Queue/Table data roles are granted in
+// modules/control-plane-rbac.bicep.
+param storageAccountName string
+param location string
+param tags object = {}
+
+@allowed(['Standard_LRS', 'Standard_ZRS', 'Standard_GRS'])
+param skuName string = 'Standard_LRS'
+
+@description('Blob container the Flex Consumption Function App deploys its package into.')
+param deploymentContainerName string = 'function-deployments'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: union(tags, { 'fg-component': 'storage' })
+  kind: 'StorageV2'
+  sku: { name: skuName }
+  properties: {
+    accessTier: 'Hot'
+    allowSharedKeyAccess: false
+    allowBlobPublicAccess: false
+    defaultToOAuthAuthentication: true
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    publicNetworkAccess: 'Enabled'
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass: 'AzureServices'
+    }
+  }
+}
+
+resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: storage
+  name: 'default'
+}
+
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobServices
+  name: deploymentContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+output storageAccountName string = storage.name
+output storageAccountId string = storage.id
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
+output tableEndpoint string = storage.properties.primaryEndpoints.table
+output deploymentContainerName string = deploymentContainer.name

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -1,0 +1,54 @@
+// FoundryGate dev: full stack (gateway + control plane), cost-minimised.
+// Runs as `qa` from the app's point of view (CONVENTIONS.md environments are local/qa/prod).
+using '../main.bicep'
+
+param environmentName = 'dev'
+param appEnvironment = 'qa'
+param location = 'eastus2'
+param nameSuffix = 'e7k2'
+param publisherEmail = 'kolatts@gmail.com'
+param publisherName = 'FoundryGate Dev'
+param anthropicProviderData = {
+  industry: 'Software'
+  organizationName: 'Imagile'
+  countryCode: 'US'
+}
+
+// Cheapest viable v2 tier; the LLM policies, pools and breakers all work on it.
+param apimSkuName = 'BasicV2'
+
+// Flip to true ONLY for the very first deployment. Anthropic deployments are
+// create-once under ARM — re-running with true re-PUTs them into a Failed state
+// (see modules/foundry.bicep). Model lifecycle after day 0 belongs to the control
+// plane, not ARM.
+param createModelDeployments = false
+
+// ---- Control plane ---------------------------------------------------------------
+param deployControlPlane = true
+
+// Entra security group that administers Azure SQL (Entra-only auth, no SQL login). The
+// CI OIDC principal must be a member for the dacpac deploy to connect — see
+// docs reference/infrastructure. Object ids are not secrets.
+param sqlAdminGroupObjectId = '2ed4d6b7-575c-4046-aeb0-eb51bc254ef5'
+param sqlAdminGroupName = 'SG_IMAGILE_SQL_ADMINS'
+
+// Serverless, auto-pauses after an hour idle (the sqlDatabaseSku default in main.bicep).
+param sqlServerless = true
+param sqlBackupStorageRedundancy = 'Local'
+
+// FoundryGate.Api app registration. Read from the environment so the deploy workflow can
+// supply it from a GitHub Environment variable; the zero GUID lets a bootstrap deploy of
+// the infrastructure succeed before the registration exists (token validation will
+// reject everything until it is real).
+param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')
+
+// Current API image. Empty on the bootstrap run (nothing pushed yet — placeholder image);
+// the deploy workflows set FG_API_IMAGE to the tag currently running before every infra
+// re-run so Bicep never resets the app to the placeholder.
+param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE', '')
+
+param containerAppMinReplicas = 1
+param containerAppMaxReplicas = 2
+param staticWebAppSku = 'Free'
+param keyVaultPurgeProtection = false
+param keyVaultSoftDeleteRetentionInDays = 7

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -1,5 +1,17 @@
 // FoundryGate dev: full stack (gateway + control plane), cost-minimised.
 // Runs as `qa` from the app's point of view (CONVENTIONS.md environments are local/qa/prod).
+//
+// Environment variables this file REQUIRES (build-params fails loudly without them —
+// deliberately, so a forgotten variable can never silently change what gets deployed):
+//   FG_API_IMAGE   image the Container App runs. Bootstrap run (registry empty):
+//                  mcr.microsoft.com/k8se/quickstart:latest. Every later run: the tag
+//                  currently running, e.g. from
+//                  az containerapp show -n ca-foundrygate-api-dev -g rg-foundrygate-dev \
+//                    --query properties.template.containers[0].image -o tsv
+// Optional:
+//   FG_ENTRA_API_CLIENT_ID   FoundryGate.Api app registration client id (#109). The
+//                            zero-GUID fallback lets infra deploy before it exists; token
+//                            validation rejects everything until it is real.
 using '../main.bicep'
 
 param environmentName = 'dev'
@@ -27,25 +39,18 @@ param createModelDeployments = false
 param deployControlPlane = true
 
 // Entra security group that administers Azure SQL (Entra-only auth, no SQL login). The
-// CI OIDC principal must be a member for the dacpac deploy to connect — see
-// docs reference/infrastructure. Object ids are not secrets.
+// CI OIDC principal must be a member for the dacpac deploy to connect (#109). Object ids
+// are identifiers, not secrets. Dev shares the tenant's existing SQL admin group.
 param sqlAdminGroupObjectId = '2ed4d6b7-575c-4046-aeb0-eb51bc254ef5'
 param sqlAdminGroupName = 'SG_IMAGILE_SQL_ADMINS'
 
-// Serverless, auto-pauses after an hour idle (the sqlDatabaseSku default in main.bicep).
-param sqlServerless = true
+// Serverless GP_S_Gen5 x1 (the main.bicep default): auto-pauses after 60 idle minutes.
+// That pause is real only because nothing polls the database — the API's readiness probe
+// deliberately hits the hermetic /health, not /health/ready (modules/container-app.bicep).
 param sqlBackupStorageRedundancy = 'Local'
 
-// FoundryGate.Api app registration. Read from the environment so the deploy workflow can
-// supply it from a GitHub Environment variable; the zero GUID lets a bootstrap deploy of
-// the infrastructure succeed before the registration exists (token validation will
-// reject everything until it is real).
 param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')
-
-// Current API image. Empty on the bootstrap run (nothing pushed yet — placeholder image);
-// the deploy workflows set FG_API_IMAGE to the tag currently running before every infra
-// re-run so Bicep never resets the app to the placeholder.
-param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE', '')
+param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE')
 
 param containerAppMinReplicas = 1
 param containerAppMaxReplicas = 2

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -1,0 +1,54 @@
+// FoundryGate prod: full stack (gateway + control plane), production-grade SKUs.
+using '../main.bicep'
+
+param environmentName = 'prod'
+param appEnvironment = 'prod'
+param location = 'eastus2'
+param nameSuffix = 'e7k2'
+param publisherEmail = 'kolatts@gmail.com'
+param publisherName = 'FoundryGate'
+param anthropicProviderData = {
+  industry: 'Software'
+  organizationName: 'Imagile'
+  countryCode: 'US'
+}
+
+param apimSkuName = 'StandardV2'
+
+// Flip to true ONLY for the very first deployment. Anthropic deployments are
+// create-once under ARM — re-running with true re-PUTs them into a Failed state
+// (see modules/foundry.bicep). Model lifecycle after day 0 belongs to the control
+// plane, not ARM.
+param createModelDeployments = false
+
+// ---- Control plane ---------------------------------------------------------------
+param deployControlPlane = true
+
+// Entra security group that administers Azure SQL (Entra-only auth, no SQL login). The
+// CI OIDC principal must be a member for the dacpac deploy to connect. A dedicated
+// prod group is preferable to sharing the dev one — swap it here when it exists.
+param sqlAdminGroupObjectId = '2ed4d6b7-575c-4046-aeb0-eb51bc254ef5'
+param sqlAdminGroupName = 'SG_IMAGILE_SQL_ADMINS'
+
+// Provisioned General Purpose, 2 vCores, geo-redundant backups: no auto-pause latency
+// for the admin plane and cross-region restore for the system of record.
+param sqlDatabaseSku = {
+  name: 'GP_Gen5_2'
+  tier: 'GeneralPurpose'
+  family: 'Gen5'
+  capacity: 2
+}
+param sqlServerless = false
+param sqlBackupStorageRedundancy = 'Geo'
+
+// See dev.bicepparam for why these two come from the environment.
+param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')
+param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE', '')
+
+param containerAppMinReplicas = 1
+param containerAppMaxReplicas = 3
+// Standard: custom domain + SLA for the admin UI.
+param staticWebAppSku = 'Standard'
+// Irreversible once on — which is the point for prod.
+param keyVaultPurgeProtection = true
+param keyVaultSoftDeleteRetentionInDays = 90

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -1,4 +1,16 @@
 // FoundryGate prod: full stack (gateway + control plane), production-grade SKUs.
+//
+// Environment variables this file REQUIRES (build-params fails loudly without them —
+// deliberately: with Entra-only SQL, group membership IS the access model, and a
+// forgotten image variable must never silently swap the production API for a
+// placeholder page):
+//   FG_SQL_ADMIN_GROUP_OBJECT_ID   object id of the DEDICATED prod SQL admin group (#109).
+//   FG_SQL_ADMIN_GROUP_NAME        its display name.
+//   FG_API_IMAGE                   image the Container App runs. Bootstrap run only:
+//                                  mcr.microsoft.com/k8se/quickstart:latest; every later
+//                                  run the tag currently running (see dev.bicepparam).
+// Optional:
+//   FG_ENTRA_API_CLIENT_ID         FoundryGate.Api app registration client id (#109).
 using '../main.bicep'
 
 param environmentName = 'prod'
@@ -24,26 +36,24 @@ param createModelDeployments = false
 // ---- Control plane ---------------------------------------------------------------
 param deployControlPlane = true
 
-// Entra security group that administers Azure SQL (Entra-only auth, no SQL login). The
-// CI OIDC principal must be a member for the dacpac deploy to connect. A dedicated
-// prod group is preferable to sharing the dev one — swap it here when it exists.
-param sqlAdminGroupObjectId = '2ed4d6b7-575c-4046-aeb0-eb51bc254ef5'
-param sqlAdminGroupName = 'SG_IMAGILE_SQL_ADMINS'
+// Deliberately NOT the dev group: every dev admin and the dev CI principal would own the
+// production database. Fails at build-params until the dedicated group exists (#109).
+param sqlAdminGroupObjectId = readEnvironmentVariable('FG_SQL_ADMIN_GROUP_OBJECT_ID')
+param sqlAdminGroupName = readEnvironmentVariable('FG_SQL_ADMIN_GROUP_NAME')
 
 // Provisioned General Purpose, 2 vCores, geo-redundant backups: no auto-pause latency
-// for the admin plane and cross-region restore for the system of record.
+// for the admin plane and cross-region restore for the system of record. Serverless
+// vs provisioned is derived from the SKU name (GP_S_* = serverless).
 param sqlDatabaseSku = {
   name: 'GP_Gen5_2'
   tier: 'GeneralPurpose'
   family: 'Gen5'
   capacity: 2
 }
-param sqlServerless = false
 param sqlBackupStorageRedundancy = 'Geo'
 
-// See dev.bicepparam for why these two come from the environment.
 param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')
-param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE', '')
+param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE')
 
 param containerAppMinReplicas = 1
 param containerAppMaxReplicas = 3
@@ -52,3 +62,8 @@ param staticWebAppSku = 'Standard'
 // Irreversible once on — which is the point for prod.
 param keyVaultPurgeProtection = true
 param keyVaultSoftDeleteRetentionInDays = 90
+
+// Deliberately v1-scoped: zone redundancy (SQL/Container Apps env), storage SKU, ACR SKU
+// and Container App CPU/memory are leaf-module params not yet plumbed through
+// modules/control-plane.bicep — the defaults (no ZR, Standard_LRS, Basic ACR,
+// 0.25 vCPU/0.5 GiB) are what prod gets today. Tracked in #134.

--- a/plans/13-bicep-infra.md
+++ b/plans/13-bicep-infra.md
@@ -66,6 +66,14 @@ ids" wording):
   `infra/README.md` was not added — the reference lives in
   `docs-site/src/content/docs/reference/infrastructure.md` (one source of truth on the
   public site).
+- Review fix pass (PR #111): role GUIDs re-verified against `az role definition list`;
+  bootstrap placeholder image (`k8se/quickstart`, :80, `/health` only — verified under
+  docker) switches the Container App to port 80 + `/health`-only probes; readiness probe
+  is `/health` (hermetic) so serverless auto-pause stays real, startup probe is
+  `/health/ready`; `FG_API_IMAGE` (both) and `FG_SQL_ADMIN_GROUP_*` (prod) are required
+  env vars with no default; serverless is derived from the SQL SKU name;
+  `Gateway__LogAnalyticsWorkspaceId` is the workspace GUID (`customerId`), the ARM id is
+  `...WorkspaceResourceId`. Prod-grade knobs not yet plumbed: #134.
 
 ## Verification
 - [x] `az bicep build --file infra/main.bicep` compiles with no errors (and `az bicep lint`

--- a/plans/13-bicep-infra.md
+++ b/plans/13-bicep-infra.md
@@ -41,10 +41,49 @@ Files expected to be created or modified:
 - `infra/parameters/prod.bicepparam`
 - `infra/README.md`
 
+## Implementation notes (2026-09-01, #43/#44)
+
+Direction updates that supersede parts of the approach above (CONVENTIONS.md wins over the
+issue bodies; the #13 direction comment supersedes the "APIM/Foundry passed in as resource
+ids" wording):
+
+- APIM and the Foundry accounts are **created by `infra/main.bicep`** (gateway data plane,
+  PR #87/#93); the control plane attaches to them by name. No `apimResourceId` /
+  `foundryResourceId` params.
+- **No SQL admin password.** Azure SQL is Entra-only (`azureADOnlyAuthentication: true`,
+  admin = Entra security group via `sqlAdminGroupObjectId`/`sqlAdminGroupName`); the app
+  connects with `Authentication=Active Directory Default`. The connection string is
+  therefore not a secret and is set as a plain env var, not a Key Vault reference.
+- **User-assigned** identities (not system-assigned) so AcrPull / storage roles exist before
+  the Container App and Function App are created; `AZURE_CLIENT_ID` is set on both hosts.
+- **No Key Vault secrets in Bicep** (`SqlConnectionString` unnecessary; `GraphClientSecret`
+  replaced by Graph app permissions on the API identity — #110). The vault holds the optional
+  `fg-apim-key-encryption` RSA key for #95 instead.
+- Leaf modules are kebab-case (`sql.bicep`, `container-app.bicep`, `static-web-app.bicep`,
+  `function-app.bicep`, `key-vault.bicep`, `control-plane-rbac.bicep`, plus
+  `managed-identities.bicep`, `container-registry.bicep`, `storage-account.bicep`),
+  orchestrated by `modules/control-plane.bicep` behind `deployControlPlane` in main.bicep.
+  `infra/README.md` was not added — the reference lives in
+  `docs-site/src/content/docs/reference/infrastructure.md` (one source of truth on the
+  public site).
+
 ## Verification
-- [ ] `az bicep build --file infra/main.bicep` compiles with no errors
-- [ ] `az deployment sub what-if` against a dev subscription shows expected resource changes
-- [ ] Container App and Function App environment variables resolve to Key Vault references
-- [ ] All Managed Identity role assignments are present after deployment
-- [ ] Function App has scale-to-zero configured (Flex Consumption plan)
-- [ ] `prod.bicepparam` uses production-grade SQL SKU
+- [x] `az bicep build --file infra/main.bicep` compiles with no errors (and `az bicep lint`
+  clean apart from the pre-existing BCP081 for the `2026-07-01` CognitiveServices API
+  version; `az bicep build-params` clean for test/dev/prod)
+- [x] `az deployment sub what-if` against a dev subscription shows expected resource changes
+  (2026-09-01, Imagile Paid, throwaway `environmentName=whatif`, `createModelDeployments=false`:
+  status Succeeded, 59 Creates — full gateway + SQL server/db/firewall, Container Apps
+  env + app, ACR, Key Vault + key, two identities, storage + deployment container, Flex plan +
+  Function App, Static Web App; role assignments are not surfaced by what-if because their
+  principal ids resolve at deploy time)
+- [ ] Container App and Function App environment variables resolve — verified on a live
+  deploy (#105). Note: SQL is Entra-auth so no Key Vault reference is involved; the API
+  resolves `@KeyVault()` tokens itself via `Azure__KeyVaultUrl`.
+- [ ] All Managed Identity role assignments are present after deployment (#105)
+- [x] Function App has scale-to-zero configured (Flex Consumption plan: `FC1`,
+  `functionAppConfig.scaleAndConcurrency`, no always-on) — verified in template/what-if;
+  runtime behaviour on live deploy (#105)
+- [x] `prod.bicepparam` uses production-grade SQL SKU (`GP_Gen5_2`, provisioned, Geo backups)
+- [ ] Contained DB users for the two identities created post-dacpac (#106)
+- [ ] CI principal in the SQL Entra admin group; real Entra client id in `FG_ENTRA_API_CLIENT_ID` (#109)


### PR DESCRIPTION
## Summary

Adds the FoundryGate **control plane** to the existing subscription-scope `infra/main.bicep` — SQL, Container Apps (API), Static Web App (UI), Functions Flex Consumption, Key Vault, container registry, two user-assigned identities and the role assignments between them — behind a `deployControlPlane` toggle that defaults to `false`, so the gateway-only deployment the team validated (`test.bicepparam`) is byte-for-byte unchanged in behaviour. New `dev.bicepparam` / `prod.bicepparam` turn it on. The gateway modules are untouched apart from one added `workspaceName` output on `monitoring.bicep`.

Closes #43
Closes #44

## What's in the box

| Module | Notes |
|---|---|
| `modules/control-plane.bicep` | RG-scope orchestrator; owns the naming convention; wires leaf modules in dependency order (identities → KV/ACR/storage/SQL/SWA → RBAC → Container App + Function App) |
| `modules/sql.bicep` | **Entra-only** (`azureADOnlyAuthentication: true`, admin = Entra group; no SQL login/password anywhere — CONVENTIONS.md supersedes the issue bodies' "SQL admin password"). Serverless `GP_S_Gen5` dev / provisioned `GP_Gen5_2` + Geo backups prod. Only `AllowAllWindowsAzureIps` declared; runner/dev IP rules belong to CLI `ip setup` (#96) and are intentionally undeclared so re-runs never wipe them |
| `modules/container-app.bicep` | Consumption env with logs via **diagnostic setting** (`destination: azure-monitor`) instead of the workspace shared key; API app with UAMI, identity-based ACR pull, `/health` + `/health/ready` probes, min 1 replica, 8080, placeholder image for the bootstrap run |
| `modules/function-app.bicep` + `storage-account.bicep` | Flex Consumption (`FC1`, .NET 10 isolated), identity-based `AzureWebJobsStorage__*` and deployment container, **storage shared-key access disabled** |
| `modules/key-vault.bicep` | RBAC mode, soft delete, purge protection param (prod on), optional `fg-apim-key-encryption` RSA-3072 key for #95 (URI exposed as output + `Gateway__KeyEncryptionKeyUri`). **No secrets created** — see design decisions |
| `modules/static-web-app.bicep`, `container-registry.bicep`, `managed-identities.bicep` | Free/Standard SWA (`provider: Custom`), Basic ACR with admin user off, two UAMIs |
| `modules/control-plane-rbac.bicep` | API: KV Secrets User + Crypto User, AcrPull, **API Management Service Contributor** (APIM), **Cognitive Services Contributor** (each Foundry account), Log Analytics Reader. Functions: KV Secrets User, Log Analytics Reader (#84 reads `ApiManagementGatewayLlmLog`), Storage Blob Data Owner / Queue / Table Data Contributor. All resource-scoped, `guid(scope, principal, role)` names |
| `main.bicep` | `deployControlPlane` + 17 control-plane params (all defaulted; no secure params needed), explicit **outputs contract** (below) |
| `parameters/dev.bicepparam`, `prod.bicepparam` | `createModelDeployments = false` shipped (override on the command line for day 0 only) |
| `docs-site/.../reference/infrastructure.md` | resources, naming, params, RBAC, env vars, outputs, firewall model, manual steps |
| `plans/13-bicep-infra.md` | implementation notes + verification checklist updated |

### Naming convention (contract for #96 / #69–#75)

`rg-foundrygate-{env}` · `sql-foundrygate-{env}-{suffix}` / `sqldb-foundrygate-{env}` · `kv-fg-{env}-{suffix}` · `crfoundrygate{env}{suffix}` · `cae-foundrygate-{env}` / `ca-foundrygate-api-{env}` · `id-foundrygate-api-{env}` / `id-foundrygate-func-{env}` · `func-foundrygate-{env}-{suffix}` / `asp-foundrygate-func-{env}` · `stfg{env}{suffix}` · `stapp-foundrygate-{env}`

### Outputs contract (`az deployment sub show --query properties.outputs`)

Gateway (existing): `resourceGroupName`, `apimGatewayUrl`, `apimName`, `apimPrincipalId`, `anthropicApiUrl`, `openaiApiUrl`, `productIds`, `defaultProductId`, `logAnalyticsWorkspaceId`, `foundryAccountNames` — plus new `logAnalyticsWorkspaceName`, `appInsightsConnectionString`.
Control plane (empty strings when off): `controlPlaneDeployed`, `sqlServerName`, `sqlServerFqdn`, `sqlDatabaseName`, `sqlEntraConnectionString`, `sqlAdminGroupName`, `keyVaultName`, `keyVaultUri`, `keyEncryptionKeyUri`, `containerRegistryName`, `containerRegistryLoginServer`, `containerAppsEnvironmentName`, `containerAppName`, `containerAppFqdn`, `functionAppName`, `functionAppHostname`, `functionsStorageAccountName`, `staticWebAppName`, `staticWebAppHostname`, `apiIdentity{Name,ClientId,PrincipalId}`, `functionsIdentity{Name,ClientId,PrincipalId}`.

## Design decisions (please scrutinize)

1. **One conditional orchestrator module instead of eight conditional modules in `main.bicep`.** Conditional modules make every `.outputs.x` reference nullable; with a single `controlPlane` module there is exactly one guarded `controlPlane!.outputs.x` per output and the leaf modules stay unconditional. The existing gateway modules are still called directly from `main.bicep`, so it is a mixed style — deliberate, documented in the module header.
2. **No Key Vault secrets in Bicep.** A Bicep-managed secret is re-PUT with its template value every deploy and would clobber operator-set values. Nothing in the control plane genuinely needs one today: SQL is Entra-only (the connection string is not a secret and is a plain env var), storage/ACR are identity-based, and Graph should use the API identity's app permissions (#110) rather than `GraphClientSecret`. This departs from spec §9.1 / the #43 body.
3. **User-assigned identities**, not system-assigned as the issue said — AcrPull and Blob Data Owner must exist before the Container App / Function App are created, which system-assigned identities make circular. `AZURE_CLIENT_ID` is set on both hosts (what `Program.cs` reads).
4. **Image drift on re-run.** `apiContainerImage` defaults to the public `k8se/quickstart` placeholder (the ACR is empty on the bootstrap run). The param files read `FG_API_IMAGE`; the infra workflow (#69) must set it to the running tag before every re-run, or the app is reset. Alternatives considered: reading the existing app's image via `existing` (fails when the app doesn't exist yet), or excluding the Container App from Bicep entirely (loses the env-var contract). Documented in the reference page and in a comment on #69.
5. **`Gateway__*` configuration keys** (`SubscriptionId`, `ResourceGroup`, `ApimName`, `ApimGatewayUrl`, `LogAnalyticsWorkspaceId`, `KeyEncryptionKeyUri`, `FoundryAccountNames__{i}`) are set on both hosts so nobody types ARM ids into `SystemConfiguration`. The app does not bind them yet — #108 asks the backend to; the names are cheap to change if the backend prefers others.
6. **Functions get Log Analytics Reader but not APIM/Foundry roles**; the API gets everything gateway-facing. Least privilege given what #38/#39/#84 describe; a one-liner to widen.
7. **Param files hold the tenant's existing `SG_IMAGILE_SQL_ADMINS` group object id** (an identifier, not a secret) so what-if/deploy work today; #109 asks for a dedicated FoundryGate group. `entraApiClientId` reads `FG_ENTRA_API_CLIENT_ID` with a zero-GUID fallback so the bootstrap deploy succeeds before the app registration exists.
8. Container App sized at 0.25 vCPU / 0.5 GiB to match the published cost page; `minReplicas = 1` per the issue (the admin API is the UI's only backend).

## Verification

- `az bicep build` + `az bicep lint` on `infra/main.bicep` and on every module: clean. The only diagnostics anywhere are the **pre-existing** BCP081 warnings for `Microsoft.CognitiveServices/accounts@2026-07-01` in `foundry.bicep` / `foundry-rbac.bicep` (untouched). My new `existing` reference in `control-plane-rbac.bicep` uses the typed `2025-06-01` version to avoid adding a fourth.
- `az bicep build-params` clean for `test`, `dev`, `prod`.
- `az deployment sub what-if` (read-only; **no deploy was run** — cost + create-once Anthropic deployments) with `dev.bicepparam`, `environmentName=whatif`, `createModelDeployments=false`: **status Succeeded, 59 Creates, 0 errors** — full gateway plus SQL server/db/firewall rule, Container Apps env + app + diagnostic setting, ACR, Key Vault + key, both identities, storage + blob container, Flex plan + Function App, Static Web App. Spot-checked payloads: SQL server has `administrators.azureADOnlyAuthentication: true`, no `administratorLogin`; storage `allowSharedKeyAccess: false`; Function App `functionAppConfig.deployment.storage.authentication.type: UserAssignedIdentity`. Role assignments don't appear in what-if output because their principal ids resolve at deploy time.
- `cd docs-site && npm ci && npm run build`: 13 pages built, `reference/infrastructure` present. (Plain `.md`, no MDX components.)
- Nothing under `src/` or `.github/` touched.
- `plans/13-bicep-infra.md` Verification: build/what-if/Flex/prod-SKU ticked; live-only items point at #105.

## Follow-ups filed

- #105 live-validate the control-plane deploy (everything that needs a real deployment)
- #106 post-dacpac contained DB users for the two identities
- #107 Marketplace/SaaS permissions for runtime Claude deployment creation (Cognitive Services Contributor is not enough)
- #108 bind the `Gateway__*` configuration section in Api/Functions
- #109 owner setup: app registrations, dedicated SQL admin group, CI principal group membership, GitHub variables
- #110 Entra sync via API managed identity Graph permissions (no client secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
