### PR TITLE
feat(api): audit service, GET /audit, and cross-cutting API scaffolding

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -74,10 +74,14 @@ Landed with #42 (the first `/api/v1` controller); every endpoint wave builds on 
 
 - **Controllers** inherit `Controllers/ApiControllerBase` (`[ApiController]`,
   `[Route("api/v1/[controller]")]`, `[Produces("application/json")]`) and declare only
-  their `[Authorize(Policy = PolicyNames.AdminOnly)]` (class- or action-level) plus thin
-  actions that delegate to a service. Authentication is already global (the
-  `AuthorizeFilter` in Program.cs): anonymous → 401, non-admin on an admin-only route →
-  403, with no per-controller code.
+  their `[Authorize(Policy = PolicyNames.AdminOnly)]` (class- or action-level) plus
+  **expression-bodied** actions that delegate to a service. No `ThrowIfNull` on bound
+  parameters: `[ApiController]` never hands an action a null `[FromQuery]`/`[FromBody]`
+  record (an empty query string yields an instance with defaults; a missing body is a
+  400 before the action runs), so the guard is unreachable — the first-line
+  `ThrowIfNull` rule in §Style applies to services, not controller actions.
+  Authentication is already global (the `AuthorizeFilter` in Program.cs): anonymous →
+  401, non-admin on an admin-only route → 403, with no per-controller code.
 - **Services** live in `Services/<Area>/` with the single-implementation interface
   co-located (`IAuditService.cs` + `AuditService.cs`); primary constructors; take
   `AppDbContext` directly; throw `KeyNotFoundException` (404) / `ArgumentException` (400)
@@ -85,39 +89,59 @@ Landed with #42 (the first `/api/v1` controller); every endpoint wave builds on 
   status codes themselves.
 - **DI — one line per area, one file.** Each area owns
   `Services/<Area>/<Area>ServiceCollectionExtensions.cs` exposing `Add<Area>Services()`;
-  register it by adding ONE line to `Services/ServiceCollectionExtensions
+  register it by adding ONE line to `Services/ApiServiceCollectionExtensions
   .AddFoundryGateApiServices()`, which Program.cs calls once. Never register application
-  services in Program.cs — parallel waves would collide there.
+  services in Program.cs. (Parallel waves will still conflict on adjacent lines in that
+  one method — a trivially-resolved conflict, versus registrations-plus-usings churn in
+  Program.cs.) Data-layer services every host shares (`IAuditWriter`, the interceptor,
+  `TimeProvider`) are registered in Data's `AddFoundryGateData`, not here.
 - **Current user**: inject `ICurrentUserAccessor` (scoped) rather than reading
   `HttpContext.User`. `EntraObjectId` (accepts both `oid` and the long
   `.../objectidentifier` claim type), `IsAdmin` (same `IsInRole` check as the policy),
   `DisplayName`/`Email` (token claims, for auto-provisioning), `TryGetUserAsync(ct)`
-  (null = not provisioned yet — a first-class path; `GET /users/me` provisions on it),
-  `GetRequiredUserAsync(ct)` (→ 404). The returned `User` is tracked by the request's
-  context, so mutate it and `SaveChangesAsync`. No oid on an authenticated principal →
-  `UnauthorizedAccessException` (403).
-- **Audit**: inject `IAuditService` and call
-  `await audit.LogAsync(AuditActions.X, AuditTargetTypes.Y, id.ToString(), new { before, after }, ct)`
-  *before* the caller's own `SaveChangesAsync` — the row is added to the SAME
-  `AppDbContext` and commits atomically with the mutation. No fire-and-forget audit: a
-  mutation without its audit row (or vice versa) is worse than a failed request. System
-  actors (Functions, sync jobs) use the `LogAsync(int? actorUserId, ...)` overload with
-  `null`. New action/target kinds are constants in Domain's `AuditActions` /
-  `AuditTargetTypes`, never inline strings. `details` is JSON-serialized (camelCase) —
-  never put a key or token in it.
+  (null = not provisioned yet — a first-class path; `GET /users/me` provisions on it; it
+  checks the change tracker first, so a `User` you just `Add`ed is found before you
+  save), `GetRequiredUserAsync(ct)`. The returned `User` is tracked by the request's
+  context, so mutate it and `SaveChangesAsync`. **"No `User` row for this caller" is 403
+  everywhere, never 404** (`GetRequiredUserAsync` and `IAuditService.LogAsync` both throw
+  `UnauthorizedAccessException` saying "call `GET /users/me` first"): an authenticated
+  principal without a row is an authorization-state problem, not a missing resource. No
+  oid on an authenticated principal → `UnauthorizedAccessException` (403) too.
+- **Audit — one writer, two entry points.** The row builder is
+  `FoundryGate.Data.Audit.IAuditWriter` (Data, so Functions/Cli use the same one):
+  `Add(User actor, …)` (attributes via the `ActorUser` navigation — works for an actor
+  that is itself unsaved), `Add(int actorUserId, …)`, `AddSystem(…)` (null actor; the
+  monthly reset / usage sync / Entra sync jobs). Api code acting as the current caller
+  uses the thin wrapper `IAuditService.LogAsync(AuditActions.X, AuditTargetTypes.Y,
+  id.ToString(), new { before, after }, ct)`; Api code that already holds a `UserId` or
+  acts as the system uses `IAuditWriter` directly. Either way call it *before* your own
+  `SaveChangesAsync` — the row is added to the SAME `AppDbContext` and commits atomically
+  with the mutation; nothing in the audit path saves. No fire-and-forget audit: a
+  mutation without its audit row (or vice versa) is worse than a failed request. For
+  auto-provisioning that means `Add(user)` → `LogAsync(UserProvisioned…)` → one save.
+  New action/target kinds are constants in Domain's `AuditActions` / `AuditTargetTypes`,
+  never inline strings. `details` is JSON-serialized (camelCase, cycles ignored) — pass
+  the fields you mean rather than a tracked entity, and never a key or token.
 - **Paging**: bind `[FromQuery] PagedRequest paging` (alongside any `[FromQuery]` filter
   record) and finish the query with `.OrderBy(...).Select(projection).ToPagedAsync(paging, ct)`
   (`FoundryGate.Data.Extensions`) → `PagedResult<T>`. Order deterministically first;
-  the helper clamps page/size itself.
+  the helper clamps page/size itself. Index the columns your default ordering and
+  filters use (`AuditLog.OccurredDate` is the precedent) and mirror the index in
+  `FoundryGate.Database/dbo/Tables/*.sql` — `SchemaParityTests` checks name, uniqueness,
+  clustering and column composition.
 - **Integration tests** use `IClassFixture<ApiTestFactory>` (real pipeline, SQLite
   in-memory, header-driven `TestAuthHandler`): `factory.CreateClient()` is anonymous,
   `factory.CreateClientAs(oid, isAdmin: true)` is an admin, `factory.SeedUserAsync(...)`
   and `factory.CreateDbContext()` arrange/assert rows, `factory.TimeProvider` moves the
   clock. One database per test class — seed with unique markers, never assert absolute
   counts. Service-level tests use `InMemoryDatabaseTest` + `Support/MutableTimeProvider`
-  + hand-rolled stubs (no mocking library). Under SQLite, `AppDbContext` stores
-  `DateTimeOffset` as UTC ticks (provider-gated) so ordering and date-range filters
-  translate; the SQL Server model is untouched.
+  + `Support/FixedHttpContextAccessor` + hand-rolled stubs (no mocking library; the
+  framework's `HttpContextAccessor` is a static `AsyncLocal` — never use it in tests).
+  Under SQLite, `AppDbContext` stores `DateTimeOffset` as UTC ticks (provider-gated) so
+  ordering and date-range filters translate; the SQL Server model is untouched. Known
+  test-only divergence: values read back from SQLite always carry `+00:00` (the instant
+  is preserved, the original offset is not), where SQL Server's `datetimeoffset` keeps
+  it — assert on instants, never on `.Offset`.
 
 ## Schema pipeline (no EF migrations)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -68,6 +68,57 @@
   (404/400/403/409 mapping), not per-controller try/catch. Controllers are thin
   expression-bodied delegations with class-level `[Authorize]`.
 
+## API service/controller conventions
+
+Landed with #42 (the first `/api/v1` controller); every endpoint wave builds on these.
+
+- **Controllers** inherit `Controllers/ApiControllerBase` (`[ApiController]`,
+  `[Route("api/v1/[controller]")]`, `[Produces("application/json")]`) and declare only
+  their `[Authorize(Policy = PolicyNames.AdminOnly)]` (class- or action-level) plus thin
+  actions that delegate to a service. Authentication is already global (the
+  `AuthorizeFilter` in Program.cs): anonymous → 401, non-admin on an admin-only route →
+  403, with no per-controller code.
+- **Services** live in `Services/<Area>/` with the single-implementation interface
+  co-located (`IAuditService.cs` + `AuditService.cs`); primary constructors; take
+  `AppDbContext` directly; throw `KeyNotFoundException` (404) / `ArgumentException` (400)
+  / `ConflictException` (409) / `UnauthorizedAccessException` (403) and never touch HTTP
+  status codes themselves.
+- **DI — one line per area, one file.** Each area owns
+  `Services/<Area>/<Area>ServiceCollectionExtensions.cs` exposing `Add<Area>Services()`;
+  register it by adding ONE line to `Services/ServiceCollectionExtensions
+  .AddFoundryGateApiServices()`, which Program.cs calls once. Never register application
+  services in Program.cs — parallel waves would collide there.
+- **Current user**: inject `ICurrentUserAccessor` (scoped) rather than reading
+  `HttpContext.User`. `EntraObjectId` (accepts both `oid` and the long
+  `.../objectidentifier` claim type), `IsAdmin` (same `IsInRole` check as the policy),
+  `DisplayName`/`Email` (token claims, for auto-provisioning), `TryGetUserAsync(ct)`
+  (null = not provisioned yet — a first-class path; `GET /users/me` provisions on it),
+  `GetRequiredUserAsync(ct)` (→ 404). The returned `User` is tracked by the request's
+  context, so mutate it and `SaveChangesAsync`. No oid on an authenticated principal →
+  `UnauthorizedAccessException` (403).
+- **Audit**: inject `IAuditService` and call
+  `await audit.LogAsync(AuditActions.X, AuditTargetTypes.Y, id.ToString(), new { before, after }, ct)`
+  *before* the caller's own `SaveChangesAsync` — the row is added to the SAME
+  `AppDbContext` and commits atomically with the mutation. No fire-and-forget audit: a
+  mutation without its audit row (or vice versa) is worse than a failed request. System
+  actors (Functions, sync jobs) use the `LogAsync(int? actorUserId, ...)` overload with
+  `null`. New action/target kinds are constants in Domain's `AuditActions` /
+  `AuditTargetTypes`, never inline strings. `details` is JSON-serialized (camelCase) —
+  never put a key or token in it.
+- **Paging**: bind `[FromQuery] PagedRequest paging` (alongside any `[FromQuery]` filter
+  record) and finish the query with `.OrderBy(...).Select(projection).ToPagedAsync(paging, ct)`
+  (`FoundryGate.Data.Extensions`) → `PagedResult<T>`. Order deterministically first;
+  the helper clamps page/size itself.
+- **Integration tests** use `IClassFixture<ApiTestFactory>` (real pipeline, SQLite
+  in-memory, header-driven `TestAuthHandler`): `factory.CreateClient()` is anonymous,
+  `factory.CreateClientAs(oid, isAdmin: true)` is an admin, `factory.SeedUserAsync(...)`
+  and `factory.CreateDbContext()` arrange/assert rows, `factory.TimeProvider` moves the
+  clock. One database per test class — seed with unique markers, never assert absolute
+  counts. Service-level tests use `InMemoryDatabaseTest` + `Support/MutableTimeProvider`
+  + hand-rolled stubs (no mocking library). Under SQLite, `AppDbContext` stores
+  `DateTimeOffset` as UTC ticks (provider-gated) so ordering and date-range filters
+  translate; the SQL Server model is untouched.
+
 ## Schema pipeline (no EF migrations)
 
 - EF entities are the model source of truth. Local: CLI `local setup` runs

--- a/plans/12-audit-logging.md
+++ b/plans/12-audit-logging.md
@@ -24,8 +24,46 @@ Files expected to be created or modified:
 - `src/FoundryGate.Api/Program.cs` (register AuditService)
 
 ## Verification
-- [ ] `dotnet build` passes
-- [ ] Every mutation listed above produces a row in `AuditLog`
-- [ ] `GET /admin/audit` returns filtered results correctly
-- [ ] Audit writes do not break the primary operation if they throw (fire-and-log pattern)
-- [ ] Actor ID is always the authenticated user's `oid` claim, not a display name
+- [x] `dotnet build` passes — zero warnings, whole solution (`TreatWarningsAsErrors`);
+      `FoundryGate.Tests.Predeployment` 119/119 (82 before #42 + 37 new); `dotnet format
+      --verify-no-changes` clean.
+- [ ] Every mutation listed above produces a row in `AuditLog` — **deferred to each endpoint
+      wave, by design.** #42 lands `IAuditService`, `GET /audit`, and the scaffolding every wave
+      shares; the mutating endpoints themselves don't exist yet (#28–#41, #61, #65–#66). Each of
+      those PRs wires its own `LogAsync` call and asserts the row in its endpoint tests — the
+      call-site list in this plan's Approach section is the checklist they work from.
+- [x] `GET /api/v1/audit` returns filtered results correctly — `AuditEndpointTests`: 401
+      anonymous, 403 authenticated non-admin, 200 admin; paging (`page`/`pageSize`, `TotalCount`,
+      `TotalPages`), newest-first ordering, and each filter (`actorUserId`, `action`, `targetType`,
+      `targetId`, inclusive `fromDate`/`toDate`, plus a non-UTC-offset date compared by instant).
+      Route is `/api/v1/audit` per spec §4.6, not this plan's original `/admin/audit`.
+- [x] ~~Audit writes do not break the primary operation if they throw (fire-and-log pattern)~~ →
+      **design decision reversed, deliberately.** `LogAsync` adds the row to the SAME `AppDbContext`
+      and the caller's `SaveChangesAsync` commits mutation + audit atomically — no separate save,
+      no swallowed failure. A fire-and-log audit can leave a mutation with no audit row, or an
+      audit row for a mutation that rolled back; for an audit trail, failing the request is the
+      correct outcome. `AuditServiceTests.LogAsync_adds_to_the_context_but_does_not_save…` pins it.
+- [x] Actor ID is always the authenticated user's `oid` claim, not a display name — amended for
+      the int-PK model (#92): `AuditLog.ActorUserId` is the `User` FK resolved from the caller's
+      `oid` by `ICurrentUserAccessor` (both oid claim types; `CurrentUserAccessorTests`). A caller
+      with no `User` row cannot write a human-attributed audit row (`UnauthorizedAccessException`
+      → 403; they are provisioned by `GET /users/me` first); system jobs use the explicit
+      `LogAsync(actorUserId: null, …)` overload. `ActorDisplayName` on the response is a
+      read-time join, never stored.
+
+### Deviations from this plan's original text (#42)
+- **Signature.** `LogAsync(string action, string targetType, string targetId, object? details, ct)`
+  with the actor taken from `ICurrentUserAccessor`, plus an explicit `LogAsync(int? actorUserId, …)`
+  overload for system actors — rather than the plan's `(AuditAction enum, string actorId, …)`.
+  Actions stay string constants (`AuditActions`, per #91's reasoning), `details` is any object
+  and is JSON-serialized here so call sites pass `new { before, after }` instead of hand-building
+  JSON, and the service returns the added `AuditLog` for callers/tests to inspect.
+- **File layout.** `Services/Audit/{IAuditService,AuditService,AuditServiceCollectionExtensions}.cs`
+  and `Services/Identity/…` — the `Services/<Area>/` convention from CONVENTIONS.md, not the flat
+  `Services/IAuditService.cs` this plan listed. Registration is one line in
+  `Services/ServiceCollectionExtensions.AddFoundryGateApiServices()`, not in Program.cs.
+- **Scaffolding beyond audit**, because #42 is the first `/api/v1` controller and seven waves
+  follow it: `ApiControllerBase`, `ICurrentUserAccessor`, `ToPagedAsync`, `AuditTargetTypes`,
+  the remaining `AuditActions` later waves need, `GatewayTiers`, and the `ApiTestFactory` /
+  `TestAuthHandler` integration-test harness. Documented in CONVENTIONS.md "API
+  service/controller conventions".

--- a/plans/12-audit-logging.md
+++ b/plans/12-audit-logging.md
@@ -45,23 +45,32 @@ Files expected to be created or modified:
       correct outcome. `AuditServiceTests.LogAsync_adds_to_the_context_but_does_not_save…` pins it.
 - [x] Actor ID is always the authenticated user's `oid` claim, not a display name — amended for
       the int-PK model (#92): `AuditLog.ActorUserId` is the `User` FK resolved from the caller's
-      `oid` by `ICurrentUserAccessor` (both oid claim types; `CurrentUserAccessorTests`). A caller
-      with no `User` row cannot write a human-attributed audit row (`UnauthorizedAccessException`
-      → 403; they are provisioned by `GET /users/me` first); system jobs use the explicit
-      `LogAsync(actorUserId: null, …)` overload. `ActorDisplayName` on the response is a
-      read-time join, never stored.
+      `oid` by `ICurrentUserAccessor` (both oid claim types; `CurrentUserAccessorTests`), and the
+      row is attached via the `ActorUser` navigation so a caller whose `User` was just `Add`ed but
+      not yet saved (first-login auto-provisioning, #28) is attributed correctly in the same save
+      (`AuditWriterTests` / `AuditServiceTests` "auto_provision_pattern"). A caller with no `User`
+      row at all cannot write a human-attributed audit row — `UnauthorizedAccessException` → 403,
+      the same status and message (`call GET /users/me first`) `GetRequiredUserAsync` gives, so the
+      two "no row" paths never disagree; system jobs use `IAuditWriter.AddSystem(…)`.
+      `ActorDisplayName` on the response is a read-time join, never stored.
+- [x] `AuditLog.OccurredDate` indexed (`[Index]` + `IX_AuditLogs_OccurredDate` in
+      `dbo/Tables/AuditLogs.sql`; `SchemaParityTests` verifies the pair) — every page of
+      `GET /audit` orders by it and the date-range filter seeks on it.
 
 ### Deviations from this plan's original text (#42)
-- **Signature.** `LogAsync(string action, string targetType, string targetId, object? details, ct)`
-  with the actor taken from `ICurrentUserAccessor`, plus an explicit `LogAsync(int? actorUserId, …)`
-  overload for system actors — rather than the plan's `(AuditAction enum, string actorId, …)`.
-  Actions stay string constants (`AuditActions`, per #91's reasoning), `details` is any object
-  and is JSON-serialized here so call sites pass `new { before, after }` instead of hand-building
-  JSON, and the service returns the added `AuditLog` for callers/tests to inspect.
+- **One writer in Data, a wrapper in Api.** The plan put `IAuditService` in Api, but `FoundryGate
+  .Functions` (monthly reset, usage sync — #38/#39) references Data and Domain only, so the
+  actor-agnostic row builder is `FoundryGate.Data.Audit.IAuditWriter`/`AuditWriter` (`Add(User
+  actor, …)`, `Add(int actorUserId, …)`, `AddSystem(…)`; `TimeProvider` timestamp; camelCase JSON
+  with cycles ignored), registered in `AddFoundryGateData`. Api's `IAuditService` is the thin
+  current-user-attributing wrapper (`LogAsync(action, targetType, targetId, details, ct)`) plus the
+  admin read query — rather than the plan's `(AuditAction enum, string actorId, …)`. Actions stay
+  string constants (`AuditActions`, per #91's reasoning); `details` is any object so call sites
+  pass `new { before, after }` instead of hand-building JSON; both return the added `AuditLog`.
 - **File layout.** `Services/Audit/{IAuditService,AuditService,AuditServiceCollectionExtensions}.cs`
   and `Services/Identity/…` — the `Services/<Area>/` convention from CONVENTIONS.md, not the flat
   `Services/IAuditService.cs` this plan listed. Registration is one line in
-  `Services/ServiceCollectionExtensions.AddFoundryGateApiServices()`, not in Program.cs.
+  `Services/ApiServiceCollectionExtensions.AddFoundryGateApiServices()`, not in Program.cs.
 - **Scaffolding beyond audit**, because #42 is the first `/api/v1` controller and seven waves
   follow it: `ApiControllerBase`, `ICurrentUserAccessor`, `ToPagedAsync`, `AuditTargetTypes`,
   the remaining `AuditActions` later waves need, `GatewayTiers`, and the `ApiTestFactory` /

--- a/src/FoundryGate.Api/Controllers/ApiControllerBase.cs
+++ b/src/FoundryGate.Api/Controllers/ApiControllerBase.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// Base class for every FoundryGate.Api controller. Fixes the three attributes spec &#167;4 implies
+/// for the whole surface — <c>[ApiController]</c> (automatic 400 ProblemDetails on model-binding
+/// failure), the <c>api/v1/[controller]</c> route prefix, and JSON-only responses — so individual
+/// controllers declare only what is specific to them: their <c>[Authorize(Policy = ...)]</c> and
+/// their actions. Authentication itself is already global (the <c>AuthorizeFilter</c> in
+/// <c>Program.cs</c>); a controller inheriting this is authenticated-only by default and opts into
+/// admin-only with <c>[Authorize(Policy = PolicyNames.AdminOnly)]</c> at class or action level.
+/// </summary>
+/// <remarks>
+/// Controllers stay thin: expression-bodied (or near-enough) delegations into a
+/// <c>Services/&lt;Area&gt;</c> service, which owns the query/mutation and throws the exception
+/// types <c>GlobalExceptionHandler</c> maps (404/400/409/403). See CONVENTIONS.md
+/// "API service/controller conventions".
+/// </remarks>
+[ApiController]
+[Route("api/v1/[controller]")]
+[Produces("application/json")]
+public abstract class ApiControllerBase : ControllerBase
+{
+}

--- a/src/FoundryGate.Api/Controllers/AuditController.cs
+++ b/src/FoundryGate.Api/Controllers/AuditController.cs
@@ -1,0 +1,35 @@
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Domain.Audit.Contracts;
+using FoundryGate.Domain.Common;
+using FoundryGate.Domain.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// <c>GET /api/v1/audit</c> — admin-only, paged, filterable view of the audit trail (spec &#167;4.6,
+/// issue #42). Newest first.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+public sealed class AuditController(IAuditService auditService) : ApiControllerBase
+{
+    /// <summary>
+    /// Lists audit log entries, newest first. Every <see cref="AuditLogQuery"/> member is an
+    /// optional query-string filter (exact match on <c>actorUserId</c>/<c>action</c>/
+    /// <c>targetType</c>/<c>targetId</c>; inclusive <c>fromDate</c>/<c>toDate</c> range on
+    /// <c>OccurredDate</c>); <c>page</c>/<c>pageSize</c> come from <see cref="PagedRequest"/>.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType<PagedResult<AuditLogEntryResponse>>(StatusCodes.Status200OK)]
+    public Task<PagedResult<AuditLogEntryResponse>> ListAsync(
+        [FromQuery] AuditLogQuery filter,
+        [FromQuery] PagedRequest paging,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(paging);
+
+        return auditService.QueryAsync(filter, paging, cancellationToken);
+    }
+}

--- a/src/FoundryGate.Api/Controllers/AuditController.cs
+++ b/src/FoundryGate.Api/Controllers/AuditController.cs
@@ -20,16 +20,16 @@ public sealed class AuditController(IAuditService auditService) : ApiControllerB
     /// <c>targetType</c>/<c>targetId</c>; inclusive <c>fromDate</c>/<c>toDate</c> range on
     /// <c>OccurredDate</c>); <c>page</c>/<c>pageSize</c> come from <see cref="PagedRequest"/>.
     /// </summary>
+    /// <remarks>
+    /// No <c>ThrowIfNull</c> on the bound records: <c>[ApiController]</c> always materializes a
+    /// <c>[FromQuery]</c> complex type (an empty query string yields an instance with defaults), so
+    /// the guard would be unreachable ceremony — controllers stay expression-bodied delegations.
+    /// </remarks>
     [HttpGet]
     [ProducesResponseType<PagedResult<AuditLogEntryResponse>>(StatusCodes.Status200OK)]
     public Task<PagedResult<AuditLogEntryResponse>> ListAsync(
         [FromQuery] AuditLogQuery filter,
         [FromQuery] PagedRequest paging,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(filter);
-        ArgumentNullException.ThrowIfNull(paging);
-
-        return auditService.QueryAsync(filter, paging, cancellationToken);
-    }
+        CancellationToken cancellationToken) =>
+        auditService.QueryAsync(filter, paging, cancellationToken);
 }

--- a/src/FoundryGate.Api/Program.cs
+++ b/src/FoundryGate.Api/Program.cs
@@ -3,6 +3,7 @@ using Azure.Security.KeyVault.Secrets;
 using FoundryGate.Api.Configuration;
 using FoundryGate.Api.Extensions;
 using FoundryGate.Api.Middleware;
+using FoundryGate.Api.Services;
 using FoundryGate.Data;
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Constants;
@@ -49,6 +50,10 @@ builder.Services.AddSingleton(appSettings);
 
 // Data layer (#92): AppDbContext, TimestampInterceptor, TimeProvider.
 builder.Services.AddFoundryGateData(appSettings.ConnectionStrings.FoundryGate);
+
+// Application services: the ONE call for every Services/<Area> group (each area registers itself
+// from Services/ServiceCollectionExtensions.cs — add areas there, not here).
+builder.Services.AddFoundryGateApiServices();
 
 // Entra ID bearer auth (spec §4: "all endpoints require a valid Entra ID bearer token";
 // §11: "FoundryGate.Admin app role in Entra"). PolicyNames.AdminOnly gates admin-only

--- a/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
@@ -7,10 +7,11 @@ namespace FoundryGate.Api.Services;
 /// The single DI entry point for FoundryGate.Api's application services, called exactly once from
 /// <c>Program.cs</c>. Each <c>Services/&lt;Area&gt;</c> folder owns its own
 /// <c>&lt;Area&gt;ServiceCollectionExtensions.Add&lt;Area&gt;Services()</c> and is invoked from here —
-/// so adding a new area is one new file plus one new line below, and <c>Program.cs</c> never becomes
-/// a merge hotspot across parallel endpoint work.
+/// so adding a new area is one new file plus one new line below. Parallel waves will still collide
+/// on adjacent lines in this method, but that conflict is one trivially-resolved line, versus the
+/// registrations-plus-usings churn <c>Program.cs</c> would otherwise take from every wave.
 /// </summary>
-public static class ServiceCollectionExtensions
+public static class ApiServiceCollectionExtensions
 {
     /// <summary>Registers every <c>Services/&lt;Area&gt;</c> group. Order is not significant.</summary>
     public static IServiceCollection AddFoundryGateApiServices(this IServiceCollection services)

--- a/src/FoundryGate.Api/Services/Audit/AuditService.cs
+++ b/src/FoundryGate.Api/Services/Audit/AuditService.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Data;
+using FoundryGate.Data.Entities;
+using FoundryGate.Data.Extensions;
+using FoundryGate.Domain.Audit.Contracts;
+using FoundryGate.Domain.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Api.Services.Audit;
+
+/// <summary>
+/// Default <see cref="IAuditService"/>. Writes go into the request-scoped <see cref="AppDbContext"/>
+/// and are persisted by the caller's <c>SaveChangesAsync</c> (see the interface remarks for why);
+/// <see cref="AuditLog.OccurredDate"/> comes from the injected <see cref="TimeProvider"/>, never
+/// <c>DateTimeOffset.UtcNow</c> (CONVENTIONS.md).
+/// </summary>
+public sealed class AuditService(AppDbContext dbContext, ICurrentUserAccessor currentUser, TimeProvider timeProvider)
+    : IAuditService
+{
+    /// <summary>Web defaults (camelCase, relaxed escaping) so <c>Details</c> reads like the rest of the API's JSON.</summary>
+    private static readonly JsonSerializerOptions DetailsSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public async Task<AuditLog> LogAsync(string action, string targetType, string targetId, object? details, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        ArgumentNullException.ThrowIfNull(targetType);
+        ArgumentNullException.ThrowIfNull(targetId);
+
+        var actor = await currentUser.TryGetUserAsync(cancellationToken)
+            ?? throw new UnauthorizedAccessException(
+                $"Cannot attribute '{action}' to the caller: no FoundryGate user exists for oid {currentUser.EntraObjectId}. " +
+                "Callers are provisioned by GET /users/me before they can perform audited actions.");
+
+        return Add(actor.UserId, action, targetType, targetId, details);
+    }
+
+    /// <inheritdoc />
+    public Task<AuditLog> LogAsync(int? actorUserId, string action, string targetType, string targetId, object? details, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        ArgumentNullException.ThrowIfNull(targetType);
+        ArgumentNullException.ThrowIfNull(targetId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(Add(actorUserId, action, targetType, targetId, details));
+    }
+
+    /// <inheritdoc />
+    public Task<PagedResult<AuditLogEntryResponse>> QueryAsync(AuditLogQuery filter, PagedRequest paging, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(paging);
+
+        IQueryable<AuditLog> query = dbContext.AuditLogs.AsNoTracking();
+
+        if (filter.ActorUserId is { } actorUserId)
+        {
+            query = query.Where(a => a.ActorUserId == actorUserId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.Action))
+        {
+            query = query.Where(a => a.Action == filter.Action);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.TargetType))
+        {
+            query = query.Where(a => a.TargetType == filter.TargetType);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.TargetId))
+        {
+            query = query.Where(a => a.TargetId == filter.TargetId);
+        }
+
+        if (filter.FromDate is { } fromDate)
+        {
+            query = query.Where(a => a.OccurredDate >= fromDate);
+        }
+
+        if (filter.ToDate is { } toDate)
+        {
+            query = query.Where(a => a.OccurredDate <= toDate);
+        }
+
+        // Projection-to-record inside the query (CONVENTIONS.md). The entity stores "no target"/"no
+        // details" as empty strings (non-nullable string convention); the response contract exposes
+        // them as null, so the translation happens here rather than leaking "" to the UI.
+        return query
+            .OrderByDescending(a => a.OccurredDate)
+            .ThenByDescending(a => a.AuditLogId)
+            .Select(a => new AuditLogEntryResponse(
+                a.AuditLogId,
+                a.ActorUserId,
+                a.ActorUser != null ? a.ActorUser.DisplayName : null,
+                a.Action,
+                a.TargetType == string.Empty ? null : a.TargetType,
+                a.TargetId == string.Empty ? null : a.TargetId,
+                a.Details == string.Empty ? null : a.Details,
+                a.OccurredDate))
+            .ToPagedAsync(paging, cancellationToken);
+    }
+
+    private AuditLog Add(int? actorUserId, string action, string targetType, string targetId, object? details)
+    {
+        var entry = new AuditLog
+        {
+            ActorUserId = actorUserId,
+            Action = action,
+            TargetType = targetType,
+            TargetId = targetId,
+            Details = details is null ? string.Empty : JsonSerializer.Serialize(details, DetailsSerializerOptions),
+            OccurredDate = timeProvider.GetUtcNow(),
+        };
+
+        dbContext.AuditLogs.Add(entry);
+        return entry;
+    }
+}

--- a/src/FoundryGate.Api/Services/Audit/AuditService.cs
+++ b/src/FoundryGate.Api/Services/Audit/AuditService.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Data;
+using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Data.Extensions;
 using FoundryGate.Domain.Audit.Contracts;
@@ -10,17 +10,12 @@ using Microsoft.EntityFrameworkCore;
 namespace FoundryGate.Api.Services.Audit;
 
 /// <summary>
-/// Default <see cref="IAuditService"/>. Writes go into the request-scoped <see cref="AppDbContext"/>
-/// and are persisted by the caller's <c>SaveChangesAsync</c> (see the interface remarks for why);
-/// <see cref="AuditLog.OccurredDate"/> comes from the injected <see cref="TimeProvider"/>, never
-/// <c>DateTimeOffset.UtcNow</c> (CONVENTIONS.md).
+/// Default <see cref="IAuditService"/>: resolves the caller through <see cref="ICurrentUserAccessor"/>
+/// and delegates the row to <see cref="IAuditWriter"/>; owns the admin read query.
 /// </summary>
-public sealed class AuditService(AppDbContext dbContext, ICurrentUserAccessor currentUser, TimeProvider timeProvider)
+public sealed class AuditService(AppDbContext dbContext, IAuditWriter auditWriter, ICurrentUserAccessor currentUser)
     : IAuditService
 {
-    /// <summary>Web defaults (camelCase, relaxed escaping) so <c>Details</c> reads like the rest of the API's JSON.</summary>
-    private static readonly JsonSerializerOptions DetailsSerializerOptions = new(JsonSerializerDefaults.Web);
-
     /// <inheritdoc />
     public async Task<AuditLog> LogAsync(string action, string targetType, string targetId, object? details, CancellationToken cancellationToken)
     {
@@ -28,23 +23,11 @@ public sealed class AuditService(AppDbContext dbContext, ICurrentUserAccessor cu
         ArgumentNullException.ThrowIfNull(targetType);
         ArgumentNullException.ThrowIfNull(targetId);
 
-        var actor = await currentUser.TryGetUserAsync(cancellationToken)
-            ?? throw new UnauthorizedAccessException(
-                $"Cannot attribute '{action}' to the caller: no FoundryGate user exists for oid {currentUser.EntraObjectId}. " +
-                "Callers are provisioned by GET /users/me before they can perform audited actions.");
+        // GetRequiredUserAsync throws the same UnauthorizedAccessException (403, "call GET /users/me
+        // first") for a missing row, so the two "no User row" paths in the API agree.
+        var actor = await currentUser.GetRequiredUserAsync(cancellationToken);
 
-        return Add(actor.UserId, action, targetType, targetId, details);
-    }
-
-    /// <inheritdoc />
-    public Task<AuditLog> LogAsync(int? actorUserId, string action, string targetType, string targetId, object? details, CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(action);
-        ArgumentNullException.ThrowIfNull(targetType);
-        ArgumentNullException.ThrowIfNull(targetId);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        return Task.FromResult(Add(actorUserId, action, targetType, targetId, details));
+        return auditWriter.Add(actor, action, targetType, targetId, details);
     }
 
     /// <inheritdoc />
@@ -101,21 +84,5 @@ public sealed class AuditService(AppDbContext dbContext, ICurrentUserAccessor cu
                 a.Details == string.Empty ? null : a.Details,
                 a.OccurredDate))
             .ToPagedAsync(paging, cancellationToken);
-    }
-
-    private AuditLog Add(int? actorUserId, string action, string targetType, string targetId, object? details)
-    {
-        var entry = new AuditLog
-        {
-            ActorUserId = actorUserId,
-            Action = action,
-            TargetType = targetType,
-            TargetId = targetId,
-            Details = details is null ? string.Empty : JsonSerializer.Serialize(details, DetailsSerializerOptions),
-            OccurredDate = timeProvider.GetUtcNow(),
-        };
-
-        dbContext.AuditLogs.Add(entry);
-        return entry;
     }
 }

--- a/src/FoundryGate.Api/Services/Audit/AuditServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Audit/AuditServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 namespace FoundryGate.Api.Services.Audit;
 
-/// <summary>DI registration for the <c>Services/Audit</c> area. Invoked from <see cref="ServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+/// <summary>DI registration for the <c>Services/Audit</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
 public static class AuditServiceCollectionExtensions
 {
     /// <summary>Registers <see cref="IAuditService"/> (scoped — it shares the request's <c>AppDbContext</c> so audit rows save atomically with the mutation).</summary>

--- a/src/FoundryGate.Api/Services/Audit/AuditServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Audit/AuditServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+namespace FoundryGate.Api.Services.Audit;
+
+/// <summary>DI registration for the <c>Services/Audit</c> area. Invoked from <see cref="ServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class AuditServiceCollectionExtensions
+{
+    /// <summary>Registers <see cref="IAuditService"/> (scoped — it shares the request's <c>AppDbContext</c> so audit rows save atomically with the mutation).</summary>
+    public static IServiceCollection AddAuditServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IAuditService, AuditService>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Audit/IAuditService.cs
+++ b/src/FoundryGate.Api/Services/Audit/IAuditService.cs
@@ -1,0 +1,63 @@
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Audit.Contracts;
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Api.Services.Audit;
+
+/// <summary>
+/// Writes and reads the <see cref="AuditLog"/> trail (spec &#167;11: "all admin actions, key rotations,
+/// approvals written to <c>AuditLog</c>"; issue #42).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Writes are not saved here.</b> <c>LogAsync</c> only <em>adds</em> the row to the request's
+/// <c>AppDbContext</c>; the calling service's own <c>SaveChangesAsync</c> persists the mutation and
+/// its audit row in one transaction. That is deliberate: a fire-and-forget/"fire-and-log" audit
+/// (separate save, swallowed failure) can leave a mutation with no audit row or an audit row for a
+/// mutation that rolled back — either is worse for an audit trail than failing the request. The
+/// pattern at every call site is therefore: mutate → <c>await audit.LogAsync(...)</c> →
+/// <c>await dbContext.SaveChangesAsync(ct)</c>.
+/// </para>
+/// <para>
+/// <c>action</c> and <c>targetType</c> should be constants from
+/// <see cref="Domain.Constants.AuditActions"/> / <see cref="Domain.Constants.AuditTargetTypes"/>.
+/// <c>details</c> is any serializable object (an anonymous <c>new { before, after }</c> is the
+/// expected shape); it is JSON-serialized with web (camelCase) defaults into
+/// <see cref="AuditLog.Details"/>. Never put a secret (an APIM key, a token) in it.
+/// </para>
+/// </remarks>
+public interface IAuditService
+{
+    /// <summary>
+    /// Adds an audit row attributed to the current caller (via <c>ICurrentUserAccessor</c>).
+    /// </summary>
+    /// <param name="action">What happened — an <see cref="Domain.Constants.AuditActions"/> constant.</param>
+    /// <param name="targetType">Kind of the affected record — an <see cref="Domain.Constants.AuditTargetTypes"/> constant; empty when there is no single target.</param>
+    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
+    /// <param name="details">Caller-defined detail object (before/after values), JSON-serialized; <see langword="null"/> stores an empty string.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
+    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row yet (→ 403): every human-attributed audit row needs a resolvable actor, and callers are provisioned by <c>GET /users/me</c> before they can act.</exception>
+    Task<AuditLog> LogAsync(string action, string targetType, string targetId, object? details, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds an audit row with an explicit actor — <see langword="null"/> for system-initiated actions
+    /// with no human behind them (the monthly reset, usage sync, Entra sync jobs) or a known
+    /// <c>UserId</c> when the caller has already resolved it.
+    /// </summary>
+    /// <param name="actorUserId">The acting user's <c>UserId</c>, or <see langword="null"/> for a system actor.</param>
+    /// <param name="action">What happened — an <see cref="Domain.Constants.AuditActions"/> constant.</param>
+    /// <param name="targetType">Kind of the affected record — an <see cref="Domain.Constants.AuditTargetTypes"/> constant; empty when there is no single target.</param>
+    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
+    /// <param name="details">Caller-defined detail object, JSON-serialized; <see langword="null"/> stores an empty string.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
+    Task<AuditLog> LogAsync(int? actorUserId, string action, string targetType, string targetId, object? details, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Pages the audit trail newest-first (<c>OccurredDate</c> then <c>AuditLogId</c> descending),
+    /// applying every non-null <paramref name="filter"/> member (exact match on actor/action/
+    /// target; inclusive date range). Read-only projection — nothing is tracked.
+    /// </summary>
+    Task<PagedResult<AuditLogEntryResponse>> QueryAsync(AuditLogQuery filter, PagedRequest paging, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/Audit/IAuditService.cs
+++ b/src/FoundryGate.Api/Services/Audit/IAuditService.cs
@@ -1,3 +1,4 @@
+using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Audit.Contracts;
 using FoundryGate.Domain.Common;
@@ -5,31 +6,26 @@ using FoundryGate.Domain.Common;
 namespace FoundryGate.Api.Services.Audit;
 
 /// <summary>
-/// Writes and reads the <see cref="AuditLog"/> trail (spec &#167;11: "all admin actions, key rotations,
-/// approvals written to <c>AuditLog</c>"; issue #42).
+/// The Api-side face of the audit trail (spec &#167;11; issue #42): attributes a row to the
+/// <em>current caller</em> and serves the admin <c>GET /audit</c> query. The actual row-building
+/// lives in <see cref="IAuditWriter"/> (FoundryGate.Data) so Functions/Cli write identical rows;
+/// this service is the thin wrapper that adds "who is calling" on top. Api code that already holds a
+/// <c>UserId</c>, or is acting as the system (no human), uses <see cref="IAuditWriter"/> directly.
 /// </summary>
 /// <remarks>
-/// <para>
-/// <b>Writes are not saved here.</b> <c>LogAsync</c> only <em>adds</em> the row to the request's
+/// <b>Nothing here saves.</b> <see cref="LogAsync"/> adds the row to the request's
 /// <c>AppDbContext</c>; the calling service's own <c>SaveChangesAsync</c> persists the mutation and
-/// its audit row in one transaction. That is deliberate: a fire-and-forget/"fire-and-log" audit
-/// (separate save, swallowed failure) can leave a mutation with no audit row or an audit row for a
-/// mutation that rolled back — either is worse for an audit trail than failing the request. The
-/// pattern at every call site is therefore: mutate → <c>await audit.LogAsync(...)</c> →
-/// <c>await dbContext.SaveChangesAsync(ct)</c>.
-/// </para>
-/// <para>
-/// <c>action</c> and <c>targetType</c> should be constants from
-/// <see cref="Domain.Constants.AuditActions"/> / <see cref="Domain.Constants.AuditTargetTypes"/>.
-/// <c>details</c> is any serializable object (an anonymous <c>new { before, after }</c> is the
-/// expected shape); it is JSON-serialized with web (camelCase) defaults into
-/// <see cref="AuditLog.Details"/>. Never put a secret (an APIM key, a token) in it.
-/// </para>
+/// its audit row atomically. Pattern at every call site: mutate → <c>await audit.LogAsync(...)</c> →
+/// <c>await dbContext.SaveChangesAsync(ct)</c>. Details/constants guidance is on
+/// <see cref="IAuditWriter"/>.
 /// </remarks>
 public interface IAuditService
 {
     /// <summary>
-    /// Adds an audit row attributed to the current caller (via <c>ICurrentUserAccessor</c>).
+    /// Adds an audit row attributed to the current caller (resolved through
+    /// <c>ICurrentUserAccessor</c>, which also sees a <c>User</c> the caller has just <c>Add</c>ed but
+    /// not yet saved — so first-login auto-provisioning gets user + <c>user.provisioned</c> row in one
+    /// save).
     /// </summary>
     /// <param name="action">What happened — an <see cref="Domain.Constants.AuditActions"/> constant.</param>
     /// <param name="targetType">Kind of the affected record — an <see cref="Domain.Constants.AuditTargetTypes"/> constant; empty when there is no single target.</param>
@@ -37,22 +33,12 @@ public interface IAuditService
     /// <param name="details">Caller-defined detail object (before/after values), JSON-serialized; <see langword="null"/> stores an empty string.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
-    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row yet (→ 403): every human-attributed audit row needs a resolvable actor, and callers are provisioned by <c>GET /users/me</c> before they can act.</exception>
+    /// <exception cref="UnauthorizedAccessException">
+    /// The caller has no <c>User</c> row (→ 403, same as <c>ICurrentUserAccessor.GetRequiredUserAsync</c>):
+    /// an authenticated principal without a row is an authorization-state problem, not a missing
+    /// resource — they must call <c>GET /users/me</c> first.
+    /// </exception>
     Task<AuditLog> LogAsync(string action, string targetType, string targetId, object? details, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Adds an audit row with an explicit actor — <see langword="null"/> for system-initiated actions
-    /// with no human behind them (the monthly reset, usage sync, Entra sync jobs) or a known
-    /// <c>UserId</c> when the caller has already resolved it.
-    /// </summary>
-    /// <param name="actorUserId">The acting user's <c>UserId</c>, or <see langword="null"/> for a system actor.</param>
-    /// <param name="action">What happened — an <see cref="Domain.Constants.AuditActions"/> constant.</param>
-    /// <param name="targetType">Kind of the affected record — an <see cref="Domain.Constants.AuditTargetTypes"/> constant; empty when there is no single target.</param>
-    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
-    /// <param name="details">Caller-defined detail object, JSON-serialized; <see langword="null"/> stores an empty string.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
-    Task<AuditLog> LogAsync(int? actorUserId, string action, string targetType, string targetId, object? details, CancellationToken cancellationToken);
 
     /// <summary>
     /// Pages the audit trail newest-first (<c>OccurredDate</c> then <c>AuditLogId</c> descending),

--- a/src/FoundryGate.Api/Services/Identity/CurrentUserAccessor.cs
+++ b/src/FoundryGate.Api/Services/Identity/CurrentUserAccessor.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using FoundryGate.Data;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+namespace FoundryGate.Api.Services.Identity;
+
+/// <summary>
+/// Default <see cref="ICurrentUserAccessor"/>: reads claims from <see cref="IHttpContextAccessor"/>
+/// and resolves the <see cref="User"/> row through the request's own <see cref="AppDbContext"/>
+/// (so the returned entity is tracked by the same context the calling service saves with).
+/// </summary>
+public sealed class CurrentUserAccessor(IHttpContextAccessor httpContextAccessor, AppDbContext dbContext)
+    : ICurrentUserAccessor
+{
+    private User? _user;
+
+    /// <inheritdoc />
+    public string EntraObjectId =>
+        // Microsoft.Identity.Web's GetObjectId() checks both claim types: the short "oid" and the
+        // long ".../identity/claims/objectidentifier" URI (which claim a token carries depends on
+        // whether the JWT handler's inbound claim-type mapping is on).
+        Principal.GetObjectId()
+        ?? throw new UnauthorizedAccessException(
+            "The authenticated principal carries no object id (oid) claim, so the caller cannot be identified.");
+
+    /// <inheritdoc />
+    public bool IsAdmin => Principal.IsInRole(RoleNames.Admin);
+
+    /// <inheritdoc />
+    public string? DisplayName =>
+        FirstNonEmptyClaim(ClaimConstants.Name, ClaimTypes.Name);
+
+    /// <inheritdoc />
+    public string? Email =>
+        FirstNonEmptyClaim(ClaimConstants.PreferredUserName, ClaimTypes.Upn, ClaimTypes.Email, "email");
+
+    private ClaimsPrincipal Principal =>
+        httpContextAccessor.HttpContext?.User is { Identity.IsAuthenticated: true } principal
+            ? principal
+            : throw new UnauthorizedAccessException("There is no authenticated principal on the current request.");
+
+    /// <inheritdoc />
+    public async Task<User?> TryGetUserAsync(CancellationToken cancellationToken)
+    {
+        if (_user is not null)
+        {
+            return _user;
+        }
+
+        var entraObjectId = EntraObjectId;
+
+        // SingleOrDefaultAsync (not AsNoTracking) deliberately: callers mutate the returned row, and
+        // EF's identity resolution hands back the already-tracked instance if the calling service
+        // has loaded this user through the same context — one instance per request, never two.
+        _user = await dbContext.Users.SingleOrDefaultAsync(u => u.EntraObjectId == entraObjectId, cancellationToken);
+        return _user;
+    }
+
+    /// <inheritdoc />
+    public async Task<User> GetRequiredUserAsync(CancellationToken cancellationToken) =>
+        await TryGetUserAsync(cancellationToken)
+        ?? throw new KeyNotFoundException(
+            $"No FoundryGate user exists for the caller (oid {EntraObjectId}). GET /users/me provisions one on first login.");
+
+    private string? FirstNonEmptyClaim(params string[] claimTypes)
+    {
+        var principal = Principal;
+        foreach (var claimType in claimTypes)
+        {
+            var value = principal.FindFirst(claimType)?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FoundryGate.Api/Services/Identity/CurrentUserAccessor.cs
+++ b/src/FoundryGate.Api/Services/Identity/CurrentUserAccessor.cs
@@ -52,6 +52,16 @@ public sealed class CurrentUserAccessor(IHttpContextAccessor httpContextAccessor
 
         var entraObjectId = EntraObjectId;
 
+        // Change tracker first: a User the calling service has just Add()ed is not in the database
+        // yet, and the auto-provisioning flow (GET /users/me) needs to add the user, then audit it
+        // against that same instance, then save once. Local is an in-memory scan of tracked Users —
+        // a handful of rows per request at most.
+        _user = dbContext.Users.Local.FirstOrDefault(u => u.EntraObjectId == entraObjectId);
+        if (_user is not null)
+        {
+            return _user;
+        }
+
         // SingleOrDefaultAsync (not AsNoTracking) deliberately: callers mutate the returned row, and
         // EF's identity resolution hands back the already-tracked instance if the calling service
         // has loaded this user through the same context — one instance per request, never two.
@@ -62,8 +72,8 @@ public sealed class CurrentUserAccessor(IHttpContextAccessor httpContextAccessor
     /// <inheritdoc />
     public async Task<User> GetRequiredUserAsync(CancellationToken cancellationToken) =>
         await TryGetUserAsync(cancellationToken)
-        ?? throw new KeyNotFoundException(
-            $"No FoundryGate user exists for the caller (oid {EntraObjectId}). GET /users/me provisions one on first login.");
+        ?? throw new UnauthorizedAccessException(
+            $"No FoundryGate user exists for the caller (oid {EntraObjectId}). Call GET /users/me first — it provisions the user on first login.");
 
     private string? FirstNonEmptyClaim(params string[] claimTypes)
     {

--- a/src/FoundryGate.Api/Services/Identity/ICurrentUserAccessor.cs
+++ b/src/FoundryGate.Api/Services/Identity/ICurrentUserAccessor.cs
@@ -1,0 +1,56 @@
+using FoundryGate.Data.Entities;
+
+namespace FoundryGate.Api.Services.Identity;
+
+/// <summary>
+/// Per-request view of the authenticated caller: their Entra identity claims and, on demand, their
+/// <see cref="User"/> row. Scoped — inject it into any service that needs to know who is calling
+/// (audit actors, "/me" endpoints, owner checks) instead of reaching for <c>HttpContext.User</c>
+/// and re-implementing claim parsing.
+/// </summary>
+/// <remarks>
+/// Every member that reads a claim throws <see cref="UnauthorizedAccessException"/> (→ 403 via
+/// <c>GlobalExceptionHandler</c>) when there is no authenticated principal or the principal carries
+/// no object id — both are configuration/token-shape faults on an already-authenticated request,
+/// not "please log in" (the global <c>AuthorizeFilter</c> has already turned anonymous callers away
+/// with a 401 before any service runs).
+/// </remarks>
+public interface ICurrentUserAccessor
+{
+    /// <summary>
+    /// The caller's Entra object id (the <c>oid</c> claim — accepted as either the short
+    /// <c>oid</c> or the long <c>http://schemas.microsoft.com/identity/claims/objectidentifier</c>
+    /// claim type). Matches <see cref="User.EntraObjectId"/>.
+    /// </summary>
+    /// <exception cref="UnauthorizedAccessException">No authenticated principal, or no oid claim.</exception>
+    string EntraObjectId { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the caller holds the <c>FoundryGate.Admin</c> app role. Evaluated
+    /// with <c>ClaimsPrincipal.IsInRole</c> — the same check <c>PolicyNames.AdminOnly</c> uses — so
+    /// the two can never disagree.
+    /// </summary>
+    /// <exception cref="UnauthorizedAccessException">No authenticated principal.</exception>
+    bool IsAdmin { get; }
+
+    /// <summary>The caller's display name from the token (<c>name</c> claim), if present. Used by first-login auto-provisioning.</summary>
+    /// <exception cref="UnauthorizedAccessException">No authenticated principal.</exception>
+    string? DisplayName { get; }
+
+    /// <summary>The caller's sign-in name/email from the token (<c>preferred_username</c>, falling back to UPN/email claims), if present. Used by first-login auto-provisioning.</summary>
+    /// <exception cref="UnauthorizedAccessException">No authenticated principal.</exception>
+    string? Email { get; }
+
+    /// <summary>
+    /// The caller's <see cref="User"/> row, or <see langword="null"/> if none exists yet for
+    /// <see cref="EntraObjectId"/> — a first-class outcome: <c>GET /users/me</c> auto-provisions on
+    /// exactly this path. Returned <em>tracked</em> so callers can mutate and save it. A found row is
+    /// cached for the rest of the request; a miss is not, so a caller that provisions the user and
+    /// asks again gets the new row.
+    /// </summary>
+    Task<User?> TryGetUserAsync(CancellationToken cancellationToken);
+
+    /// <summary>Like <see cref="TryGetUserAsync"/> but a missing row is an error.</summary>
+    /// <exception cref="KeyNotFoundException">No <see cref="User"/> exists for the caller's oid (→ 404).</exception>
+    Task<User> GetRequiredUserAsync(CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/Identity/ICurrentUserAccessor.cs
+++ b/src/FoundryGate.Api/Services/Identity/ICurrentUserAccessor.cs
@@ -9,11 +9,21 @@ namespace FoundryGate.Api.Services.Identity;
 /// and re-implementing claim parsing.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every member that reads a claim throws <see cref="UnauthorizedAccessException"/> (→ 403 via
 /// <c>GlobalExceptionHandler</c>) when there is no authenticated principal or the principal carries
 /// no object id — both are configuration/token-shape faults on an already-authenticated request,
 /// not "please log in" (the global <c>AuthorizeFilter</c> has already turned anonymous callers away
 /// with a 401 before any service runs).
+/// </para>
+/// <para>
+/// <b>"No <c>User</c> row for this caller" is always 403, never 404.</b> An authenticated principal
+/// with no row is an authorization-<em>state</em> problem — they haven't been provisioned yet, which
+/// <c>GET /users/me</c> does on first call — not a missing resource. <see cref="GetRequiredUserAsync"/>
+/// and <c>IAuditService.LogAsync</c> both throw <see cref="UnauthorizedAccessException"/> with a
+/// message that says so, so an admin who holds the role but hasn't loaded the UI yet reads one
+/// consistent instruction rather than a "Not found" on one endpoint and "Forbidden" on the next.
+/// </para>
 /// </remarks>
 public interface ICurrentUserAccessor
 {
@@ -44,13 +54,15 @@ public interface ICurrentUserAccessor
     /// <summary>
     /// The caller's <see cref="User"/> row, or <see langword="null"/> if none exists yet for
     /// <see cref="EntraObjectId"/> — a first-class outcome: <c>GET /users/me</c> auto-provisions on
-    /// exactly this path. Returned <em>tracked</em> so callers can mutate and save it. A found row is
-    /// cached for the rest of the request; a miss is not, so a caller that provisions the user and
-    /// asks again gets the new row.
+    /// exactly this path. Returned <em>tracked</em> so callers can mutate and save it. Looks in the
+    /// context's change tracker before the database, so a <c>User</c> the calling service has just
+    /// <c>Add</c>ed (and not yet saved) is found too — auto-provisioning can add the user, write its
+    /// audit row against the same instance, and commit both in one save. A found row is cached for
+    /// the rest of the request; a miss is not.
     /// </summary>
     Task<User?> TryGetUserAsync(CancellationToken cancellationToken);
 
     /// <summary>Like <see cref="TryGetUserAsync"/> but a missing row is an error.</summary>
-    /// <exception cref="KeyNotFoundException">No <see cref="User"/> exists for the caller's oid (→ 404).</exception>
+    /// <exception cref="UnauthorizedAccessException">No <see cref="User"/> exists for the caller's oid (→ 403; see the type remarks for why not 404).</exception>
     Task<User> GetRequiredUserAsync(CancellationToken cancellationToken);
 }

--- a/src/FoundryGate.Api/Services/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Identity/IdentityServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 namespace FoundryGate.Api.Services.Identity;
 
-/// <summary>DI registration for the <c>Services/Identity</c> area. Invoked from <see cref="ServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+/// <summary>DI registration for the <c>Services/Identity</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
 public static class IdentityServiceCollectionExtensions
 {
     /// <summary>Registers <see cref="ICurrentUserAccessor"/> (scoped — it caches the caller's <c>User</c> per request) and the <see cref="IHttpContextAccessor"/> it reads claims from.</summary>

--- a/src/FoundryGate.Api/Services/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Identity/IdentityServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+namespace FoundryGate.Api.Services.Identity;
+
+/// <summary>DI registration for the <c>Services/Identity</c> area. Invoked from <see cref="ServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class IdentityServiceCollectionExtensions
+{
+    /// <summary>Registers <see cref="ICurrentUserAccessor"/> (scoped — it caches the caller's <c>User</c> per request) and the <see cref="IHttpContextAccessor"/> it reads claims from.</summary>
+    public static IServiceCollection AddIdentityServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpContextAccessor();
+        services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/ServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Identity;
+
+namespace FoundryGate.Api.Services;
+
+/// <summary>
+/// The single DI entry point for FoundryGate.Api's application services, called exactly once from
+/// <c>Program.cs</c>. Each <c>Services/&lt;Area&gt;</c> folder owns its own
+/// <c>&lt;Area&gt;ServiceCollectionExtensions.Add&lt;Area&gt;Services()</c> and is invoked from here —
+/// so adding a new area is one new file plus one new line below, and <c>Program.cs</c> never becomes
+/// a merge hotspot across parallel endpoint work.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>Registers every <c>Services/&lt;Area&gt;</c> group. Order is not significant.</summary>
+    public static IServiceCollection AddFoundryGateApiServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddIdentityServices();
+        services.AddAuditServices();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Data/AppDbContext.cs
+++ b/src/FoundryGate.Data/AppDbContext.cs
@@ -57,6 +57,14 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     /// interceptor writes. Never runs under SQL Server, so the production model and the
     /// <c>FoundryGate.Database</c> dacpac are untouched.
     /// </summary>
+    /// <remarks>
+    /// Known, accepted test-only divergence: SQL Server's <c>datetimeoffset</c> preserves the offset
+    /// a value was written with (<c>-05:00</c> reads back as <c>-05:00</c>); this converter reads
+    /// everything back as <c>+00:00</c>. The instant is identical, so <c>==</c>/ordering assertions
+    /// hold, but an assertion on <c>.Offset</c> or on <c>ToString()</c> of a non-UTC value would pass
+    /// on SQL Server and fail here. Application code only ever writes UTC (interceptor +
+    /// <see cref="TimeProvider"/>), so nothing in production depends on the offset surviving.
+    /// </remarks>
     private static void ApplySqliteDateTimeOffsetConversion(ModelBuilder modelBuilder)
     {
         var converter = new ValueConverter<DateTimeOffset, long>(

--- a/src/FoundryGate.Data/AppDbContext.cs
+++ b/src/FoundryGate.Data/AppDbContext.cs
@@ -1,5 +1,6 @@
 using FoundryGate.Data.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FoundryGate.Data;
 
@@ -32,5 +33,45 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+
+        // Provider-name check rather than Database.IsSqlite(): that extension lives in the SQLite
+        // provider package, which only the test project references (Data ships SQL Server only).
+        if (Database.ProviderName == SqliteProviderName)
+        {
+            ApplySqliteDateTimeOffsetConversion(modelBuilder);
+        }
+    }
+
+    private const string SqliteProviderName = "Microsoft.EntityFrameworkCore.Sqlite";
+
+    /// <summary>
+    /// SQLite-only (i.e. test-harness-only) workaround, straight from the EF Core "SQLite
+    /// limitations" docs: SQLite has no native <see cref="DateTimeOffset"/>, and the provider refuses
+    /// to translate ordering or comparison on the TEXT it would otherwise store ("SQLite cannot order
+    /// by expressions of type 'DateTimeOffset'"). Storing every <see cref="DateTimeOffset"/> column as
+    /// its <see cref="DateTimeOffset.UtcTicks"/> instead makes <c>OrderBy</c>/<c>&gt;=</c> filters
+    /// (the audit log's date range, quota periods, review dates) translate and behave exactly as on
+    /// SQL Server. Normalizing to UTC ticks, rather than EF's built-in
+    /// <c>DateTimeOffsetToBinaryConverter</c> (which packs the offset into the low bits), means a
+    /// query parameter carrying a non-UTC offset still compares correctly against the UTC values the
+    /// interceptor writes. Never runs under SQL Server, so the production model and the
+    /// <c>FoundryGate.Database</c> dacpac are untouched.
+    /// </summary>
+    private static void ApplySqliteDateTimeOffsetConversion(ModelBuilder modelBuilder)
+    {
+        var converter = new ValueConverter<DateTimeOffset, long>(
+            value => value.UtcTicks,
+            ticks => new DateTimeOffset(ticks, TimeSpan.Zero));
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTimeOffset) || property.ClrType == typeof(DateTimeOffset?))
+                {
+                    property.SetValueConverter(converter);
+                }
+            }
+        }
     }
 }

--- a/src/FoundryGate.Data/Audit/AuditWriter.cs
+++ b/src/FoundryGate.Data/Audit/AuditWriter.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FoundryGate.Data.Entities;
+
+namespace FoundryGate.Data.Audit;
+
+/// <summary>
+/// Default <see cref="IAuditWriter"/>. Adds rows to the shared <see cref="AppDbContext"/> (never
+/// saves — see the interface remarks); <see cref="AuditLog.OccurredDate"/> comes from the injected
+/// <see cref="TimeProvider"/>, never <c>DateTimeOffset.UtcNow</c> (CONVENTIONS.md).
+/// </summary>
+public sealed class AuditWriter(AppDbContext dbContext, TimeProvider timeProvider) : IAuditWriter
+{
+    /// <summary>
+    /// Web defaults (camelCase property names, so <c>Details</c> reads like the rest of the API's
+    /// JSON) plus <see cref="ReferenceHandler.IgnoreCycles"/>: a caller who passes a tracked entity
+    /// whose navigations point back at it must get a row with <c>null</c> at the cycle, not a
+    /// serializer exception that turns their mutation into an unmapped 500.
+    /// </summary>
+    private static readonly JsonSerializerOptions DetailsSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+    };
+
+    /// <inheritdoc />
+    public AuditLog Add(User actor, string action, string targetType, string targetId, object? details)
+    {
+        ArgumentNullException.ThrowIfNull(actor);
+
+        var entry = Create(action, targetType, targetId, details);
+
+        // Navigation, not FK: an actor added in this same unit of work has UserId == 0 until
+        // SaveChanges; EF fixes up ActorUserId from the navigation at save time either way.
+        entry.ActorUser = actor;
+
+        dbContext.AuditLogs.Add(entry);
+        return entry;
+    }
+
+    /// <inheritdoc />
+    public AuditLog Add(int actorUserId, string action, string targetType, string targetId, object? details)
+    {
+        var entry = Create(action, targetType, targetId, details);
+        entry.ActorUserId = actorUserId;
+
+        dbContext.AuditLogs.Add(entry);
+        return entry;
+    }
+
+    /// <inheritdoc />
+    public AuditLog AddSystem(string action, string targetType, string targetId, object? details)
+    {
+        var entry = Create(action, targetType, targetId, details);
+
+        dbContext.AuditLogs.Add(entry);
+        return entry;
+    }
+
+    private AuditLog Create(string action, string targetType, string targetId, object? details)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        ArgumentNullException.ThrowIfNull(targetType);
+        ArgumentNullException.ThrowIfNull(targetId);
+
+        return new AuditLog
+        {
+            Action = action,
+            TargetType = targetType,
+            TargetId = targetId,
+            Details = details is null ? string.Empty : JsonSerializer.Serialize(details, DetailsSerializerOptions),
+            OccurredDate = timeProvider.GetUtcNow(),
+        };
+    }
+}

--- a/src/FoundryGate.Data/Audit/IAuditWriter.cs
+++ b/src/FoundryGate.Data/Audit/IAuditWriter.cs
@@ -1,0 +1,65 @@
+using FoundryGate.Data.Entities;
+
+namespace FoundryGate.Data.Audit;
+
+/// <summary>
+/// The one audit-row writer for every host (Api, Functions, Cli). Lives in Data — not Api — because
+/// system jobs in <c>FoundryGate.Functions</c> (monthly reset, usage sync, Entra sync) reference Data
+/// and Domain only, yet must write the same rows the Api does; two hosts must never grow two
+/// writers. Api's <c>IAuditService</c> is a thin wrapper that resolves the current caller and
+/// delegates here.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Nothing here saves.</b> Each method only <em>adds</em> the row to the shared
+/// <see cref="AppDbContext"/>; the caller's own <c>SaveChangesAsync</c> persists the mutation and its
+/// audit row in one transaction. A fire-and-forget audit (separate save, swallowed failure) can leave
+/// a mutation with no audit row or an audit row for a rolled-back mutation — for an audit trail,
+/// failing the request is the correct outcome. Pattern at every call site: mutate →
+/// <c>audit.Add(...)</c> → <c>await dbContext.SaveChangesAsync(ct)</c>.
+/// </para>
+/// <para>
+/// The methods are synchronous because they touch only the change tracker — there is no I/O to await.
+/// <c>action</c>/<c>targetType</c> should be constants from Domain's <c>AuditActions</c> /
+/// <c>AuditTargetTypes</c>. <c>details</c> is any serializable object (an anonymous
+/// <c>new { before, after }</c> is the expected shape), JSON-serialized with web (camelCase) defaults
+/// and cycle-tolerant reference handling into <see cref="AuditLog.Details"/>. Prefer projecting the
+/// fields you mean over passing a tracked entity — an entity graph serializes its navigations too.
+/// Never put a secret (an APIM key, a token) in it.
+/// </para>
+/// </remarks>
+public interface IAuditWriter
+{
+    /// <summary>
+    /// Adds a row attributed to <paramref name="actor"/> via the <see cref="AuditLog.ActorUser"/>
+    /// navigation — so an actor that has itself just been <c>Add</c>ed and not yet saved (first-login
+    /// auto-provisioning) is attributed correctly once the caller saves; EF fixes up the FK then.
+    /// </summary>
+    /// <param name="actor">The acting user (tracked, saved or not).</param>
+    /// <param name="action">What happened — an <c>AuditActions</c> constant.</param>
+    /// <param name="targetType">Kind of the affected record — an <c>AuditTargetTypes</c> constant; empty when there is no single target.</param>
+    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
+    /// <param name="details">Caller-defined detail object (before/after values), JSON-serialized; <see langword="null"/> stores an empty string.</param>
+    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
+    AuditLog Add(User actor, string action, string targetType, string targetId, object? details);
+
+    /// <summary>Adds a row attributed to an already-persisted user by <paramref name="actorUserId"/>.</summary>
+    /// <param name="actorUserId">The acting user's <c>UserId</c>.</param>
+    /// <param name="action">What happened — an <c>AuditActions</c> constant.</param>
+    /// <param name="targetType">Kind of the affected record — an <c>AuditTargetTypes</c> constant; empty when there is no single target.</param>
+    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
+    /// <param name="details">Caller-defined detail object, JSON-serialized; <see langword="null"/> stores an empty string.</param>
+    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
+    AuditLog Add(int actorUserId, string action, string targetType, string targetId, object? details);
+
+    /// <summary>
+    /// Adds a row with no human actor (<see cref="AuditLog.ActorUserId"/> = <see langword="null"/>) —
+    /// the monthly reset, usage sync, and Entra sync jobs.
+    /// </summary>
+    /// <param name="action">What happened — an <c>AuditActions</c> constant.</param>
+    /// <param name="targetType">Kind of the affected record — an <c>AuditTargetTypes</c> constant; empty when there is no single target.</param>
+    /// <param name="targetId">Identifier of the affected record as a string; empty when there is no single target.</param>
+    /// <param name="details">Caller-defined detail object, JSON-serialized; <see langword="null"/> stores an empty string.</param>
+    /// <returns>The added (not yet saved) <see cref="AuditLog"/> entity.</returns>
+    AuditLog AddSystem(string action, string targetType, string targetId, object? details);
+}

--- a/src/FoundryGate.Data/Entities/AuditLog.cs
+++ b/src/FoundryGate.Data/Entities/AuditLog.cs
@@ -7,6 +7,13 @@ namespace FoundryGate.Data.Entities;
 /// <summary>
 /// An immutable record of an admin/system action (e.g. <c>"quota.approved"</c>, <c>"key.rotated"</c>).
 /// </summary>
+/// <remarks>
+/// Indexed on <see cref="OccurredDate"/> because every page of <c>GET /audit</c> orders by it
+/// (newest first) and the date-range filter seeks on it — without the index an unfiltered admin
+/// view is a full sort of the table forever. Ascending is fine for a descending scan; SQL Server
+/// reads the index backwards. The FK index on <see cref="ActorUserId"/> is EF's implicit one.
+/// </remarks>
+[Index(nameof(OccurredDate))]
 public class AuditLog
 {
     public int AuditLogId { get; set; }

--- a/src/FoundryGate.Data/Extensions/QueryableExtensions.cs
+++ b/src/FoundryGate.Data/Extensions/QueryableExtensions.cs
@@ -1,0 +1,39 @@
+using FoundryGate.Domain.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Data.Extensions;
+
+/// <summary>
+/// The shared paging helper every "(paged)" list endpoint uses (CONVENTIONS.md §EF Core: "a
+/// shared <c>PagedResult&lt;T&gt;</c> + <c>.ToPagedAsync(page, size, ct)</c> helper in
+/// Domain/Data"). Lives in Data rather than Domain because it needs EF Core's async
+/// materialization and Domain has zero dependencies by design.
+/// </summary>
+public static class QueryableExtensions
+{
+    /// <summary>
+    /// Materializes one page of <paramref name="query"/> plus the total match count. Call it
+    /// last, after every <c>Where</c>, <c>OrderBy</c>, and projection — the query must already be
+    /// deterministically ordered or pages will overlap/skip between requests.
+    /// <paramref name="request"/> is <see cref="PagedRequest.Clamp"/>ed here so callers never
+    /// have to remember to.
+    /// </summary>
+    public static async Task<PagedResult<T>> ToPagedAsync<T>(
+        this IQueryable<T> query,
+        PagedRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var paging = request.Clamp();
+
+        var totalCount = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((paging.Page - 1) * paging.PageSize)
+            .Take(paging.PageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<T>(items, totalCount, paging.Page, paging.PageSize);
+    }
+}

--- a/src/FoundryGate.Data/ServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Data/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using FoundryGate.Data.Audit;
 using FoundryGate.Data.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,15 +6,17 @@ using Microsoft.Extensions.DependencyInjection;
 namespace FoundryGate.Data;
 
 /// <summary>
-/// DI wiring for <see cref="AppDbContext"/>. Called by every host that talks to the database
-/// (Api now; Functions/Cli in later issues) so the context, its interceptor, and the
-/// <see cref="TimeProvider"/> it depends on are configured exactly once, in one place.
+/// DI wiring for <see cref="AppDbContext"/> and the data-layer services every host shares. Called
+/// by every host that talks to the database (Api now; Functions/Cli in later issues) so the context,
+/// its interceptor, the <see cref="TimeProvider"/> it depends on, and the <see cref="IAuditWriter"/>
+/// are configured exactly once, in one place.
 /// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers <see cref="TimeProvider.System"/>, <see cref="TimestampInterceptor"/>, and
-    /// <see cref="AppDbContext"/> (SQL Server) against <paramref name="connectionString"/>.
+    /// Registers <see cref="TimeProvider.System"/>, <see cref="TimestampInterceptor"/>,
+    /// <see cref="AppDbContext"/> (SQL Server) against <paramref name="connectionString"/>, and the
+    /// scoped <see cref="IAuditWriter"/> (scoped because it adds to the same context the caller saves).
     /// </summary>
     public static IServiceCollection AddFoundryGateData(this IServiceCollection services, string connectionString)
     {
@@ -26,6 +29,8 @@ public static class ServiceCollectionExtensions
         services.AddDbContext<AppDbContext>((serviceProvider, options) =>
             options.UseSqlServer(connectionString)
                 .AddInterceptors(serviceProvider.GetRequiredService<TimestampInterceptor>()));
+
+        services.AddScoped<IAuditWriter, AuditWriter>();
 
         return services;
     }

--- a/src/FoundryGate.Database/dbo/Tables/AuditLogs.sql
+++ b/src/FoundryGate.Database/dbo/Tables/AuditLogs.sql
@@ -20,3 +20,7 @@ GO
 CREATE NONCLUSTERED INDEX [IX_AuditLogs_ActorUserId]
     ON [dbo].[AuditLogs]([ActorUserId] ASC);
 GO
+
+CREATE NONCLUSTERED INDEX [IX_AuditLogs_OccurredDate]
+    ON [dbo].[AuditLogs]([OccurredDate] ASC);
+GO

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -14,7 +14,10 @@ namespace FoundryGate.Domain.Constants;
 /// </summary>
 public static class AuditActions
 {
-    // -- Users (spec 4.1) --
+    // -- Users (spec 4.1, 7.1) --
+
+    /// <summary>First-login auto-provisioning via GET /users/me (spec &#167;7.1).</summary>
+    public const string UserProvisioned = "user.provisioned";
 
     /// <summary>PUT /users/{id}/activate.</summary>
     public const string UserActivated = "user.activated";
@@ -44,6 +47,12 @@ public static class AuditActions
     /// <summary>The scheduled monthly reset job (spec &#167;6, exact string from spec).</summary>
     public const string QuotaMonthlyReset = "quota.monthly-reset";
 
+    /// <summary>POST /quota/reset — an admin manually triggering the (idempotent) reset outside the schedule.</summary>
+    public const string QuotaAllocationReset = "quota.reset";
+
+    /// <summary>POST /requests — a developer (or an admin on their behalf) submitting a quota increase request.</summary>
+    public const string QuotaIncreaseSubmitted = "quota.requested";
+
     /// <summary>PUT /requests/{id}/approve (spec &#167;3.1, exact example string from spec).</summary>
     public const string QuotaIncreaseApproved = "quota.approved";
 
@@ -58,6 +67,19 @@ public static class AuditActions
     public const string KeyRotated = "key.rotated";
 
     public const string KeyRevoked = "key.revoked";
+
+    /// <summary>A developer revealing their own full key (spec &#167;11: "reveal action fetches directly, not stored in browser").</summary>
+    public const string KeyRevealed = "key.revealed";
+
+    // -- Usage sync (spec 5.4, issue #39) --
+
+    /// <summary>The Log Analytics → <c>QuotaAllocation.TokensUsed</c> reconciliation job (reconciliation, not enforcement).</summary>
+    public const string UsageSynced = "usage.synced";
+
+    // -- Foundry model deployments (issue #61) --
+
+    public const string FoundryDeploymentCreated = "foundry.deployment.created";
+    public const string FoundryDeploymentDeleted = "foundry.deployment.deleted";
 
     // -- Config (spec 4.6) --
 

--- a/src/FoundryGate.Domain/Constants/AuditTargetTypes.cs
+++ b/src/FoundryGate.Domain/Constants/AuditTargetTypes.cs
@@ -1,0 +1,32 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// Well-known values for <c>AuditLog.TargetType</c> (spec &#167;3.1: e.g. <c>"User"</c>,
+/// <c>"Group"</c>, <c>"Request"</c>). String constants rather than an enum for the same reason
+/// as <see cref="AuditActions"/>: the audit trail is open-ended and the column is free text.
+/// Every audit call site should pass one of these so the admin audit viewer's
+/// <c>targetType</c> filter never has to guess at spelling.
+/// </summary>
+public static class AuditTargetTypes
+{
+    /// <summary>A <c>User</c> row; <c>TargetId</c> is the <c>UserId</c>.</summary>
+    public const string User = "User";
+
+    /// <summary>A <c>Group</c> row; <c>TargetId</c> is the <c>GroupId</c>.</summary>
+    public const string Group = "Group";
+
+    /// <summary>A <c>QuotaIncreaseRequest</c> row (spec &#167;3.1's "Request"); <c>TargetId</c> is the <c>QuotaIncreaseRequestId</c>.</summary>
+    public const string QuotaIncreaseRequest = "Request";
+
+    /// <summary>A <c>QuotaAllocation</c> row; <c>TargetId</c> is the <c>QuotaAllocationId</c>.</summary>
+    public const string QuotaAllocation = "QuotaAllocation";
+
+    /// <summary>A developer's APIM subscription key; <c>TargetId</c> is the owning <c>UserId</c> (the key itself is never logged).</summary>
+    public const string ApiKey = "ApiKey";
+
+    /// <summary>A <c>SystemConfiguration</c> row; <c>TargetId</c> is the configuration <c>Key</c>.</summary>
+    public const string SystemConfiguration = "SystemConfiguration";
+
+    /// <summary>An Azure AI Foundry model deployment; <c>TargetId</c> is the deployment name.</summary>
+    public const string FoundryDeployment = "FoundryDeployment";
+}

--- a/src/FoundryGate.Domain/Constants/GatewayTiers.cs
+++ b/src/FoundryGate.Domain/Constants/GatewayTiers.cs
@@ -1,0 +1,43 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// APIM product ids for the gateway's quota tiers. Quota tiers are APIM <em>products</em>, not
+/// per-user numbers, because APIM's <c>token-quota</c> accepts literals only — policy expressions
+/// are rejected (CLAUDE.md ground truth, validated live 2026-09-01) — so a single policy cannot
+/// read a per-developer budget. Each tier is a product carrying its own rendered
+/// <c>llm-token-limit</c> policy, and the control plane sets a developer's quota by issuing their
+/// APIM subscription against the matching tier product (#82). Supersedes the single-product model
+/// behind <see cref="SystemConfigurationKeys.ApimProductId"/>.
+/// </summary>
+/// <remarks>
+/// These values MUST match the <c>name</c> of each entry in <c>infra/main.bicep</c>'s
+/// <c>quotaTiers</c> parameter (surfaced as the deployment's <c>productIds</c> output). Renaming a
+/// tier in one place without the other silently breaks subscription provisioning against the
+/// gateway; <c>GatewayTiersTests</c> in FoundryGate.Tests.Predeployment cross-checks the two.
+/// </remarks>
+public static class GatewayTiers
+{
+    /// <summary>Everyday agent usage tier (5M tokens/month, 20K TPM as shipped in <c>infra/main.bicep</c>).</summary>
+    public const string Standard = "standard";
+
+    /// <summary>Heavy agentic workloads tier (20M tokens/month, 40K TPM as shipped in <c>infra/main.bicep</c>).</summary>
+    public const string Power = "power";
+
+    /// <summary>No gateway-enforced monthly budget; burst smoothing only. Monthly oversight is the control plane's job.</summary>
+    public const string Unlimited = "unlimited";
+
+    /// <summary>
+    /// The tier a newly provisioned developer lands on. Mirrors the bicep <c>defaultProductId</c>
+    /// output (<c>quotaTiers[0].name</c>), so the first entry in the bicep array must stay
+    /// <see cref="Standard"/>.
+    /// </summary>
+    public const string Default = Standard;
+
+    /// <summary>Every tier product id, in the same order as <c>infra/main.bicep</c>'s <c>quotaTiers</c>.</summary>
+    public static readonly IReadOnlyList<string> All =
+    [
+        Standard,
+        Power,
+        Unlimited,
+    ];
+}

--- a/src/FoundryGate.Domain/Constants/SystemConfigurationKeys.cs
+++ b/src/FoundryGate.Domain/Constants/SystemConfigurationKeys.cs
@@ -17,7 +17,13 @@ public static class SystemConfigurationKeys
     /// <summary>APIM gateway base URL shown to developers on <c>/me</c> (see <see cref="Config.Contracts.GatewayConnectionInfo"/>).</summary>
     public const string ApimGatewayUrl = nameof(ApimGatewayUrl);
 
-    /// <summary>APIM product name covering the Foundry routes (spec &#167;5.1).</summary>
+    /// <summary>
+    /// <b>Legacy (single-product model).</b> APIM product name covering the Foundry routes (spec
+    /// &#167;5.1), from before quota tiers became per-tier APIM products. Superseded by
+    /// <see cref="GatewayTiers"/>: a developer's subscription is issued against the product for
+    /// their tier (<see cref="GatewayTiers.Default"/> for new users), not against this one value.
+    /// Kept because the seeded reference data references it; do not remove without a migration.
+    /// </summary>
     public const string ApimProductId = nameof(ApimProductId);
 
     /// <summary>ARM resource ID of the Azure AI Foundry account.</summary>

--- a/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
@@ -1,0 +1,203 @@
+using FoundryGate.Data;
+using FoundryGate.Data.Entities;
+using FoundryGate.Data.Interceptors;
+using FoundryGate.Data.Seeding;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace FoundryGate.Tests.Predeployment.Api;
+
+/// <summary>
+/// Integration-test host for FoundryGate.Api: the real <c>Program.cs</c> pipeline (auth filter,
+/// exception handler, controllers, DI) with two substitutions — <see cref="AppDbContext"/> runs on a
+/// single kept-open SQLite in-memory connection instead of SQL Server, and
+/// <see cref="TestAuthHandler"/> replaces Entra bearer auth so requests can act as any identity via
+/// headers. Hermetic: no docker, no Azure. Reference data (<c>SystemConfiguration</c> defaults) is
+/// seeded on startup exactly as a deploy would.
+/// </summary>
+/// <remarks>
+/// Use as <c>IClassFixture&lt;ApiTestFactory&gt;</c>: one factory (one database) per test class,
+/// shared by that class's tests — so seed rows with unique markers (oids, actions, target ids)
+/// rather than asserting on absolute counts. <see cref="TimeProvider"/> is the app's clock; move it
+/// to control anything time-dependent (quota periods, audit timestamps).
+/// </remarks>
+public sealed class ApiTestFactory : WebApplicationFactory<Program>
+{
+    private static readonly DateTimeOffset DefaultNow = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SqliteConnection _connection;
+
+    public ApiTestFactory()
+    {
+        // ":memory:" is per-connection, so every DbContext must share this one instance; keeping it
+        // open for the factory's lifetime is what keeps the database alive between scopes.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    /// <summary>The host's <see cref="System.TimeProvider"/>: <c>2026-09-01T12:00:00Z</c> until a test moves it.</summary>
+    public MutableTimeProvider TimeProvider { get; } = new(DefaultNow);
+
+    /// <summary>
+    /// A client authenticated as <paramref name="oid"/> (with the <c>FoundryGate.Admin</c> role when
+    /// <paramref name="isAdmin"/>), via <see cref="TestAuthHandler"/> headers. Use the plain
+    /// <see cref="WebApplicationFactory{TEntryPoint}.CreateClient()"/> for an anonymous caller.
+    /// </summary>
+    public HttpClient CreateClientAs(string oid, bool isAdmin = false, string? name = null, string? email = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oid);
+
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.OidHeader, oid);
+
+        if (isAdmin)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, RoleNames.Admin);
+        }
+
+        if (name is not null)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.NameHeader, name);
+        }
+
+        if (email is not null)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.EmailHeader, email);
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// A fresh <see cref="AppDbContext"/> on the shared database, independent of any request scope —
+    /// for arranging rows and asserting on what an endpoint persisted. Dispose it. Runs the real
+    /// <see cref="TimestampInterceptor"/> against <see cref="TimeProvider"/>.
+    /// </summary>
+    public AppDbContext CreateDbContext()
+    {
+        // WebApplicationFactory builds the host lazily (first CreateClient()/Services access), and
+        // that's where EnsureCreated + seeding run — a test that arranges rows before sending its
+        // first request would otherwise hit an empty database with no tables.
+        _ = Services;
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(new TimestampInterceptor(TimeProvider))
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    /// <summary>
+    /// Inserts a <see cref="User"/> and returns it (detached). Defaults to a fresh random oid and
+    /// email so callers can seed as many as they like without unique-index collisions; pass
+    /// <paramref name="entraObjectId"/> to line the row up with a <see cref="CreateClientAs"/> client.
+    /// </summary>
+    public async Task<User> SeedUserAsync(
+        string? entraObjectId = null,
+        string displayName = "Test User",
+        string? email = null,
+        bool isActive = true,
+        Action<User>? configure = null)
+    {
+        await using var dbContext = CreateDbContext();
+
+        var user = new User
+        {
+            EntraObjectId = entraObjectId ?? Guid.NewGuid().ToString(),
+            DisplayName = displayName,
+            Email = email ?? $"{Guid.NewGuid():N}@contoso.test",
+            IsActive = isActive,
+        };
+        configure?.Invoke(user);
+
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        return user;
+    }
+
+    /// <inheritdoc />
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.UseEnvironment("local");
+
+        // AppSettings.ValidateRecursively() needs these populated; none is ever used to reach Azure or
+        // SQL Server here (the DbContext registration is replaced below and bearer auth is never the
+        // default scheme), so the factory stays hermetic even if appsettings.local.json changes.
+        builder.ConfigureAppConfiguration((_, configuration) =>
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:FoundryGate"] =
+                    "Server=127.0.0.1,1;Database=FoundryGateTest;Connect Timeout=1;TrustServerCertificate=True",
+                ["AzureAd:Instance"] = "https://login.microsoftonline.com/",
+                ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
+                ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000000",
+                ["AzureAd:Audience"] = "api://00000000-0000-0000-0000-000000000000",
+            }));
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Swap SQL Server → SQLite. EF Core 9+ registers the provider through
+            // IDbContextOptionsConfiguration<TContext> entries as well as DbContextOptions<TContext>;
+            // all of them must go or EF sees two providers configured on one context.
+            services.RemoveAll<IDbContextOptionsConfiguration<AppDbContext>>();
+            services.RemoveAll<DbContextOptions<AppDbContext>>();
+            services.RemoveAll<DbContextOptions>();
+            services.RemoveAll<AppDbContext>();
+            services.AddDbContext<AppDbContext>((serviceProvider, options) =>
+                options.UseSqlite(_connection)
+                    .AddInterceptors(serviceProvider.GetRequiredService<TimestampInterceptor>()));
+
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(TimeProvider);
+
+            // Registered after Program.cs's AddMicrosoftIdentityWebApiAuthentication, so this
+            // Configure<AuthenticationOptions> runs last and wins the default-scheme selection. The
+            // JwtBearer scheme still exists; it just isn't consulted unless asked for by name.
+            services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = TestAuthHandler.SchemeName;
+                options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+            }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+        });
+    }
+
+    /// <inheritdoc />
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+
+        using var scope = host.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        dbContext.Database.EnsureCreated();
+        ReferenceDataSeeder.SeedAsync(dbContext).GetAwaiter().GetResult();
+
+        return host;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            _connection.Dispose();
+        }
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/AuditEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/AuditEndpointTests.cs
@@ -1,0 +1,215 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Audit.Contracts;
+using FoundryGate.Domain.Common;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// End-to-end coverage of <c>GET /api/v1/audit</c> through the real pipeline — and, since this is
+/// the first controller under <c>/api/v1</c>, the first proof of the auth contract plans/04 deferred:
+/// anonymous → 401, authenticated non-admin → 403 on an admin-only route, admin → 200.
+/// </summary>
+public class AuditEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string AuditPath = "/api/v1/audit";
+
+    [Fact]
+    public async Task Anonymous_request_returns_401()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri(AuditPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Authenticated_non_admin_returns_403()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: false);
+
+        var response = await client.GetAsync(new Uri(AuditPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_returns_200_with_the_paged_envelope_and_default_paging()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await client.GetAsync(new Uri(AuditPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        var page = await response.Content.ReadFromJsonAsync<PagedResult<AuditLogEntryResponse>>(JsonOptions);
+        Assert.NotNull(page);
+        Assert.Equal(1, page.Page);
+        Assert.Equal(PagedRequest.DefaultPageSize, page.PageSize);
+    }
+
+    [Fact]
+    public async Task Results_are_newest_first_and_carry_the_actors_display_name()
+    {
+        var marker = Marker();
+        var actor = await factory.SeedUserAsync(displayName: "Grace Hopper");
+        await SeedAuditAsync(actor.UserId, AuditActions.GroupCreated, AuditTargetTypes.Group, marker, BaseTime);
+        await SeedAuditAsync(actor.UserId, AuditActions.GroupUpdated, AuditTargetTypes.Group, marker, BaseTime.AddHours(2));
+        await SeedAuditAsync(null, AuditActions.GroupDeleted, AuditTargetTypes.Group, marker, BaseTime.AddHours(1));
+
+        var page = await GetPageAsync($"?targetId={marker}");
+
+        Assert.Equal(3, page.TotalCount);
+        Assert.Equal(
+            [AuditActions.GroupUpdated, AuditActions.GroupDeleted, AuditActions.GroupCreated],
+            page.Items.Select(i => i.Action));
+        Assert.Equal("Grace Hopper", page.Items[0].ActorDisplayName);
+        Assert.Null(page.Items[1].ActorDisplayName);
+        Assert.Null(page.Items[1].ActorUserId);
+    }
+
+    [Fact]
+    public async Task Paging_honours_page_and_pageSize_and_reports_totals()
+    {
+        var marker = Marker();
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedAuditAsync(null, AuditActions.UsageSynced, AuditTargetTypes.QuotaAllocation, marker, BaseTime.AddMinutes(i));
+        }
+
+        var page = await GetPageAsync($"?targetId={marker}&page=2&pageSize=2");
+
+        Assert.Equal(5, page.TotalCount);
+        Assert.Equal(2, page.Page);
+        Assert.Equal(2, page.PageSize);
+        Assert.Equal(3, page.TotalPages);
+        Assert.Equal(2, page.Items.Count);
+        // Newest first overall → page 2 of size 2 is the 3rd and 4th newest (minutes 2 and 1).
+        Assert.Equal([BaseTime.AddMinutes(2), BaseTime.AddMinutes(1)], page.Items.Select(i => i.OccurredDate));
+    }
+
+    [Fact]
+    public async Task Filter_by_actorUserId_returns_only_that_actors_rows()
+    {
+        var marker = Marker();
+        var alice = await factory.SeedUserAsync(displayName: "Alice");
+        var bob = await factory.SeedUserAsync(displayName: "Bob");
+        await SeedAuditAsync(alice.UserId, AuditActions.UserActivated, AuditTargetTypes.User, marker, BaseTime);
+        await SeedAuditAsync(bob.UserId, AuditActions.UserActivated, AuditTargetTypes.User, marker, BaseTime);
+
+        var page = await GetPageAsync($"?targetId={marker}&actorUserId={alice.UserId}");
+
+        var entry = Assert.Single(page.Items);
+        Assert.Equal(alice.UserId, entry.ActorUserId);
+        Assert.Equal("Alice", entry.ActorDisplayName);
+    }
+
+    [Fact]
+    public async Task Filter_by_action_is_an_exact_match()
+    {
+        var marker = Marker();
+        await SeedAuditAsync(null, AuditActions.KeyRotated, AuditTargetTypes.ApiKey, marker, BaseTime);
+        await SeedAuditAsync(null, AuditActions.KeyRevoked, AuditTargetTypes.ApiKey, marker, BaseTime);
+
+        var page = await GetPageAsync($"?targetId={marker}&action={AuditActions.KeyRotated}");
+
+        var entry = Assert.Single(page.Items);
+        Assert.Equal(AuditActions.KeyRotated, entry.Action);
+    }
+
+    [Fact]
+    public async Task Filter_by_targetType_returns_only_that_type()
+    {
+        var marker = Marker();
+        await SeedAuditAsync(null, AuditActions.ConfigUpdated, AuditTargetTypes.SystemConfiguration, marker, BaseTime);
+        await SeedAuditAsync(null, AuditActions.GroupCreated, AuditTargetTypes.Group, marker, BaseTime);
+
+        var page = await GetPageAsync($"?targetId={marker}&targetType={AuditTargetTypes.SystemConfiguration}");
+
+        var entry = Assert.Single(page.Items);
+        Assert.Equal(AuditTargetTypes.SystemConfiguration, entry.TargetType);
+    }
+
+    [Fact]
+    public async Task Filter_by_targetId_returns_only_that_target()
+    {
+        var mine = Marker();
+        var theirs = Marker();
+        await SeedAuditAsync(null, AuditActions.GroupCreated, AuditTargetTypes.Group, mine, BaseTime);
+        await SeedAuditAsync(null, AuditActions.GroupCreated, AuditTargetTypes.Group, theirs, BaseTime);
+
+        var page = await GetPageAsync($"?targetId={mine}");
+
+        var entry = Assert.Single(page.Items);
+        Assert.Equal(mine, entry.TargetId);
+    }
+
+    [Fact]
+    public async Task Filter_by_date_range_is_inclusive_at_both_ends()
+    {
+        var marker = Marker();
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime.AddDays(-1));
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime);
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime.AddDays(1));
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime.AddDays(2));
+
+        var from = Uri.EscapeDataString(BaseTime.ToString("O"));
+        var to = Uri.EscapeDataString(BaseTime.AddDays(1).ToString("O"));
+        var page = await GetPageAsync($"?targetId={marker}&fromDate={from}&toDate={to}");
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.Equal([BaseTime.AddDays(1), BaseTime], page.Items.Select(i => i.OccurredDate));
+        Assert.All(page.Items, i => Assert.Null(i.TargetType)); // "" in the row → null on the wire
+    }
+
+    [Fact]
+    public async Task Date_filter_with_a_non_utc_offset_compares_by_instant_not_by_wall_clock()
+    {
+        var marker = Marker();
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime.AddHours(-1));
+        await SeedAuditAsync(null, AuditActions.UsageSynced, string.Empty, marker, BaseTime.AddHours(1));
+
+        // 07:00-05:00 is the same instant as BaseTime (12:00Z); only the +1h row is at/after it.
+        var from = Uri.EscapeDataString(BaseTime.ToOffset(TimeSpan.FromHours(-5)).ToString("O"));
+        var page = await GetPageAsync($"?targetId={marker}&fromDate={from}");
+
+        var entry = Assert.Single(page.Items);
+        Assert.Equal(BaseTime.AddHours(1), entry.OccurredDate);
+    }
+
+    private static string Marker() => Guid.NewGuid().ToString("N");
+
+    private async Task<PagedResult<AuditLogEntryResponse>> GetPageAsync(string queryString)
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await client.GetAsync(new Uri(AuditPath + queryString, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PagedResult<AuditLogEntryResponse>>(JsonOptions);
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private async Task SeedAuditAsync(int? actorUserId, string action, string targetType, string targetId, DateTimeOffset occurredDate)
+    {
+        await using var dbContext = factory.CreateDbContext();
+        dbContext.AuditLogs.Add(new AuditLog
+        {
+            ActorUserId = actorUserId,
+            Action = action,
+            TargetType = targetType,
+            TargetId = targetId,
+            Details = string.Empty,
+            OccurredDate = occurredDate,
+        });
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Audit/AuditServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Audit/AuditServiceTests.cs
@@ -1,143 +1,76 @@
-using System.Text.Json;
+using System.Security.Claims;
 using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
+using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Audit.Contracts;
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Tests.Predeployment.Data;
 using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
 
 namespace FoundryGate.Tests.Predeployment.Api.Services.Audit;
 
 /// <summary>
-/// Write-side contract of <see cref="AuditService"/>: actor attribution, JSON details, the
-/// <see cref="TimeProvider"/> timestamp, and — the design decision worth pinning — that it adds to
-/// the caller's context without saving, so mutation and audit row commit together.
+/// The Api wrapper's own contract: current-caller attribution through the <em>real</em>
+/// <see cref="CurrentUserAccessor"/> + <see cref="AuditWriter"/> (so the first-login pattern is tested
+/// end-to-end at the service level), the 403 for an unprovisioned caller, and the admin read query.
+/// Row-building semantics (JSON, timestamps, no-save) are covered in <c>AuditWriterTests</c>.
 /// </summary>
 public class AuditServiceTests : InMemoryDatabaseTest
 {
     private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
 
     private readonly MutableTimeProvider _timeProvider = new(Now);
-    private readonly StubCurrentUserAccessor _currentUser = new();
 
     [Fact]
-    public async Task LogAsync_attributes_the_row_to_the_current_user_and_serializes_details_as_camelCase_json()
+    public async Task LogAsync_attributes_the_row_to_the_caller_resolved_from_the_oid_claim()
     {
-        var actor = await SeedActorAsync();
-        _currentUser.User = actor;
-        var service = CreateService();
+        var actor = await SeedUserAsync("Ada Lovelace");
+        var service = CreateService(actor.EntraObjectId);
 
-        var entry = await service.LogAsync(
-            AuditActions.UserQuotaChanged,
-            AuditTargetTypes.User,
-            "42",
-            new { Before = 1_000_000L, After = (long?)null, IsUnlimited = true },
-            CancellationToken.None);
+        var entry = await service.LogAsync(AuditActions.UserQuotaChanged, AuditTargetTypes.User, "42", new { After = 5 }, CancellationToken.None);
         await Context.SaveChangesAsync();
 
         var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
         Assert.Equal(actor.UserId, saved.ActorUserId);
-        Assert.Equal(AuditActions.UserQuotaChanged, saved.Action);
-        Assert.Equal(AuditTargetTypes.User, saved.TargetType);
-        Assert.Equal("42", saved.TargetId);
-
-        using var details = JsonDocument.Parse(saved.Details);
-        Assert.Equal(1_000_000L, details.RootElement.GetProperty("before").GetInt64());
-        Assert.Equal(JsonValueKind.Null, details.RootElement.GetProperty("after").ValueKind);
-        Assert.True(details.RootElement.GetProperty("isUnlimited").GetBoolean());
+        Assert.Equal("{\"after\":5}", saved.Details);
     }
 
     [Fact]
-    public async Task LogAsync_stamps_OccurredDate_from_the_injected_TimeProvider()
+    public async Task LogAsync_attributes_a_caller_whose_User_was_added_but_not_yet_saved_the_auto_provision_pattern()
     {
-        _currentUser.User = await SeedActorAsync();
-        var service = CreateService();
-        var frozen = new DateTimeOffset(2031, 2, 3, 4, 5, 6, TimeSpan.Zero);
-        _timeProvider.SetUtcNow(frozen);
+        // What GET /users/me (#28) does on first login, in one unit of work: Add user → LogAsync →
+        // SaveChanges. Before the fix, TryGetUserAsync went straight to the database, missed the
+        // unsaved row, and LogAsync 403'd.
+        var oid = Guid.NewGuid().ToString();
+        var service = CreateService(oid);
+        var newUser = new User { EntraObjectId = oid, DisplayName = "New Joiner", Email = "new@contoso.test" };
+        Context.Users.Add(newUser);
 
-        var entry = await service.LogAsync(AuditActions.UserActivated, AuditTargetTypes.User, "1", null, CancellationToken.None);
+        var entry = await service.LogAsync(AuditActions.UserProvisioned, AuditTargetTypes.User, string.Empty, null, CancellationToken.None);
         await Context.SaveChangesAsync();
 
-        Assert.Equal(frozen, entry.OccurredDate);
+        Assert.Same(newUser, entry.ActorUser);
         var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
-        Assert.Equal(frozen, saved.OccurredDate); // survives the SQLite round-trip, too
-    }
-
-    [Fact]
-    public async Task LogAsync_adds_to_the_context_but_does_not_save_so_the_caller_commits_mutation_and_audit_atomically()
-    {
-        _currentUser.User = await SeedActorAsync();
-        var service = CreateService();
-
-        var entry = await service.LogAsync(AuditActions.GroupCreated, AuditTargetTypes.Group, "7", null, CancellationToken.None);
-
-        Assert.Equal(EntityState.Added, Context.Entry(entry).State);
-        Assert.Equal(0, await Context.AuditLogs.AsNoTracking().CountAsync());
-
-        await Context.SaveChangesAsync();
-
-        Assert.Equal(1, await Context.AuditLogs.AsNoTracking().CountAsync());
-    }
-
-    [Fact]
-    public async Task LogAsync_with_null_details_stores_an_empty_string_not_the_literal_null()
-    {
-        _currentUser.User = await SeedActorAsync();
-        var service = CreateService();
-
-        var entry = await service.LogAsync(AuditActions.UserDeactivated, AuditTargetTypes.User, "1", null, CancellationToken.None);
-
-        Assert.Equal(string.Empty, entry.Details);
+        Assert.Equal(newUser.UserId, saved.ActorUserId);
+        Assert.NotEqual(0, saved.ActorUserId);
     }
 
     [Fact]
     public async Task LogAsync_throws_UnauthorizedAccessException_when_the_caller_has_no_User_row()
     {
-        _currentUser.User = null;
-        _currentUser.EntraObjectId = "no-such-user";
-        var service = CreateService();
+        var service = CreateService("no-such-user");
 
         var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             service.LogAsync(AuditActions.GroupCreated, AuditTargetTypes.Group, "7", null, CancellationToken.None));
 
         Assert.Contains("no-such-user", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("GET /users/me", exception.Message, StringComparison.Ordinal);
         Assert.Empty(Context.ChangeTracker.Entries<AuditLog>());
-    }
-
-    [Fact]
-    public async Task LogAsync_explicit_actor_overload_accepts_null_for_system_actors_and_never_touches_the_current_user()
-    {
-        // No User set and a throwing accessor: a system job (Functions) has no HttpContext at all.
-        _currentUser.ThrowOnAccess = true;
-        var service = CreateService();
-
-        var entry = await service.LogAsync(
-            actorUserId: null,
-            AuditActions.QuotaMonthlyReset,
-            string.Empty,
-            string.Empty,
-            new { PeriodYear = 2026, PeriodMonth = 9, AllocationsWritten = 12 },
-            CancellationToken.None);
-        await Context.SaveChangesAsync();
-
-        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
-        Assert.Null(saved.ActorUserId);
-        Assert.Equal(AuditActions.QuotaMonthlyReset, saved.Action);
-        Assert.Contains("\"periodMonth\":9", saved.Details, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task LogAsync_explicit_actor_overload_records_the_given_UserId()
-    {
-        var actor = await SeedActorAsync();
-        var service = CreateService();
-
-        var entry = await service.LogAsync(actor.UserId, AuditActions.KeyRotated, AuditTargetTypes.ApiKey, actor.UserId.ToString(), null, CancellationToken.None);
-
-        Assert.Equal(actor.UserId, entry.ActorUserId);
     }
 
     [Theory]
@@ -145,25 +78,24 @@ public class AuditServiceTests : InMemoryDatabaseTest
     [InlineData("   ")]
     public async Task LogAsync_rejects_a_blank_action(string action)
     {
-        _currentUser.User = await SeedActorAsync();
-        var service = CreateService();
+        var actor = await SeedUserAsync("Ada Lovelace");
+        var service = CreateService(actor.EntraObjectId);
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             service.LogAsync(action, AuditTargetTypes.User, "1", null, CancellationToken.None));
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            service.LogAsync(null, action, AuditTargetTypes.User, "1", null, CancellationToken.None));
     }
 
     [Fact]
     public async Task QueryAsync_returns_newest_first_and_maps_empty_target_and_details_to_null()
     {
-        var actor = await SeedActorAsync(displayName: "Grace Hopper");
-        var service = CreateService();
+        var actor = await SeedUserAsync("Grace Hopper");
+        var writer = new AuditWriter(Context, _timeProvider);
+        var service = CreateService(actor.EntraObjectId);
 
         _timeProvider.SetUtcNow(Now);
-        var older = await service.LogAsync(actor.UserId, AuditActions.GroupCreated, AuditTargetTypes.Group, "1", new { Name = "A" }, CancellationToken.None);
+        var older = writer.Add(actor, AuditActions.GroupCreated, AuditTargetTypes.Group, "1", new { Name = "A" });
         _timeProvider.SetUtcNow(Now.AddMinutes(5));
-        var newer = await service.LogAsync(null, AuditActions.UsageSynced, string.Empty, string.Empty, null, CancellationToken.None);
+        var newer = writer.AddSystem(AuditActions.UsageSynced, string.Empty, string.Empty, null);
         await Context.SaveChangesAsync();
 
         var page = await service.QueryAsync(new AuditLogQuery(null, null, null, null, null, null), new PagedRequest(), CancellationToken.None);
@@ -186,9 +118,16 @@ public class AuditServiceTests : InMemoryDatabaseTest
         Assert.Equal("{\"name\":\"A\"}", human.Details);
     }
 
-    private AuditService CreateService() => new(Context, _currentUser, _timeProvider);
+    /// <summary>Wires the real accessor + real writer over this test's context, as the DI container would per request.</summary>
+    private AuditService CreateService(string oid)
+    {
+        var identity = new ClaimsIdentity([new Claim(ClaimConstants.Oid, oid)], "TestAuth", nameType: ClaimConstants.Name, roleType: ClaimConstants.Roles);
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
+        return new AuditService(Context, new AuditWriter(Context, _timeProvider), accessor);
+    }
 
-    private async Task<User> SeedActorAsync(string displayName = "Ada Lovelace")
+    private async Task<User> SeedUserAsync(string displayName)
     {
         var user = new User
         {
@@ -199,35 +138,5 @@ public class AuditServiceTests : InMemoryDatabaseTest
         Context.Users.Add(user);
         await Context.SaveChangesAsync();
         return user;
-    }
-
-    /// <summary>Hand-rolled stub (no mocking library in this repo): returns a preset user, or throws like the real accessor does off-request.</summary>
-    private sealed class StubCurrentUserAccessor : ICurrentUserAccessor
-    {
-        private string _entraObjectId = "stub-oid";
-
-        public User? User { get; set; }
-
-        public bool ThrowOnAccess { get; set; }
-
-        public string EntraObjectId
-        {
-            get => ThrowOnAccess ? throw new UnauthorizedAccessException("no principal") : _entraObjectId;
-            set => _entraObjectId = value;
-        }
-
-        public bool IsAdmin => ThrowOnAccess ? throw new UnauthorizedAccessException("no principal") : false;
-
-        public string? DisplayName => User?.DisplayName;
-
-        public string? Email => User?.Email;
-
-        public Task<User?> TryGetUserAsync(CancellationToken cancellationToken) =>
-            ThrowOnAccess
-                ? throw new UnauthorizedAccessException("no principal")
-                : Task.FromResult(User);
-
-        public async Task<User> GetRequiredUserAsync(CancellationToken cancellationToken) =>
-            await TryGetUserAsync(cancellationToken) ?? throw new KeyNotFoundException("no user");
     }
 }

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Audit/AuditServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Audit/AuditServiceTests.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Audit.Contracts;
+using FoundryGate.Domain.Common;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Audit;
+
+/// <summary>
+/// Write-side contract of <see cref="AuditService"/>: actor attribution, JSON details, the
+/// <see cref="TimeProvider"/> timestamp, and — the design decision worth pinning — that it adds to
+/// the caller's context without saving, so mutation and audit row commit together.
+/// </summary>
+public class AuditServiceTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly MutableTimeProvider _timeProvider = new(Now);
+    private readonly StubCurrentUserAccessor _currentUser = new();
+
+    [Fact]
+    public async Task LogAsync_attributes_the_row_to_the_current_user_and_serializes_details_as_camelCase_json()
+    {
+        var actor = await SeedActorAsync();
+        _currentUser.User = actor;
+        var service = CreateService();
+
+        var entry = await service.LogAsync(
+            AuditActions.UserQuotaChanged,
+            AuditTargetTypes.User,
+            "42",
+            new { Before = 1_000_000L, After = (long?)null, IsUnlimited = true },
+            CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(actor.UserId, saved.ActorUserId);
+        Assert.Equal(AuditActions.UserQuotaChanged, saved.Action);
+        Assert.Equal(AuditTargetTypes.User, saved.TargetType);
+        Assert.Equal("42", saved.TargetId);
+
+        using var details = JsonDocument.Parse(saved.Details);
+        Assert.Equal(1_000_000L, details.RootElement.GetProperty("before").GetInt64());
+        Assert.Equal(JsonValueKind.Null, details.RootElement.GetProperty("after").ValueKind);
+        Assert.True(details.RootElement.GetProperty("isUnlimited").GetBoolean());
+    }
+
+    [Fact]
+    public async Task LogAsync_stamps_OccurredDate_from_the_injected_TimeProvider()
+    {
+        _currentUser.User = await SeedActorAsync();
+        var service = CreateService();
+        var frozen = new DateTimeOffset(2031, 2, 3, 4, 5, 6, TimeSpan.Zero);
+        _timeProvider.SetUtcNow(frozen);
+
+        var entry = await service.LogAsync(AuditActions.UserActivated, AuditTargetTypes.User, "1", null, CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(frozen, entry.OccurredDate);
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(frozen, saved.OccurredDate); // survives the SQLite round-trip, too
+    }
+
+    [Fact]
+    public async Task LogAsync_adds_to_the_context_but_does_not_save_so_the_caller_commits_mutation_and_audit_atomically()
+    {
+        _currentUser.User = await SeedActorAsync();
+        var service = CreateService();
+
+        var entry = await service.LogAsync(AuditActions.GroupCreated, AuditTargetTypes.Group, "7", null, CancellationToken.None);
+
+        Assert.Equal(EntityState.Added, Context.Entry(entry).State);
+        Assert.Equal(0, await Context.AuditLogs.AsNoTracking().CountAsync());
+
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(1, await Context.AuditLogs.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task LogAsync_with_null_details_stores_an_empty_string_not_the_literal_null()
+    {
+        _currentUser.User = await SeedActorAsync();
+        var service = CreateService();
+
+        var entry = await service.LogAsync(AuditActions.UserDeactivated, AuditTargetTypes.User, "1", null, CancellationToken.None);
+
+        Assert.Equal(string.Empty, entry.Details);
+    }
+
+    [Fact]
+    public async Task LogAsync_throws_UnauthorizedAccessException_when_the_caller_has_no_User_row()
+    {
+        _currentUser.User = null;
+        _currentUser.EntraObjectId = "no-such-user";
+        var service = CreateService();
+
+        var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            service.LogAsync(AuditActions.GroupCreated, AuditTargetTypes.Group, "7", null, CancellationToken.None));
+
+        Assert.Contains("no-such-user", exception.Message, StringComparison.Ordinal);
+        Assert.Empty(Context.ChangeTracker.Entries<AuditLog>());
+    }
+
+    [Fact]
+    public async Task LogAsync_explicit_actor_overload_accepts_null_for_system_actors_and_never_touches_the_current_user()
+    {
+        // No User set and a throwing accessor: a system job (Functions) has no HttpContext at all.
+        _currentUser.ThrowOnAccess = true;
+        var service = CreateService();
+
+        var entry = await service.LogAsync(
+            actorUserId: null,
+            AuditActions.QuotaMonthlyReset,
+            string.Empty,
+            string.Empty,
+            new { PeriodYear = 2026, PeriodMonth = 9, AllocationsWritten = 12 },
+            CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Null(saved.ActorUserId);
+        Assert.Equal(AuditActions.QuotaMonthlyReset, saved.Action);
+        Assert.Contains("\"periodMonth\":9", saved.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LogAsync_explicit_actor_overload_records_the_given_UserId()
+    {
+        var actor = await SeedActorAsync();
+        var service = CreateService();
+
+        var entry = await service.LogAsync(actor.UserId, AuditActions.KeyRotated, AuditTargetTypes.ApiKey, actor.UserId.ToString(), null, CancellationToken.None);
+
+        Assert.Equal(actor.UserId, entry.ActorUserId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task LogAsync_rejects_a_blank_action(string action)
+    {
+        _currentUser.User = await SeedActorAsync();
+        var service = CreateService();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.LogAsync(action, AuditTargetTypes.User, "1", null, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.LogAsync(null, action, AuditTargetTypes.User, "1", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task QueryAsync_returns_newest_first_and_maps_empty_target_and_details_to_null()
+    {
+        var actor = await SeedActorAsync(displayName: "Grace Hopper");
+        var service = CreateService();
+
+        _timeProvider.SetUtcNow(Now);
+        var older = await service.LogAsync(actor.UserId, AuditActions.GroupCreated, AuditTargetTypes.Group, "1", new { Name = "A" }, CancellationToken.None);
+        _timeProvider.SetUtcNow(Now.AddMinutes(5));
+        var newer = await service.LogAsync(null, AuditActions.UsageSynced, string.Empty, string.Empty, null, CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        var page = await service.QueryAsync(new AuditLogQuery(null, null, null, null, null, null), new PagedRequest(), CancellationToken.None);
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.Equal([newer.AuditLogId, older.AuditLogId], page.Items.Select(i => i.AuditLogId));
+
+        var system = page.Items[0];
+        Assert.Null(system.ActorUserId);
+        Assert.Null(system.ActorDisplayName);
+        Assert.Null(system.TargetType);
+        Assert.Null(system.TargetId);
+        Assert.Null(system.Details);
+
+        var human = page.Items[1];
+        Assert.Equal(actor.UserId, human.ActorUserId);
+        Assert.Equal("Grace Hopper", human.ActorDisplayName);
+        Assert.Equal(AuditTargetTypes.Group, human.TargetType);
+        Assert.Equal("1", human.TargetId);
+        Assert.Equal("{\"name\":\"A\"}", human.Details);
+    }
+
+    private AuditService CreateService() => new(Context, _currentUser, _timeProvider);
+
+    private async Task<User> SeedActorAsync(string displayName = "Ada Lovelace")
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = displayName,
+            Email = $"{Guid.NewGuid():N}@contoso.test",
+        };
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    /// <summary>Hand-rolled stub (no mocking library in this repo): returns a preset user, or throws like the real accessor does off-request.</summary>
+    private sealed class StubCurrentUserAccessor : ICurrentUserAccessor
+    {
+        private string _entraObjectId = "stub-oid";
+
+        public User? User { get; set; }
+
+        public bool ThrowOnAccess { get; set; }
+
+        public string EntraObjectId
+        {
+            get => ThrowOnAccess ? throw new UnauthorizedAccessException("no principal") : _entraObjectId;
+            set => _entraObjectId = value;
+        }
+
+        public bool IsAdmin => ThrowOnAccess ? throw new UnauthorizedAccessException("no principal") : false;
+
+        public string? DisplayName => User?.DisplayName;
+
+        public string? Email => User?.Email;
+
+        public Task<User?> TryGetUserAsync(CancellationToken cancellationToken) =>
+            ThrowOnAccess
+                ? throw new UnauthorizedAccessException("no principal")
+                : Task.FromResult(User);
+
+        public async Task<User> GetRequiredUserAsync(CancellationToken cancellationToken) =>
+            await TryGetUserAsync(cancellationToken) ?? throw new KeyNotFoundException("no user");
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Identity/CurrentUserAccessorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Identity/CurrentUserAccessorTests.cs
@@ -3,6 +3,7 @@ using FoundryGate.Api.Services.Identity;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
@@ -94,13 +95,16 @@ public class CurrentUserAccessorTests : InMemoryDatabaseTest
     }
 
     [Fact]
-    public async Task GetRequiredUserAsync_throws_KeyNotFoundException_for_an_unknown_oid()
+    public async Task GetRequiredUserAsync_throws_UnauthorizedAccessException_for_an_unknown_oid_telling_the_caller_to_provision_first()
     {
+        // 403, not 404: an authenticated principal with no row is an authorization-state problem
+        // (not provisioned yet), and it must read the same as IAuditService.LogAsync's failure.
         var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
 
-        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(() => accessor.GetRequiredUserAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => accessor.GetRequiredUserAsync(CancellationToken.None));
 
         Assert.Contains(Oid, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("GET /users/me", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -127,13 +131,27 @@ public class CurrentUserAccessorTests : InMemoryDatabaseTest
     }
 
     [Fact]
+    public async Task TryGetUserAsync_finds_a_User_that_was_added_to_the_context_but_not_yet_saved()
+    {
+        // The auto-provision unit of work (#28): Add the user, then resolve "the current user" for
+        // the audit row, then save once. Before the fix this went straight to the database and missed.
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+        var added = new User { EntraObjectId = Oid, DisplayName = "New Joiner", Email = "new@contoso.com" };
+        Context.Users.Add(added);
+
+        var resolved = await accessor.TryGetUserAsync(CancellationToken.None);
+
+        Assert.Same(added, resolved);
+        Assert.Equal(EntityState.Added, Context.Entry(added).State);
+    }
+
+    [Fact]
     public async Task TryGetUserAsync_does_not_cache_a_miss_so_a_caller_that_provisions_the_user_sees_it_on_the_next_call()
     {
         var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
 
         Assert.Null(await accessor.TryGetUserAsync(CancellationToken.None));
 
-        // What GET /users/me (#28) does on the null path.
         Context.Users.Add(new User { EntraObjectId = Oid, DisplayName = "New Joiner", Email = "new@contoso.com" });
         await Context.SaveChangesAsync();
 
@@ -147,15 +165,5 @@ public class CurrentUserAccessorTests : InMemoryDatabaseTest
         var identity = new ClaimsIdentity(claims, "TestAuth", nameType: ClaimConstants.Name, roleType: ClaimConstants.Roles);
         var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
         return new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
-    }
-
-    /// <summary>
-    /// Not the framework's <see cref="HttpContextAccessor"/>: that one keeps its context in a
-    /// <em>static</em> <c>AsyncLocal</c>, so several instances created in one test all observe
-    /// whichever context was set last. This holds exactly the context it was given.
-    /// </summary>
-    private sealed class FixedHttpContextAccessor(HttpContext? httpContext) : IHttpContextAccessor
-    {
-        public HttpContext? HttpContext { get; set; } = httpContext;
     }
 }

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Identity/CurrentUserAccessorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Identity/CurrentUserAccessorTests.cs
@@ -1,0 +1,161 @@
+using System.Security.Claims;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Tests.Predeployment.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Identity;
+
+/// <summary>
+/// Claim parsing and <c>User</c> resolution for <see cref="CurrentUserAccessor"/>. The oid claim
+/// arrives under two different claim types depending on the JWT handler's inbound claim mapping —
+/// both must resolve, and a missing oid on an authenticated principal must be a 403-class failure
+/// rather than a null.
+/// </summary>
+public class CurrentUserAccessorTests : InMemoryDatabaseTest
+{
+    private const string Oid = "11111111-2222-3333-4444-555555555555";
+
+    [Theory]
+    [InlineData(ClaimConstants.Oid)]
+    [InlineData(ClaimConstants.ObjectId)]
+    public void EntraObjectId_reads_the_oid_from_either_claim_type(string claimType)
+    {
+        var accessor = CreateAccessor(new Claim(claimType, Oid));
+
+        Assert.Equal(Oid, accessor.EntraObjectId);
+    }
+
+    [Fact]
+    public void EntraObjectId_throws_UnauthorizedAccessException_when_the_authenticated_principal_has_no_oid()
+    {
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Name, "No Oid"));
+
+        var exception = Assert.Throws<UnauthorizedAccessException>(() => accessor.EntraObjectId);
+
+        Assert.Contains("oid", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EntraObjectId_throws_UnauthorizedAccessException_when_the_principal_is_not_authenticated()
+    {
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) };
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
+
+        Assert.Throws<UnauthorizedAccessException>(() => accessor.EntraObjectId);
+    }
+
+    [Fact]
+    public void EntraObjectId_throws_UnauthorizedAccessException_when_there_is_no_HttpContext_at_all()
+    {
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(null), Context);
+
+        Assert.Throws<UnauthorizedAccessException>(() => accessor.EntraObjectId);
+    }
+
+    [Fact]
+    public void IsAdmin_is_true_only_with_the_admin_role_claim()
+    {
+        var admin = CreateAccessor(new Claim(ClaimConstants.Oid, Oid), new Claim(ClaimConstants.Roles, RoleNames.Admin));
+        var developer = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+        var otherRole = CreateAccessor(new Claim(ClaimConstants.Oid, Oid), new Claim(ClaimConstants.Roles, "FoundryGate.Something"));
+
+        Assert.True(admin.IsAdmin);
+        Assert.False(developer.IsAdmin);
+        Assert.False(otherRole.IsAdmin);
+    }
+
+    [Fact]
+    public void DisplayName_and_Email_read_the_name_and_preferred_username_claims_and_are_null_when_absent()
+    {
+        var full = CreateAccessor(
+            new Claim(ClaimConstants.Oid, Oid),
+            new Claim(ClaimConstants.Name, "Ada Lovelace"),
+            new Claim(ClaimConstants.PreferredUserName, "ada@contoso.com"));
+        var bare = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+
+        Assert.Equal("Ada Lovelace", full.DisplayName);
+        Assert.Equal("ada@contoso.com", full.Email);
+        Assert.Null(bare.DisplayName);
+        Assert.Null(bare.Email);
+    }
+
+    [Fact]
+    public async Task TryGetUserAsync_returns_null_for_an_unknown_oid_as_a_first_class_outcome()
+    {
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+
+        var user = await accessor.TryGetUserAsync(CancellationToken.None);
+
+        Assert.Null(user);
+    }
+
+    [Fact]
+    public async Task GetRequiredUserAsync_throws_KeyNotFoundException_for_an_unknown_oid()
+    {
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(() => accessor.GetRequiredUserAsync(CancellationToken.None));
+
+        Assert.Contains(Oid, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TryGetUserAsync_returns_the_tracked_row_and_the_same_instance_for_the_rest_of_the_request()
+    {
+        var seeded = new User { EntraObjectId = Oid, DisplayName = "Ada Lovelace", Email = "ada@contoso.com" };
+        Context.Users.Add(seeded);
+        await Context.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+
+        var first = await accessor.TryGetUserAsync(CancellationToken.None);
+        var second = await accessor.GetRequiredUserAsync(CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
+        Assert.Equal(EntityState.Unchanged, Context.Entry(first).State);
+
+        // "Tracked so callers can mutate": a plain property set must flow through SaveChanges.
+        first.DisplayName = "Ada King";
+        await Context.SaveChangesAsync();
+        var reloaded = await Context.Users.AsNoTracking().SingleAsync(u => u.EntraObjectId == Oid);
+        Assert.Equal("Ada King", reloaded.DisplayName);
+    }
+
+    [Fact]
+    public async Task TryGetUserAsync_does_not_cache_a_miss_so_a_caller_that_provisions_the_user_sees_it_on_the_next_call()
+    {
+        var accessor = CreateAccessor(new Claim(ClaimConstants.Oid, Oid));
+
+        Assert.Null(await accessor.TryGetUserAsync(CancellationToken.None));
+
+        // What GET /users/me (#28) does on the null path.
+        Context.Users.Add(new User { EntraObjectId = Oid, DisplayName = "New Joiner", Email = "new@contoso.com" });
+        await Context.SaveChangesAsync();
+
+        var provisioned = await accessor.TryGetUserAsync(CancellationToken.None);
+        Assert.NotNull(provisioned);
+        Assert.Equal("New Joiner", provisioned.DisplayName);
+    }
+
+    private CurrentUserAccessor CreateAccessor(params Claim[] claims)
+    {
+        var identity = new ClaimsIdentity(claims, "TestAuth", nameType: ClaimConstants.Name, roleType: ClaimConstants.Roles);
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        return new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
+    }
+
+    /// <summary>
+    /// Not the framework's <see cref="HttpContextAccessor"/>: that one keeps its context in a
+    /// <em>static</em> <c>AsyncLocal</c>, so several instances created in one test all observe
+    /// whichever context was set last. This holds exactly the context it was given.
+    /// </summary>
+    private sealed class FixedHttpContextAccessor(HttpContext? httpContext) : IHttpContextAccessor
+    {
+        public HttpContext? HttpContext { get; set; } = httpContext;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/TestAuthHandler.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/TestAuthHandler.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web;
+
+namespace FoundryGate.Tests.Predeployment.Api;
+
+/// <summary>
+/// Header-driven authentication scheme for integration tests. <c>ApiTestFactory</c> makes it the
+/// default authenticate/challenge scheme so a request can act as any identity without a real Entra
+/// token: <see cref="OidHeader"/> becomes the <c>oid</c> claim, <see cref="RolesHeader"/>
+/// (comma-separated) becomes <c>roles</c> claims, <see cref="NameHeader"/>/<see cref="EmailHeader"/>
+/// become <c>name</c>/<c>preferred_username</c>. No <see cref="OidHeader"/> → no result → the global
+/// <c>AuthorizeFilter</c> challenges → 401, exactly as an anonymous caller sees in production.
+/// </summary>
+/// <remarks>
+/// The identity is built with <c>roles</c> as its role claim type, matching what
+/// Microsoft.Identity.Web configures on real Entra tokens, so <c>IsInRole</c> — and therefore
+/// <c>PolicyNames.AdminOnly</c> and <c>ICurrentUserAccessor.IsAdmin</c> — behave identically here
+/// and in production.
+/// </remarks>
+public sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+    public const string OidHeader = "X-Test-Oid";
+    public const string RolesHeader = "X-Test-Roles";
+    public const string NameHeader = "X-Test-Name";
+    public const string EmailHeader = "X-Test-Email";
+
+    /// <inheritdoc />
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(OidHeader, out var oidValues) || string.IsNullOrWhiteSpace(oidValues))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var claims = new List<Claim> { new(ClaimConstants.Oid, oidValues.ToString()) };
+
+        if (Request.Headers.TryGetValue(NameHeader, out var nameValues) && !string.IsNullOrWhiteSpace(nameValues))
+        {
+            claims.Add(new Claim(ClaimConstants.Name, nameValues.ToString()));
+        }
+
+        if (Request.Headers.TryGetValue(EmailHeader, out var emailValues) && !string.IsNullOrWhiteSpace(emailValues))
+        {
+            claims.Add(new Claim(ClaimConstants.PreferredUserName, emailValues.ToString()));
+        }
+
+        if (Request.Headers.TryGetValue(RolesHeader, out var roleValues))
+        {
+            claims.AddRange(roleValues.ToString()
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(role => new Claim(ClaimConstants.Roles, role)));
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName, nameType: ClaimConstants.Name, roleType: ClaimConstants.Roles);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Data/Audit/AuditWriterTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Audit/AuditWriterTests.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using FoundryGate.Data.Audit;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Data.Audit;
+
+/// <summary>
+/// The host-agnostic audit writer every host shares: actor attribution (navigation vs id vs none),
+/// JSON details, the <see cref="TimeProvider"/> timestamp, and — the design decision worth pinning —
+/// that it adds to the caller's context without saving, so mutation and audit row commit together.
+/// </summary>
+public class AuditWriterTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly MutableTimeProvider _timeProvider = new(Now);
+
+    [Fact]
+    public async Task Add_with_an_unsaved_actor_attributes_the_row_once_the_caller_saves_the_auto_provision_pattern()
+    {
+        // The exact GET /users/me (#28) sequence: Add the new user, audit it, save once.
+        var newUser = NewUser("New Joiner");
+        Context.Users.Add(newUser);
+        var writer = CreateWriter();
+
+        var entry = writer.Add(newUser, AuditActions.UserProvisioned, AuditTargetTypes.User, string.Empty, new { newUser.DisplayName });
+        Assert.Equal(0, newUser.UserId); // still unsaved — nothing to put in ActorUserId yet
+        await Context.SaveChangesAsync();
+
+        Assert.NotEqual(0, newUser.UserId);
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(newUser.UserId, saved.ActorUserId);
+        Assert.Equal(AuditActions.UserProvisioned, saved.Action);
+    }
+
+    [Fact]
+    public async Task Add_with_a_saved_actor_serializes_details_as_camelCase_json()
+    {
+        var actor = await SeedActorAsync();
+        var writer = CreateWriter();
+
+        var entry = writer.Add(
+            actor,
+            AuditActions.UserQuotaChanged,
+            AuditTargetTypes.User,
+            "42",
+            new { Before = 1_000_000L, After = (long?)null, IsUnlimited = true });
+        await Context.SaveChangesAsync();
+
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(actor.UserId, saved.ActorUserId);
+        Assert.Equal(AuditTargetTypes.User, saved.TargetType);
+        Assert.Equal("42", saved.TargetId);
+
+        using var details = JsonDocument.Parse(saved.Details);
+        Assert.Equal(1_000_000L, details.RootElement.GetProperty("before").GetInt64());
+        Assert.Equal(JsonValueKind.Null, details.RootElement.GetProperty("after").ValueKind);
+        Assert.True(details.RootElement.GetProperty("isUnlimited").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Add_by_id_records_the_given_UserId()
+    {
+        var actor = await SeedActorAsync();
+        var writer = CreateWriter();
+
+        var entry = writer.Add(actor.UserId, AuditActions.KeyRotated, AuditTargetTypes.ApiKey, actor.UserId.ToString(), null);
+        await Context.SaveChangesAsync();
+
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(actor.UserId, saved.ActorUserId);
+    }
+
+    [Fact]
+    public async Task AddSystem_records_a_null_actor()
+    {
+        var writer = CreateWriter();
+
+        var entry = writer.AddSystem(
+            AuditActions.QuotaMonthlyReset,
+            string.Empty,
+            string.Empty,
+            new { PeriodYear = 2026, PeriodMonth = 9, AllocationsWritten = 12 });
+        await Context.SaveChangesAsync();
+
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Null(saved.ActorUserId);
+        Assert.Equal(AuditActions.QuotaMonthlyReset, saved.Action);
+        Assert.Contains("\"periodMonth\":9", saved.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Add_stamps_OccurredDate_from_the_injected_TimeProvider_and_it_survives_the_round_trip()
+    {
+        var writer = CreateWriter();
+        var frozen = new DateTimeOffset(2031, 2, 3, 4, 5, 6, TimeSpan.Zero);
+        _timeProvider.SetUtcNow(frozen);
+
+        var entry = writer.AddSystem(AuditActions.UsageSynced, string.Empty, string.Empty, null);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(frozen, entry.OccurredDate);
+        var saved = await Context.AuditLogs.AsNoTracking().SingleAsync(a => a.AuditLogId == entry.AuditLogId);
+        Assert.Equal(frozen, saved.OccurredDate);
+    }
+
+    [Fact]
+    public async Task Add_adds_to_the_context_but_does_not_save_so_the_caller_commits_mutation_and_audit_atomically()
+    {
+        var writer = CreateWriter();
+
+        var entry = writer.AddSystem(AuditActions.GroupCreated, AuditTargetTypes.Group, "7", null);
+
+        Assert.Equal(EntityState.Added, Context.Entry(entry).State);
+        Assert.Equal(0, await Context.AuditLogs.AsNoTracking().CountAsync());
+
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(1, await Context.AuditLogs.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public void Add_with_null_details_stores_an_empty_string_not_the_literal_null()
+    {
+        var writer = CreateWriter();
+
+        var entry = writer.AddSystem(AuditActions.UserDeactivated, AuditTargetTypes.User, "1", null);
+
+        Assert.Equal(string.Empty, entry.Details);
+    }
+
+    [Fact]
+    public void Add_tolerates_object_cycles_in_details_instead_of_throwing()
+    {
+        // A tracked entity graph (Group <-> GroupMember <-> Group) is the realistic way a caller
+        // passes a cycle by accident. Default System.Text.Json throws; that would turn the caller's
+        // mutation into an unmapped 500.
+        var group = new Group { Name = "Cyclic" };
+        var member = new GroupMember { Group = group, User = NewUser("Member") };
+        group.GroupMemberships.Add(member);
+        var writer = CreateWriter();
+
+        var entry = writer.AddSystem(AuditActions.GroupUpdated, AuditTargetTypes.Group, "1", group);
+
+        Assert.Contains("\"name\":\"Cyclic\"", entry.Details, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Add_rejects_a_blank_action_on_every_overload(string action)
+    {
+        var writer = CreateWriter();
+        var actor = NewUser("Anyone");
+
+        Assert.Throws<ArgumentException>(() => writer.Add(actor, action, AuditTargetTypes.User, "1", null));
+        Assert.Throws<ArgumentException>(() => writer.Add(1, action, AuditTargetTypes.User, "1", null));
+        Assert.Throws<ArgumentException>(() => writer.AddSystem(action, AuditTargetTypes.User, "1", null));
+    }
+
+    private AuditWriter CreateWriter() => new(Context, _timeProvider);
+
+    private async Task<User> SeedActorAsync()
+    {
+        var user = NewUser("Ada Lovelace");
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private static User NewUser(string displayName) => new()
+    {
+        EntraObjectId = Guid.NewGuid().ToString(),
+        DisplayName = displayName,
+        Email = $"{Guid.NewGuid():N}@contoso.test",
+    };
+}

--- a/src/FoundryGate.Tests.Predeployment/Data/QueryableExtensionsTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/QueryableExtensionsTests.cs
@@ -1,0 +1,70 @@
+using FoundryGate.Data.Entities;
+using FoundryGate.Data.Extensions;
+using FoundryGate.Domain.Common;
+
+namespace FoundryGate.Tests.Predeployment.Data;
+
+/// <summary>The shared <c>ToPagedAsync</c> helper every paged list endpoint depends on.</summary>
+public class QueryableExtensionsTests : InMemoryDatabaseTest
+{
+    [Fact]
+    public async Task ToPagedAsync_returns_the_requested_page_with_the_total_count_across_all_pages()
+    {
+        await SeedUsersAsync(7);
+
+        var page = await Context.Users
+            .OrderBy(u => u.DisplayName)
+            .Select(u => u.DisplayName)
+            .ToPagedAsync(new PagedRequest(Page: 2, PageSize: 3), CancellationToken.None);
+
+        Assert.Equal(7, page.TotalCount);
+        Assert.Equal(2, page.Page);
+        Assert.Equal(3, page.PageSize);
+        Assert.Equal(3, page.TotalPages);
+        Assert.Equal(["User 3", "User 4", "User 5"], page.Items);
+    }
+
+    [Fact]
+    public async Task ToPagedAsync_clamps_out_of_range_paging_instead_of_failing()
+    {
+        await SeedUsersAsync(3);
+
+        var page = await Context.Users
+            .OrderBy(u => u.DisplayName)
+            .Select(u => u.DisplayName)
+            .ToPagedAsync(new PagedRequest(Page: 0, PageSize: PagedRequest.MaxPageSize + 1), CancellationToken.None);
+
+        Assert.Equal(1, page.Page);
+        Assert.Equal(PagedRequest.MaxPageSize, page.PageSize);
+        Assert.Equal(3, page.Items.Count);
+    }
+
+    [Fact]
+    public async Task ToPagedAsync_past_the_last_page_returns_an_empty_page_with_the_true_total()
+    {
+        await SeedUsersAsync(2);
+
+        var page = await Context.Users
+            .OrderBy(u => u.UserId)
+            .ToPagedAsync(new PagedRequest(Page: 5, PageSize: 10), CancellationToken.None);
+
+        Assert.Empty(page.Items);
+        Assert.Equal(2, page.TotalCount);
+        Assert.Equal(5, page.Page);
+    }
+
+    private async Task SeedUsersAsync(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            Context.Users.Add(new User
+            {
+                EntraObjectId = Guid.NewGuid().ToString(),
+                DisplayName = $"User {i}",
+                Email = $"user{i}@contoso.test",
+            });
+        }
+
+        await Context.SaveChangesAsync();
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Data/TimestampInterceptorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/TimestampInterceptorTests.cs
@@ -1,6 +1,7 @@
 using FoundryGate.Data;
 using FoundryGate.Data.Entities;
 using FoundryGate.Data.Interceptors;
+using FoundryGate.Tests.Predeployment.Support;
 using Microsoft.EntityFrameworkCore;
 
 namespace FoundryGate.Tests.Predeployment.Data;
@@ -78,15 +79,5 @@ public class TimestampInterceptorTests : IDisposable
         _context.Database.EnsureDeleted();
         _context.Dispose();
         GC.SuppressFinalize(this);
-    }
-
-    /// <summary>Fake clock whose "now" can be advanced mid-test, unlike a fixed-value stub.</summary>
-    private sealed class MutableTimeProvider(DateTimeOffset now) : TimeProvider
-    {
-        private DateTimeOffset _now = now;
-
-        public override DateTimeOffset GetUtcNow() => _now;
-
-        public void SetUtcNow(DateTimeOffset value) => _now = value;
     }
 }

--- a/src/FoundryGate.Tests.Predeployment/Domain/GatewayTiersTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/GatewayTiersTests.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>
+/// <see cref="GatewayTiers"/> must match the APIM products <c>infra/main.bicep</c> actually creates
+/// — a tier id that exists in code but not in the gateway (or vice versa) breaks subscription
+/// provisioning silently. Parses the bicep <c>quotaTiers</c> parameter's default value rather than
+/// trusting a comment.
+/// </summary>
+public class GatewayTiersTests
+{
+    [Fact]
+    public void All_contains_every_tier_in_declaration_order_and_Default_is_one_of_them()
+    {
+        Assert.Equal([GatewayTiers.Standard, GatewayTiers.Power, GatewayTiers.Unlimited], GatewayTiers.All);
+        Assert.Contains(GatewayTiers.Default, GatewayTiers.All);
+        Assert.Equal(GatewayTiers.All.Count, GatewayTiers.All.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void Tier_ids_match_the_quotaTiers_names_in_infra_main_bicep_in_the_same_order()
+    {
+        var bicep = File.ReadAllText(Path.Combine(FindRepoRoot(), "infra", "main.bicep"));
+
+        // The default value of `param quotaTiers array = [ ... ]` runs from that line to the first
+        // line that is exactly "]" — each entry's `name: '<id>'` is the APIM product id.
+        var block = Regex.Match(bicep, @"param quotaTiers array = \[(?<body>.*?)^\]", RegexOptions.Singleline | RegexOptions.Multiline);
+        Assert.True(block.Success, "Could not find `param quotaTiers array = [ ... ]` in infra/main.bicep.");
+
+        var bicepTierNames = Regex.Matches(block.Groups["body"].Value, @"^\s*name:\s*'(?<name>[^']+)'", RegexOptions.Multiline)
+            .Select(m => m.Groups["name"].Value)
+            .ToList();
+
+        Assert.Equal(bicepTierNames, GatewayTiers.All);
+        Assert.Equal(GatewayTiers.Default, bicepTierNames[0]); // bicep's defaultProductId is quotaTiers[0].name
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "FoundryGate.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root (FoundryGate.sln) from the test output directory.");
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/GatewayTiersTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/GatewayTiersTests.cs
@@ -19,20 +19,34 @@ public class GatewayTiersTests
         Assert.Equal(GatewayTiers.All.Count, GatewayTiers.All.Distinct(StringComparer.Ordinal).Count());
     }
 
+    /// <summary>
+    /// Scope, stated so the first person this breaks knows why: this pins the bicep parameter's
+    /// <em>default</em> value, not what a <c>.bicepparam</c> file actually deploys — a fork that
+    /// overrides <c>quotaTiers</c> at deploy time must update <see cref="GatewayTiers"/> to match
+    /// (nothing here can see that). Only <em>top-level</em> tier items are read: an item is a
+    /// <c>{ ... }</c> block indented exactly two spaces inside the array, and its <c>name:</c> is the
+    /// property indented exactly four — a nested block with its own <c>name:</c> key (six or more
+    /// spaces) is deliberately not matched. If main.bicep is ever re-indented, adjust the anchors.
+    /// </summary>
     [Fact]
     public void Tier_ids_match_the_quotaTiers_names_in_infra_main_bicep_in_the_same_order()
     {
         var bicep = File.ReadAllText(Path.Combine(FindRepoRoot(), "infra", "main.bicep"));
 
         // The default value of `param quotaTiers array = [ ... ]` runs from that line to the first
-        // line that is exactly "]" — each entry's `name: '<id>'` is the APIM product id.
-        var block = Regex.Match(bicep, @"param quotaTiers array = \[(?<body>.*?)^\]", RegexOptions.Singleline | RegexOptions.Multiline);
+        // line that is exactly "]" (the array's own closing bracket sits at column 0).
+        var block = Regex.Match(bicep, @"^param quotaTiers array = \[\r?\n(?<body>.*?)^\]", RegexOptions.Singleline | RegexOptions.Multiline);
         Assert.True(block.Success, "Could not find `param quotaTiers array = [ ... ]` in infra/main.bicep.");
 
-        var bicepTierNames = Regex.Matches(block.Groups["body"].Value, @"^\s*name:\s*'(?<name>[^']+)'", RegexOptions.Multiline)
-            .Select(m => m.Groups["name"].Value)
+        // Top-level items only: `  {` ... `  }` at two-space indentation; within one, the tier's own
+        // `name:` is at exactly four spaces. Anything deeper belongs to a nested object.
+        var bicepTierNames = Regex.Matches(block.Groups["body"].Value, @"^  \{\r?\n(?<item>.*?)^  \}", RegexOptions.Singleline | RegexOptions.Multiline)
+            .Select(item => Regex.Match(item.Groups["item"].Value, @"^ {4}name:\s*'(?<name>[^']+)'\s*$", RegexOptions.Multiline))
+            .Where(nameMatch => nameMatch.Success)
+            .Select(nameMatch => nameMatch.Groups["name"].Value)
             .ToList();
 
+        Assert.NotEmpty(bicepTierNames);
         Assert.Equal(bicepTierNames, GatewayTiers.All);
         Assert.Equal(GatewayTiers.Default, bicepTierNames[0]); // bicep's defaultProductId is quotaTiers[0].name
     }

--- a/src/FoundryGate.Tests.Predeployment/Support/FixedHttpContextAccessor.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FixedHttpContextAccessor.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Http;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// <see cref="IHttpContextAccessor"/> that holds exactly the context it was given. Not the
+/// framework's <see cref="HttpContextAccessor"/>: that one keeps its context in a <em>static</em>
+/// <c>AsyncLocal</c>, so several instances created in one test all observe whichever context was
+/// set last — which makes "admin vs developer vs other role" side-by-side assertions silently test
+/// the same principal three times.
+/// </summary>
+public sealed class FixedHttpContextAccessor(HttpContext? httpContext) : IHttpContextAccessor
+{
+    /// <inheritdoc />
+    public HttpContext? HttpContext { get; set; } = httpContext;
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/MutableTimeProvider.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/MutableTimeProvider.cs
@@ -1,0 +1,21 @@
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// Fake clock whose "now" can be set mid-test. Registered as the <see cref="TimeProvider"/> singleton
+/// by <c>ApiTestFactory</c> (so endpoint tests control quota periods, audit timestamps, etc.) and
+/// usable directly in service-level tests. Deliberately not <c>Microsoft.Extensions.TimeProvider
+/// .Testing</c>'s <c>FakeTimeProvider</c> — that's another package for one method.
+/// </summary>
+public sealed class MutableTimeProvider(DateTimeOffset now) : TimeProvider
+{
+    private DateTimeOffset _now = now;
+
+    /// <inheritdoc />
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    /// <summary>Moves the clock to <paramref name="value"/> (converted to UTC).</summary>
+    public void SetUtcNow(DateTimeOffset value) => _now = value.ToUniversalTime();
+
+    /// <summary>Moves the clock forward by <paramref name="delta"/>.</summary>
+    public void Advance(TimeSpan delta) => _now += delta;
+}


### PR DESCRIPTION
## Summary

First `/api/v1` controller, plus the cross-cutting scaffolding the seven endpoint waves that follow (users, groups, quota, requests, keys, Entra sync, foundry deployments) build on.

**Issue #42 — audit**
- `Services/Audit/IAuditService` + `AuditService`: `LogAsync(action, targetType, targetId, details, ct)` attributed to the current caller, and `LogAsync(int? actorUserId, ...)` for system actors (Functions/sync jobs pass `null`). `details` is any object, JSON-serialized (camelCase) into `AuditLog.Details`; `OccurredDate` from the injected `TimeProvider`. Returns the added `AuditLog`.
- `Controllers/AuditController`: `GET /api/v1/audit`, `[Authorize(Policy = PolicyNames.AdminOnly)]`, paged + filterable via the existing `AuditLogQuery` / `PagedRequest` records -> `PagedResult<AuditLogEntryResponse>`. Projection-to-record inside the query, `AsNoTracking`, newest first (`OccurredDate` desc, `AuditLogId` desc).
- `AuditActions`: added `UserProvisioned`, `QuotaIncreaseSubmitted`, `QuotaAllocationReset`, `FoundryDeploymentCreated/Deleted`, `KeyRevealed`, `UsageSynced` (existing ones untouched). New `AuditTargetTypes` constants so call sites never spell `"User"`/`"Group"`/`"Request"` inline.

**Cross-cutting scaffolding**
- `Services/Identity/ICurrentUserAccessor` + `CurrentUserAccessor` (scoped): `EntraObjectId` (accepts both `oid` and the long `.../objectidentifier` claim type via Microsoft.Identity.Web's `GetObjectId()`), `IsAdmin` (`IsInRole` — the same check as the policy), `DisplayName`/`Email` (for #28's auto-provision), `TryGetUserAsync` (null = not provisioned, a first-class path; misses are not cached so a provisioning caller sees the new row), `GetRequiredUserAsync` (-> `KeyNotFoundException`/404). Returned `User` is tracked. No oid -> `UnauthorizedAccessException`/403.
- `Controllers/ApiControllerBase` — `[ApiController]`, `[Route("api/v1/[controller]")]`, `[Produces("application/json")]`.
- DI convention: `Services/ServiceCollectionExtensions.AddFoundryGateApiServices()` called **once** from `Program.cs`; each area owns `Services/<Area>/<Area>ServiceCollectionExtensions.Add<Area>Services()`. Later waves add one file + one line and never touch `Program.cs`.
- `FoundryGate.Data.Extensions.QueryableExtensions.ToPagedAsync(PagedRequest, ct)` -> `PagedResult<T>` (CONVENTIONS.md asked for this; it didn't exist yet). Clamps paging itself.
- `GatewayTiers` (coordinator-requested): APIM tier product ids `standard`/`power`/`unlimited`, `Default = Standard`, `All`; XML-doc'd as APIM products because `token-quota` accepts literals only, and as must-match-`infra/main.bicep`. `SystemConfigurationKeys.ApimProductId` doc amended to "legacy single-product model, superseded by `GatewayTiers`" (constant kept — seed data references it). `GatewayTiersTests` parses the bicep `quotaTiers` default and asserts parity + order.
- Test harness: `Api/ApiTestFactory` (`WebApplicationFactory<Program>`, env `local`, SQL Server `AppDbContext` swapped for SQLite in-memory on one kept-open `SqliteConnection`, `EnsureCreated` + `ReferenceDataSeeder`, `TestAuthHandler` as default authenticate/challenge scheme, `AzureAd` placeholders supplied in-memory so it never needs Azure) with `CreateClientAs(oid, isAdmin, name, email)`, `SeedUserAsync(...)`, `CreateDbContext()`, `TimeProvider` (a `Support/MutableTimeProvider`). `HealthEndpointTests` unchanged and still green.
- CONVENTIONS.md: new **"API service/controller conventions"** section documenting all of the above for the next agents.

## Design decisions (please scrutinize)

1. **Audit rows are NOT fire-and-forget.** `LogAsync` adds to the request's `AppDbContext`; the caller's `SaveChangesAsync` commits mutation + audit atomically. The plan's "fire-and-log" verification item is reversed with rationale: a fire-and-log audit can leave a mutation with no audit row, or an audit row for a rolled-back mutation — for an audit trail, failing the request is the correct outcome. Pattern at every call site: mutate -> `await audit.LogAsync(...)` -> `await dbContext.SaveChangesAsync(ct)`.
2. **A caller with no `User` row cannot write a human-attributed audit row** — the current-user `LogAsync` overload throws `UnauthorizedAccessException` (403) rather than silently logging `ActorUserId = null`. Admins are provisioned by `GET /users/me` (#28) before they act, so this only bites an admin who calls a mutating endpoint before ever loading the UI. Alternative considered: fall back to a null actor with the oid in `details` — rejected because it makes "system action" and "unprovisioned human" indistinguishable in the log.
3. **SQLite-only `DateTimeOffset` -> UTC-ticks value conversion in `AppDbContext.OnModelCreating`** (gated on `Database.ProviderName`). EF's SQLite provider refuses to translate ordering/comparison on `DateTimeOffset`, which would have broken the audit date-range filter (and every future quota-period/review-date query) in the test harness. Normalizing to `UtcTicks` (not EF's built-in `DateTimeOffsetToBinaryConverter`) means a query parameter with a non-UTC offset still compares by instant — pinned by `Date_filter_with_a_non_utc_offset_compares_by_instant_not_by_wall_clock`. SQL Server model and dacpac untouched; column names/nullability unchanged so convention/parity tests are unaffected.
4. **Empty-string <-> null translation happens in the projection.** Entities keep the non-nullable-string convention (`TargetType = ""` for "no target"); the pre-existing `AuditLogEntryResponse` contract exposes `null`. The query maps `""` -> `null` so the UI never sees `""`.
5. `IsAdmin` uses `ClaimsPrincipal.IsInRole` rather than inspecting claims directly, so it can never disagree with `PolicyNames.AdminOnly`. `TestAuthHandler` builds identities with role claim type `roles`, matching Microsoft.Identity.Web's real tokens.
6. `ICurrentUserAccessor` also exposes `DisplayName`/`Email` — slightly beyond the brief, but #28 needs both for auto-provisioning and this avoids a second claim-parsing site.

## Verification

```
dotnet build FoundryGate.sln -c Release                                 -> 0 Warning(s), 0 Error(s)
dotnet test src/FoundryGate.Tests.Predeployment -c Release --no-build   -> Passed! Failed: 0, Passed: 119, Skipped: 0, Total: 119  (82 on main + 37 new)
dotnet format FoundryGate.sln --verify-no-changes                       -> exit 0
```

New tests: `AuditServiceTests` (9 — actor attribution, camelCase JSON, `TimeProvider` timestamp incl. SQLite round-trip, adds-without-saving, null details -> `""`, 403 on unprovisioned caller, system-actor overload, blank action rejected, newest-first + `""`->null projection), `CurrentUserAccessorTests` (10 — both oid claim types, 403 on missing oid / unauthenticated / no HttpContext, `IsAdmin`, name/email claims, null miss, 404, tracked + cached, miss not cached), `AuditEndpointTests` (11 — 401 anonymous, 403 non-admin, 200 admin + default paging, newest first + actor display name, page/pageSize/totals, each filter, inclusive date range, non-UTC offset), `QueryableExtensionsTests` (3), `GatewayTiersTests` (2).

plans/12-audit-logging.md Verification checklist updated; "every mutation produces a row" is explicitly deferred to each endpoint wave's own PR (the endpoints don't exist yet — #28–#41, #61, #65–#66 each wire their own `LogAsync` and assert it).

Also closes the two plans/04 deferrals in-process: unauthenticated -> 401 and wrong role -> 403 are now asserted against a real `/api/v1` endpoint (#102 remains for the deployed-environment version).

## Not in this PR
- Wiring `LogAsync` into mutating endpoints — they don't exist yet; each wave owns its call sites (tracked by the existing per-endpoint issues).
- No `.github/`, `infra/`, `docs-site/`, or `SchemaParityTests.cs` changes (other agents own those). Landing page / architecture docs unaffected: no enforcement-semantics or topology change.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtuGhG69SaSuVfx92RwwNk
