### PR TITLE
feat(api): APIM subscription keys — provisioning, rotation, reveal, revocation, encryption at rest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,10 @@
     <PackageVersion Include="Azure.Core" Version="1.62.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+
+    <!-- Api: APIM subscription lifecycle + Key Vault key wrapping of stored APIM keys (#36, #37, #95) -->
+    <PackageVersion Include="Azure.ResourceManager.ApiManagement" Version="1.3.1" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />

--- a/docs-site/src/components/KeyLifecycle.astro
+++ b/docs-site/src/components/KeyLifecycle.astro
@@ -1,7 +1,7 @@
 ---
 // APIM subscription (developer key) state machine — gateway-centric model, lifecycle per
 // plans/21-provision-deprovision.md (#65/#66): a key IS an APIM subscription created under
-// a tier product. Rotation (regeneratePrimaryKey) and quota changes (re-scope to another
+// a tier product. Rotation (regeneratePrimaryKey + regenerateSecondaryKey — both keys) and quota changes (re-scope to another
 // tier product) keep it Active; 403/429 are gateway responses and change nothing. Admin
 // deactivation, Entra departure and admin key revocation all DELETE the subscription;
 // re-activation re-runs provisioning (reusing an orphan subscription if one exists).
@@ -12,7 +12,7 @@
   <p id="fgd-kl-title" class="fgd-sr-only">APIM key lifecycle state machine</p>
   <p id="fgd-kl-desc" class="fgd-sr-only">
     From No key, first login or admin provision creates an APIM subscription under the developer's tier product and
-    the key becomes Active. While Active: rotating the key calls regeneratePrimaryKey and stays Active; changing the
+    the key becomes Active. While Active: rotating the key regenerates both the primary and the secondary key and stays Active; changing the
     quota re-scopes the subscription to the new tier's product and stays Active (the gateway's monthly counter
     restarts for that subscription; live validation tracked in #88); a 403 for an exhausted monthly quota or a 429
     with Retry-After for the per-minute cap are gateway responses that change nothing. Admin deactivation, Entra
@@ -69,7 +69,7 @@
       <!-- Active ⟲ rotate (right loop) -->
       <path d="M 430,148 C 482,140 482,182 430,176" class="fgd-s-edge fgd-s-edge--green" marker-end="url(#fgd-kl-head-green)" />
       <text x="488" y="156" class="fgd-s-label fgd-s-label--green">rotate key</text>
-      <text x="488" y="170" class="fgd-s-label fgd-s-mono">regeneratePrimaryKey</text>
+      <text x="488" y="170" class="fgd-s-label fgd-s-mono">regenerate both keys</text>
 
       <!-- Active ⟲ change quota (left loop) -->
       <path d="M 220,148 C 168,140 168,182 220,176" class="fgd-s-edge fgd-s-edge--green" marker-end="url(#fgd-kl-head-green)" />

--- a/docs-site/src/components/SystemDiagram.astro
+++ b/docs-site/src/components/SystemDiagram.astro
@@ -18,7 +18,7 @@ const ariaLabel =
   'Azure Static Web Apps calls FoundryGate.Api on Azure Container Apps, which stores state in Azure SQL ' +
   'through EF Core; FoundryGate.Functions run the monthly reset and usage reconciliation, reading ' +
   'ApiManagementGatewayLlmLog from Log Analytics; Key Vault holds secrets. The API manages APIM ' +
-  'subscriptions through the Management API: create under a tier product, regenerate key, move tier, delete. ' +
+  'subscriptions through the Management API: create under a tier product, regenerate both keys, move tier, delete. ' +
   'Legend: solid azure arrows are the real-time enforcement path on the request; dashed grey arrows are telemetry ' +
   'and reconciliation, out of band; dashed amber arrows are control-plane calls for lifecycle and tiers.';
 ---
@@ -153,7 +153,7 @@ const ariaLabel =
     <div class="fgd-arrow fgd-arrow--app fgd-arrow--up">
       <span class="fgd-arrow__label">
         <strong>APIM Management API</strong> — create subscription under a tier product ·
-        <code>regeneratePrimaryKey</code> · move tier · delete
+        regenerate both keys · move tier · delete
       </span>
       <span class="fgd-arrow__line"></span>
       <span class="fgd-arrow__head"></span>

--- a/docs-site/src/content/docs/architecture/overview.mdx
+++ b/docs-site/src/content/docs/architecture/overview.mdx
@@ -200,9 +200,13 @@ people-lifecycle events change its state — there is no suspended state:
 <KeyLifecycle />
 
 **Rotate** — `POST /keys/me/rotate` (or an admin's `POST /keys/{userId}/rotate`) calls
-`regeneratePrimaryKey` on the subscription. The primary key the developer holds is
-replaced instantly, the new one is shown once, and the subscription stays `active` with
-its counters intact.
+`regeneratePrimaryKey` *and* `regenerateSecondaryKey` on the subscription: the primary key
+the developer holds is replaced instantly and shown once, and the secondary — which
+FoundryGate never issues or stores — is replaced too, so no credential outlives a rotation.
+The subscription stays `active` with its counters intact. Stored keys are wrapped with a
+Key Vault RSA key before they reach SQL; `GET /keys/me` shows only the last four characters,
+and `POST /keys/me/reveal` decrypts on demand (audited) rather than caching anything in the
+browser.
 
 **Change quota** — the control plane re-scopes the subscription to the new tier's
 product. The new product's `llm-token-limit` applies from the next request, and because

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -53,11 +53,14 @@ Base path: `/api/v1`. All endpoints require a valid Entra ID bearer token. Admin
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET` | `/keys/me` | Any | Own key info (masked, last 4 visible) |
-| `POST` | `/keys/me/rotate` | Any | Rotate own key — returns new key value once |
-| `POST` | `/keys/{userId}/rotate` | Admin | Rotate any user's key |
-| `POST` | `/keys/{userId}/provision` | Admin | Provision a new key for a user with no active key |
-| `DELETE` | `/keys/{userId}` | Admin | Revoke key (user stays active) |
+| `GET` | `/keys/me` | Any | Own key info (masked, last 4 visible; `isProvisioned: false` when none). Served from a stored hint — no decryption |
+| `POST` | `/keys/me/reveal` | Any | Decrypt and return own full key once. Audited (`key.revealed`), never cached. `404` when no key |
+| `POST` | `/keys/me/rotate` | Any | Rotate own key — regenerates **both** APIM keys (primary and never-issued secondary), returns the new primary once. `404` no key; `409` if the APIM subscription vanished |
+| `POST` | `/keys/{userId}/rotate` | Admin | Rotate any user's key (same semantics) |
+| `POST` | `/keys/{userId}/provision` | Admin | Provision a key for a user with none, under `?tier=standard\|power\|unlimited` (default `standard`). Returns plaintext once. `409` key exists or user deactivated; `400` unknown tier; reuses an orphaned APIM subscription with fresh keys |
+| `DELETE` | `/keys/{userId}` | Admin | Revoke key only: APIM subscription deleted, stored key cleared, `key.revoked` audited. **User stays active** and can be re-provisioned; `204` even when no key existed. Deactivation is `POST /users/{id}/deactivate` |
+
+Callers of every `/keys/me` route must already have a FoundryGate user row (`GET /users/me` provisions one) — otherwise `403`. The plaintext key is stored encrypted (Key Vault RSA key wrapping; see [Configuration](/reference/configuration/)) and appears in exactly one response per mint or reveal.
 
 ## Foundry
 

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -60,7 +60,7 @@ Base path: `/api/v1`. All endpoints require a valid Entra ID bearer token. Admin
 | `POST` | `/keys/{userId}/provision` | Admin | Provision a key for a user with none, under `?tier=standard\|power\|unlimited` (default `standard`). Returns plaintext once. `409` key exists or user deactivated; `400` unknown tier; reuses an orphaned APIM subscription with fresh keys |
 | `DELETE` | `/keys/{userId}` | Admin | Revoke key only: APIM subscription deleted, stored key cleared, `key.revoked` audited. **User stays active** and can be re-provisioned; `204` even when no key existed. Deactivation is `POST /users/{id}/deactivate` |
 
-Callers of every `/keys/me` route must already have a FoundryGate user row (`GET /users/me` provisions one) — otherwise `403`. The plaintext key is stored encrypted (Key Vault RSA key wrapping; see [Configuration](/reference/configuration/)) and appears in exactly one response per mint or reveal.
+Callers of every `/keys/me` route must already have a FoundryGate user row (`GET /users/me` provisions one) — otherwise `403`. The plaintext key is stored encrypted (Key Vault RSA key wrapping; see [Configuration](/reference/configuration/)) and appears in exactly one response per mint or reveal. Reveal is not yet rate-limited (tracked in #136). Provisioning is race-safe: two concurrent `provision` calls for one user cannot both mint — the second gets `409`.
 
 ## Foundry
 

--- a/docs-site/src/content/docs/reference/configuration.mdx
+++ b/docs-site/src/content/docs/reference/configuration.mdx
@@ -12,9 +12,9 @@ These are stored in the `SystemConfiguration` database table and editable by adm
 | Key | Default | Description |
 |---|---|---|
 | `DefaultMonthlyTokenQuota` | `"1000000"` | Per-user monthly token budget when no user or group override applies. |
-| `ApimResourceId` | `""` | ARM resource ID of the APIM instance (`/subscriptions/.../Microsoft.ApiManagement/service/...`). Used by `IApimKeyService` to target Management plane calls. |
+| `ApimResourceId` | `""` | ARM resource ID of the APIM instance (`/subscriptions/.../Microsoft.ApiManagement/service/...`). Informational — the key service addresses APIM through the `Gateway__*` environment variables below, not this value. |
 | `ApimGatewayUrl` | `""` | APIM gateway base URL shown to developers on `/me` for CLI configuration (e.g., `https://my-apim.azure-api.net`). |
-| `ApimProductId` | `"foundrygate"` | APIM product name that all Foundry API routes belong to. New APIM subscriptions are scoped to this product. |
+| `ApimProductId` | `"foundrygate"` | Legacy single-product name. Superseded: a developer's subscription is created under their **quota-tier product** (`standard`, `power`, `unlimited`), not this one. Kept for the seeded reference data. |
 | `FoundryResourceId` | `""` | ARM resource ID of the Azure AI Foundry account. Used by `IFoundryDeploymentService` for model deployment management. |
 | `EntraTenantId` | `""` | Azure AD tenant ID used by the Microsoft Graph SDK for bulk user sync. |
 | `EntraGroupSyncEnabled` | `"false"` | Set to `"true"` to enable automatic Entra group member sync. When `false`, group sync must be triggered manually from the admin UI. |
@@ -36,12 +36,15 @@ These are set as Container App environment variables (sourced from Key Vault ref
 | `AzureAd__TenantId` | Config / env var | Entra tenant ID for bearer token validation |
 | `AzureAd__ClientId` | Config / env var | Entra App Registration client ID |
 | `AzureAd__Audience` | Config / env var | Token audience (usually `api://{clientId}`) |
-| `Azure__ApimResourceGroup` | Config / env var | Resource group containing the APIM instance |
-| `Azure__ApimServiceName` | Config / env var | APIM service name (short name, not full resource ID) |
+| `Azure__KeyVaultUrl` | Config / env var | Key Vault URI for resolving `@KeyVault(SecretName)` references in appsettings. Optional locally |
+| `Gateway__SubscriptionId` | Set by infra | Azure subscription id holding the APIM instance. With the next two, addresses the APIM management plane for subscription-key operations; all three or none |
+| `Gateway__ResourceGroup` | Set by infra | Resource group of the APIM instance |
+| `Gateway__ApimName` | Set by infra | APIM service name (short name, not the full resource ID) |
+| `Gateway__KeyEncryptionKeyUri` | Set by infra | Versionless URI of the Key Vault RSA key (`fg-apim-key-encryption`) that wraps stored APIM subscription keys (RSA-OAEP-256). Required when `KeyProtection__Provider` is `KeyVault` |
+| `KeyProtection__Provider` | Config / env var | `KeyVault` (default; cloud) or `DataProtection` (machine-local key ring — accepted in the `local` environment only; the API refuses to start with it anywhere else) |
 | `Azure__FoundrySubscriptionId` | Config / env var | Azure subscription ID containing Foundry |
 | `Azure__FoundryResourceGroup` | Config / env var | Resource group containing the Foundry account |
 | `Azure__FoundryAccountName` | Config / env var | Foundry account name (short name) |
-| `Azure__KeyVaultUri` | Config / env var | Key Vault URI for key wrapping (APIM key encryption) |
 | `Graph__ClientId` | Config / env var | App registration client ID for Graph SDK (may differ from AzureAd__ClientId) |
 | `Graph__ClientSecret` | Key Vault secret | Client secret for Graph app-only credentials |
 

--- a/foundrygate-spec.md
+++ b/foundrygate-spec.md
@@ -227,10 +227,11 @@ PUT    /requests/{id}/reject         Admin only
 
 ```
 GET    /keys/me                      Any: get own APIM key (masked except last 4)
-POST   /keys/me/rotate               Any: rotate own APIM subscription key
+POST   /keys/me/reveal               Any: decrypt and return own full key once (audited)
+POST   /keys/me/rotate               Any: rotate own APIM subscription key (both APIM keys regenerated)
 POST   /keys/{userId}/rotate         Admin: rotate key for any user
-POST   /keys/{userId}/provision      Admin: provision a new APIM key for a user
-DELETE /keys/{userId}                Admin: revoke APIM key (hard deactivate)
+POST   /keys/{userId}/provision      Admin: provision a new APIM key for a user (?tier=standard|power|unlimited)
+DELETE /keys/{userId}                Admin: revoke APIM key only — user stays active (deactivation is PUT /users/{id}/deactivate)
 ```
 
 ### 4.6 Admin / Configuration
@@ -253,34 +254,46 @@ Managed Identity credential (Container App system-assigned identity).
 
 ```
 1. Admin activates a user or user auto-provisions on first login
-2. API calls APIM Management: POST /subscriptions
-   - Name: "foundrygate-{userId}"
-   - Scope: /products/{productId}  (a single APIM Product covering all Foundry routes)
-   - DisplayName: user's email
-3. APIM returns primary + secondary keys
-4. API encrypts the primary key with Azure Key Vault and stores in User.ApimSubscriptionKey
-5. User.ApimSubscriptionId is set to the APIM subscription resource ID
+2. API checks APIM for an existing subscription named "foundrygate-{userId}" (an orphan from a
+   failed earlier save); if found it is reused — re-scoped to the tier and both keys regenerated
+3. Otherwise API calls APIM Management: PUT /subscriptions/foundrygate-{userId}
+   - Scope: /products/{tierProductId}  (the user's quota-tier product: standard | power | unlimited, #82)
+   - DisplayName: "FoundryGate {email}"
+   - State: active
+4. APIM returns primary + secondary keys; only the primary is ever issued or stored
+5. API wraps the primary key with the Key Vault RSA key (RSA-OAEP-256, versioned envelope) and
+   stores it in User.ApimSubscriptionKey; User.ApimSubscriptionKeyHint = last 4 chars;
+   User.ApimKeyIssuedDate = now
+6. User.ApimSubscriptionId is set to the APIM subscription resource ID (not secret, stored plain)
+7. Audit key.provisioned; the plaintext is returned once in the response and never again
 ```
 
 ### 5.2 Key rotation flow
 
 ```
-1. User or admin calls POST /keys/{userId}/rotate
-2. API calls APIM Management: POST /subscriptions/{sid}/regeneratePrimaryKey
-3. API fetches new primary key, re-encrypts, updates DB
+1. User calls POST /keys/me/rotate, or admin calls POST /keys/{userId}/rotate
+2. API calls APIM Management: POST /subscriptions/{sid}/regeneratePrimaryKey AND
+   POST /subscriptions/{sid}/regenerateSecondaryKey — both keys, so the never-issued secondary
+   cannot outlive the primary (#117)
+3. API fetches the new primary key (listSecrets), re-encrypts, updates DB (key, hint, issued date)
 4. Old key is immediately invalidated by APIM
-5. Audit log entry written
+5. Audit key.rotated; the new value is returned once
 ```
 
-### 5.3 Key revocation flow
+### 5.3 Key revocation flow (key-only)
 
 ```
-1. Admin deactivates user or DELETE /keys/{userId}
-2. API calls APIM Management: DELETE /subscriptions/{sid}
-3. User.ApimSubscriptionId and User.ApimSubscriptionKey set to NULL
-4. User.IsActive set to false
-5. QuotaAllocation.IsHardStopped set to true for current period
+1. Admin calls DELETE /keys/{userId}  (or the deactivation pipeline calls IApimKeyService.RevokeAsync as its first step)
+2. API calls APIM Management: DELETE /subscriptions/{sid}  (already-gone is tolerated)
+3. User.ApimSubscriptionId, ApimSubscriptionKey, ApimSubscriptionKeyHint cleared; ApimKeyIssuedDate = NULL
+4. Audit key.revoked
+5. User.IsActive is NOT changed — the user can be re-provisioned with POST /keys/{userId}/provision.
+   Deactivation (IsActive = false, QuotaAllocation.IsHardStopped = true, pending requests cancelled)
+   is PUT /users/{id}/deactivate's job (plans/21-provision-deprovision.md), which runs this flow first.
 ```
+
+There is no "suspend" state: quota exhaustion is a real-time gateway `403` (§5.4, #81), and every
+people-lifecycle exit deletes the subscription (#116).
 
 ### 5.4 Monthly token usage sync (amended: reconciliation, not enforcement)
 

--- a/plans/09-apim-keys.md
+++ b/plans/09-apim-keys.md
@@ -46,4 +46,4 @@ Files:
 - [x] Audit log captures provision, rotation, reveal, revocation and tier-change events, attributed to the caller, with no key material in `Details`
 - [x] Plaintext never reaches the logger (`Plaintext_key_material_never_reaches_the_logger_or_an_audit_row`)
 - [x] Key protector round-trips under both providers; `DataProtection` is refused outside `local`; `KeyVault` without a key URI fails startup; envelope fits the 1000-char column for RSA-4096
-- [ ] Live: provision/rotate/reveal/revoke against a real APIM + Key Vault (manual checklist in the follow-up issue filed by the #36/#37/#95 PR)
+- [ ] Live: provision/rotate/reveal/revoke against a real APIM + Key Vault — manual checklist in #132

--- a/plans/09-apim-keys.md
+++ b/plans/09-apim-keys.md
@@ -39,7 +39,11 @@ Files:
 - [x] `dotnet build FoundryGate.sln -c Release` passes with zero warnings
 - [x] Provisioning creates an APIM subscription under the tier product and returns the key value once (`ApimKeyServiceTests`, `KeysEndpointTests`)
 - [x] A second provision attempt while a key is active returns `409`; an unknown tier `400`; a deactivated user `409`
-- [x] An orphan subscription is reused (re-scoped, both keys regenerated) instead of erroring
+- [x] An orphan subscription is reused (re-scoped, both keys regenerated) instead of erroring; a non-`active` orphan is deleted and recreated
+- [x] Two concurrent provisions cannot both PUT: the row is claimed (`ApimSubscriptionId = '' → resource id`) in a transaction before APIM is called; the loser gets `409`, an APIM failure rolls the claim back, and an orchestrator-owned transaction is joined rather than nested
+- [x] A rotation that fails after APIM regenerated the keys restores the previous row values, logs an Error naming the remedy, and writes a `key.rotation-failed` audit row
+- [x] `RevokeAsSystemAsync` revokes with a system-attributed audit row and no HTTP caller (plan 21 Trigger B)
+- [x] Key Vault protector resolves the key's current version per wrap (5-minute cache) and refuses to unwrap with a key id outside the configured vault/key
 - [x] Rotation regenerates both keys, updates `ApimKeyIssuedDate`, and the old plaintext no longer matches
 - [x] Revocation deletes the subscription, clears every key field, leaves `IsActive = true`, and is idempotent (`204`)
 - [x] `GET /keys/me` never exposes more than the last four characters; reveal returns the full key and is audited

--- a/plans/09-apim-keys.md
+++ b/plans/09-apim-keys.md
@@ -5,31 +5,45 @@
 > Labels: epic, backend
 
 ## Overview
-This epic wires Foundry Gate to Azure API Management so that approved developers get a real APIM subscription key they can use to call the AI Foundry gateway. Key operations — provision, rotate (self-service and admin), and revoke — are all mediated through the Foundry Gate API using the Azure Resource Manager SDK with Managed Identity, so no APIM credentials are stored in the application. The `ApiKey` table tracks key metadata (APIM subscription ID, status, created/rotated timestamps) but never stores the raw key value.
+This epic wires Foundry Gate to Azure API Management so that approved developers get a real APIM subscription key they can use to call the AI Foundry gateway. Key operations — provision, rotate (self-service and admin), reveal, and revoke — are all mediated through the Foundry Gate API using the Azure Resource Manager SDK with the API's managed identity, so no APIM credentials are stored in the application. Key metadata lives on `User` (`ApimSubscriptionId` — the ARM resource id, not secret; `ApimSubscriptionKey` — the primary key **encrypted** by `IKeyProtector`, #95; `ApimSubscriptionKeyHint` — last four characters for the masked view; `ApimKeyIssuedDate`). The plaintext key is never persisted and never logged.
+
+Direction (Sep 2026, #81/#82): a developer's subscription is created under their **quota-tier product** (`GatewayTiers.Standard/Power/Unlimited`), and a tier change re-scopes the subscription to another product (`IApimKeyService.MoveToProductAsync`). There is no suspended state anywhere in the lifecycle (#116): quota exhaustion is a real-time gateway `403`, and every people-lifecycle exit (admin deactivation, Entra departure, admin key revocation) **deletes** the subscription. Re-activation re-runs provisioning and reuses an orphaned subscription if one exists.
 
 ## Approach
 
+### Encrypt `User.ApimSubscriptionKey` at rest (#95)
+`Services/Security/IKeyProtector` with two implementations selected by `KeyProtection:Provider`: `KeyVaultKeyProtector` wraps the key bytes directly with RSA-OAEP-256 under the RSA key at `Gateway:KeyEncryptionKeyUri` (the `fg-apim-key-encryption` key infra creates, #43/#111; the API identity is Key Vault Crypto User) and stores `kv1:{versionedKeyId}:{base64}`; `DataProtectionKeyProtector` (ASP.NET Core Data Protection, `dp1:{token}`) is permitted in `local` only. Selection is fail-fast at startup (`KeyProtectorFactory` + `AddResolveOnStartup`): `KeyVault` without a key URI, or `DataProtection` outside `local`, refuses to boot. The envelope records the exact Key Vault key *version* that wrapped each row, so a Key Vault key rotation needs no re-encryption sweep — old rows unwrap with their version, new writes use the new one. `ApimSubscriptionId` is an address, not a credential, and stays plain.
+
+Files:
+- `src/FoundryGate.Api/Services/Security/{IKeyProtector,KeyEnvelope,KeyVaultKeyProtector,DataProtectionKeyProtector,KeyProtectorFactory,SecurityServiceCollectionExtensions}.cs`
+- `src/FoundryGate.Api/Configuration/AppSettings.cs` (`GatewayOptions`, `KeyProtectionOptions`)
+- `src/FoundryGate.Data/Entities/User.cs` + `src/FoundryGate.Database/dbo/Tables/Users.sql` (`ApimSubscriptionKey` widened to 1000; `ApimSubscriptionKeyHint`, `ApimKeyIssuedDate` added)
+
 ### Implement APIM key provisioning using Azure SDK and Managed Identity (#36)
-Create an `IApimKeyService` backed by `ApiManagementSubscriptionResource` from `Azure.ResourceManager.ApiManagement`. On `POST /keys/provision` (developer-only, one active key per user limit enforced), the service calls `CreateOrUpdateAsync` on the APIM management plane to create a subscription named `foundrygate-{userId}` scoped to the configured product, then stores the APIM `subscriptionId` and a masked key hint in `User.ApimSubscriptionId` / `User.ApimSubscriptionKey`. The actual key value is returned once in the response body and never persisted in plaintext. After provisioning, call `IQuotaResolutionService` to write the initial `QuotaAllocation` and push the user's resolved limit into the APIM cache key `quota-{subscriptionId}`. The subscription starts in `active` state. Use `DefaultAzureCredential`. Read APIM resource details from `IConfiguration`.
+`Services/Keys/IApimManagementClient` is the thin seam over `Azure.ResourceManager.ApiManagement` (`ArmApimManagementClient`; addressed by `Gateway:SubscriptionId/ResourceGroup/ApimName` — the `Gateway__*` env vars infra sets, #108). `IApimKeyService.ProvisionAsync(user, tierProductId)` creates the subscription `foundrygate-{UserId}` (`Domain/Keys/ApimSubscriptionNames`, shared with the Functions reconciliation job) scoped to `/products/{tier}`, display name carrying the email, `active`; stores the encrypted primary key, resource id, hint and issue date; audits `key.provisioned`; saves; returns the plaintext once (`ApiKeyRevealResponse`). A second provision is `409`. If APIM already holds a subscription with that name (an orphan from a save that failed after APIM succeeded), it is reused: re-scoped if needed and **both keys regenerated**, so the orphan's keys are dead. APIM is called before the row is touched, so an ARM failure leaves the database untouched. Quota resolution and the lifecycle orchestration around this call belong to plan 21 (#64/#65).
 
-Files expected to be created or modified:
+Files:
+- `src/FoundryGate.Api/Services/Keys/{IApimManagementClient,ArmApimManagementClient,UnconfiguredApimManagementClient,IApimKeyService,ApimKeyService,KeysServiceCollectionExtensions}.cs`
 - `src/FoundryGate.Api/Controllers/KeysController.cs`
-- `src/FoundryGate.Api/Services/IApimKeyService.cs`
-- `src/FoundryGate.Api/Services/ApimKeyService.cs`
-- `src/FoundryGate.Api/appsettings.json` (Apim section)
-- `src/FoundryGate.Api/FoundryGate.Api.csproj` (Azure.ResourceManager.ApiManagement package)
+- `src/FoundryGate.Domain/Keys/ApimSubscriptionNames.cs`
+- `Directory.Packages.props` / `FoundryGate.Api.csproj` (`Azure.ResourceManager.ApiManagement`, `Azure.Security.KeyVault.Keys`)
 
-### Implement key rotation (self-service and admin) and revocation (#37)
-`POST /keys/me/rotate` and `POST /keys/{userId}/rotate` (admin): call `RegeneratePrimaryKeyAsync` on the APIM subscription, re-encrypt the new key via Key Vault, update `User.ApimSubscriptionKey`, write audit log, return new key value once. `DELETE /keys/{userId}` (admin) and the user deactivation path: call APIM to **delete** the subscription entirely (not suspend — deletion means the key stops working immediately and cannot be re-enabled). Set `User.ApimSubscriptionId` and `User.ApimSubscriptionKey` to null, `User.IsActive = false`, `QuotaAllocation.IsHardStopped = true`. Suspension (for quota exhaustion) is distinct from deletion (for account deactivation): suspended subscriptions can be re-enabled; deleted ones require a new `POST /keys/{userId}/provision`.
+### Implement key rotation (self-service and admin), reveal, and revocation (#37)
+`POST /keys/me/rotate` and `POST /keys/{userId}/rotate` (admin): regenerate **both** the primary and the secondary key (#117 — the secondary is never issued, but rotating it bounds its lifetime to the primary's), re-encrypt the new primary, update `User.ApimSubscriptionKey`/`Hint`/`IssuedDate`, audit `key.rotated`, return the new value once. `GET /keys/me` returns the masked key from the stored hint (no decryption). `POST /keys/me/reveal` decrypts and returns the full key once, audited `key.revealed`, never cached. `DELETE /keys/{userId}` (admin) is **key-only revocation** (#116): delete the APIM subscription, clear the four key fields, audit `key.revoked`; `User.IsActive` is untouched and the user can be re-provisioned. Idempotent (`204` even with no key). Full deactivation is `POST /users/{id}/deactivate` (plan 21), which calls `RevokeAsync` as its first step. A subscription that vanished from APIM behind FoundryGate's back turns rotate/move into a `409` with "revoke and re-provision" guidance.
 
-Files expected to be created or modified:
+Files:
 - `src/FoundryGate.Api/Controllers/KeysController.cs`
-- `src/FoundryGate.Api/Services/ApimKeyService.cs`
+- `src/FoundryGate.Api/Services/Keys/ApimKeyService.cs`
 
 ## Verification
-- [ ] `dotnet build` passes
-- [ ] Provisioning creates an APIM subscription and returns the key value
-- [ ] A second provision attempt while a key is active returns `409`
-- [ ] Rotation generates a new key and updates `RotatedAt`
-- [ ] Revoked key status is reflected in `GET /keys` response
-- [ ] Audit log captures provision, rotation, and revocation events
+- [x] `dotnet build FoundryGate.sln -c Release` passes with zero warnings
+- [x] Provisioning creates an APIM subscription under the tier product and returns the key value once (`ApimKeyServiceTests`, `KeysEndpointTests`)
+- [x] A second provision attempt while a key is active returns `409`; an unknown tier `400`; a deactivated user `409`
+- [x] An orphan subscription is reused (re-scoped, both keys regenerated) instead of erroring
+- [x] Rotation regenerates both keys, updates `ApimKeyIssuedDate`, and the old plaintext no longer matches
+- [x] Revocation deletes the subscription, clears every key field, leaves `IsActive = true`, and is idempotent (`204`)
+- [x] `GET /keys/me` never exposes more than the last four characters; reveal returns the full key and is audited
+- [x] Audit log captures provision, rotation, reveal, revocation and tier-change events, attributed to the caller, with no key material in `Details`
+- [x] Plaintext never reaches the logger (`Plaintext_key_material_never_reaches_the_logger_or_an_audit_row`)
+- [x] Key protector round-trips under both providers; `DataProtection` is refused outside `local`; `KeyVault` without a key URI fails startup; envelope fits the 1000-char column for RSA-4096
+- [ ] Live: provision/rotate/reveal/revoke against a real APIM + Key Vault (manual checklist in the follow-up issue filed by the #36/#37/#95 PR)

--- a/plans/21-provision-deprovision.md
+++ b/plans/21-provision-deprovision.md
@@ -58,20 +58,21 @@ Trigger C — Admin key revocation without deactivation (DELETE /keys/{userId})
 **Steps:**
 
 ```
-1. Call IApimKeyService.DeleteSubscriptionAsync:
-     a. APIM Management: DELETE /subscriptions/{apimSubscriptionId}
-     b. Set User.ApimSubscriptionId = null, User.ApimSubscriptionKey = null
+1. Call IApimKeyService.RevokeAsync (no-op when the user has no key):
+     a. APIM Management: DELETE /subscriptions/foundrygate-{userId}
+     b. Clear User.ApimSubscriptionId / ApimSubscriptionKey / ApimSubscriptionKeyHint / ApimKeyIssuedDate
+     c. Audit key.revoked
 2. [Triggers A + B only] Set User.IsActive = false
 3. Set QuotaAllocation.IsHardStopped = true for the current period
 4. Cancel any Pending QuotaIncreaseRequests for this user (set Status = Rejected, ReviewNotes = "User deactivated")
 5. Write audit log: user.deactivated | user.key-revoked | sync.user-departed (as appropriate)
 ```
 
-**Key distinction — suspend vs. delete:**
+**Every exit deletes — there is no suspended state (#116):**
 
 | Scenario | APIM action | User.IsActive | Key can be restored? |
 |---|---|---|---|
-| Quota exhausted (usage sync) | Suspend subscription | true | Yes — monthly reset re-enables |
+| Quota exhausted | None — the gateway's `llm-token-limit` returns `403` until the month resets (#81); the subscription stays `active` | true | n/a — the key keeps working the moment the window resets |
 | Admin deactivation | Delete subscription | false | Only via re-activation (Trigger C of provision) |
 | Entra departure | Delete subscription | false | Only if user returns to Entra and admin re-activates |
 | Admin key revocation only | Delete subscription | true | Yes — admin calls POST /keys/{userId}/provision |
@@ -113,7 +114,7 @@ Files expected to be created or modified:
 - `src/FoundryGate.Api/Controllers/UsersController.cs` (deactivate/activate wired to lifecycle service)
 - `src/FoundryGate.Api/Services/EntraUserSyncService.cs` (departure path wired to lifecycle service)
 - `src/FoundryGate.Api/Controllers/KeysController.cs` (provision/revoke wired to lifecycle service)
-- `src/FoundryGate.Api/Services/IApimKeyService.cs` (add SuspendAsync, ReenableAsync, DeleteAsync)
+- `src/FoundryGate.Api/Services/Keys/IApimKeyService.cs` (already provides the building blocks: `ProvisionAsync`, `RotateAsync`, `RevokeAsync`, `MoveToProductAsync` — plan 09; no suspend/re-enable surface exists, #116)
 
 ### Add re-activation endpoint and orphan subscription detection (#66)
 `POST /users/{id}/activate` currently just sets `User.IsActive = true`. It must call `IUserLifecycleService.ReactivateAsync` which runs the full provision pipeline (Trigger C). Before calling APIM to create a new subscription, check if a subscription named `foundrygate-{userId}` already exists on the APIM Management plane — if it does (orphan from a failed previous deprovision), reuse it rather than creating a duplicate. `DELETE /keys/{userId}` (admin key revocation without deactivation) leaves `User.IsActive = true` and must not call the full deprovision pipeline — only step 1 (APIM delete) and step 5 (audit log).

--- a/src/FoundryGate.Api/Configuration/AppSettings.cs
+++ b/src/FoundryGate.Api/Configuration/AppSettings.cs
@@ -132,9 +132,9 @@ public class KeyProtectionOptions
     /// Defaults to <see cref="KeyProtectionProviderType.KeyVault"/> so a cloud environment that
     /// forgets the section fails closed (missing key URI → startup error) rather than silently
     /// falling back to a machine-local key ring; <c>appsettings.local.json</c> opts into
-    /// <see cref="KeyProtectionProviderType.DataProtection"/>.
+    /// <see cref="KeyProtectionProviderType.DataProtection"/>. (No <c>[Required]</c>: it is a no-op
+    /// on a non-nullable enum; the binder rejects unknown names and the default is the safe one.)
     /// </summary>
-    [Required]
     public KeyProtectionProviderType Provider { get; set; } = KeyProtectionProviderType.KeyVault;
 }
 

--- a/src/FoundryGate.Api/Configuration/AppSettings.cs
+++ b/src/FoundryGate.Api/Configuration/AppSettings.cs
@@ -34,6 +34,108 @@ public class AppSettings
     /// <see cref="AzureOptions.KeyVaultUrl"/> skips resolution entirely so local dev runs
     /// with docker SQL and no Azure connectivity at all.</summary>
     public AzureOptions Azure { get; set; } = new();
+
+    /// <summary>
+    /// Where the gateway lives (#108): APIM addressing for subscription lifecycle calls and the
+    /// Key Vault key that wraps stored APIM keys. Set by <c>infra/modules/control-plane.bicep</c> as
+    /// <c>Gateway__*</c> environment variables; optional locally (no APIM → the key endpoints answer
+    /// with a clear "not configured" error, everything else runs).
+    /// </summary>
+    public GatewayOptions Gateway { get; set; } = new();
+
+    /// <summary>How <c>User.ApimSubscriptionKey</c> is encrypted at rest (#95).</summary>
+    public KeyProtectionOptions KeyProtection { get; set; } = new();
+}
+
+/// <summary>
+/// Gateway addressing bound from the <c>Gateway</c> section — the keys
+/// <c>infra/modules/control-plane.bicep</c> sets on both hosts (#108), so nobody types ARM ids into
+/// <c>SystemConfiguration</c> by hand. This wave binds the APIM and key-wrapping subset; the Foundry
+/// (#61) and reconciliation (#84) waves add <c>ApimGatewayUrl</c>, <c>LogAnalyticsWorkspaceId</c> and
+/// <c>FoundryAccountNames</c> to this same class.
+/// </summary>
+public class GatewayOptions : IValidatableObject
+{
+    /// <summary>Azure subscription id that holds the APIM instance (<c>Gateway__SubscriptionId</c>).</summary>
+    public string? SubscriptionId { get; set; }
+
+    /// <summary>Resource group of the APIM instance (<c>Gateway__ResourceGroup</c>).</summary>
+    public string? ResourceGroup { get; set; }
+
+    /// <summary>APIM service name — the short name, not the ARM id (<c>Gateway__ApimName</c>).</summary>
+    public string? ApimName { get; set; }
+
+    /// <summary>
+    /// Versionless Key Vault key URI (<c>https://{vault}.vault.azure.net/keys/fg-apim-key-encryption</c>)
+    /// of the RSA key that wraps APIM subscription keys before they are stored (#95;
+    /// <c>Gateway__KeyEncryptionKeyUri</c>). Versionless so a Key Vault key rotation needs no redeploy —
+    /// each stored envelope records the exact key version that wrapped it. Required when
+    /// <see cref="KeyProtectionOptions.Provider"/> is <see cref="KeyProtectionProviderType.KeyVault"/>.
+    /// </summary>
+    public string? KeyEncryptionKeyUri { get; set; }
+
+    /// <summary><see langword="true"/> when all three APIM addressing values are present, i.e. the Api can reach the APIM management plane.</summary>
+    public bool IsApimConfigured =>
+        !string.IsNullOrWhiteSpace(SubscriptionId)
+        && !string.IsNullOrWhiteSpace(ResourceGroup)
+        && !string.IsNullOrWhiteSpace(ApimName);
+
+    /// <summary>
+    /// The three APIM values are all-or-nothing — a partially addressed APIM instance is a
+    /// misconfiguration, not "APIM off" — and the key URI, when present, must be an absolute
+    /// <c>https</c> URI (the shape <c>CryptographyClient</c> accepts).
+    /// </summary>
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var anyApim = !string.IsNullOrWhiteSpace(SubscriptionId)
+            || !string.IsNullOrWhiteSpace(ResourceGroup)
+            || !string.IsNullOrWhiteSpace(ApimName);
+
+        if (anyApim && !IsApimConfigured)
+        {
+            yield return new ValidationResult(
+                $"{nameof(SubscriptionId)}, {nameof(ResourceGroup)} and {nameof(ApimName)} must all be set (or all be empty) to address the APIM instance.",
+                [nameof(SubscriptionId), nameof(ResourceGroup), nameof(ApimName)]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(KeyEncryptionKeyUri)
+            && (!Uri.TryCreate(KeyEncryptionKeyUri, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps))
+        {
+            yield return new ValidationResult(
+                $"{nameof(KeyEncryptionKeyUri)} must be an absolute https URI of a Key Vault key.",
+                [nameof(KeyEncryptionKeyUri)]);
+        }
+    }
+}
+
+/// <summary>Which <c>IKeyProtector</c> encrypts <c>User.ApimSubscriptionKey</c> at rest (#95).</summary>
+public enum KeyProtectionProviderType
+{
+    /// <summary>
+    /// Azure Key Vault RSA-OAEP-256 key wrapping with <see cref="GatewayOptions.KeyEncryptionKeyUri"/>
+    /// through the app's managed identity (Key Vault Crypto User). The only provider allowed outside
+    /// <c>local</c>.
+    /// </summary>
+    KeyVault,
+
+    /// <summary>
+    /// ASP.NET Core Data Protection with the machine-local key ring — no Azure needed, so local dev
+    /// and the integration tests run hermetically. Refused at startup in <c>qa</c>/<c>prod</c>.
+    /// </summary>
+    DataProtection,
+}
+
+/// <summary>Bound from the <c>KeyProtection</c> section.</summary>
+public class KeyProtectionOptions
+{
+    /// <summary>
+    /// Defaults to <see cref="KeyProtectionProviderType.KeyVault"/> so a cloud environment that
+    /// forgets the section fails closed (missing key URI → startup error) rather than silently
+    /// falling back to a machine-local key ring; <c>appsettings.local.json</c> opts into
+    /// <see cref="KeyProtectionProviderType.DataProtection"/>.
+    /// </summary>
+    [Required]
+    public KeyProtectionProviderType Provider { get; set; } = KeyProtectionProviderType.KeyVault;
 }
 
 /// <summary>

--- a/src/FoundryGate.Api/Controllers/KeysController.cs
+++ b/src/FoundryGate.Api/Controllers/KeysController.cs
@@ -1,0 +1,89 @@
+using FoundryGate.Api.Services.Keys;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Keys.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// <c>/api/v1/keys</c> — APIM subscription-key lifecycle (spec &#167;4.5; issues #36, #37). The
+/// <c>/me</c> routes serve any authenticated developer with a <c>User</c> row (403 otherwise — call
+/// <c>GET /users/me</c> first); the <c>/{userId}</c> routes are admin-only. Every route that mints a
+/// key returns the plaintext exactly once in an <see cref="ApiKeyRevealResponse"/>; every other read
+/// is the masked <see cref="ApiKeyResponse"/>.
+/// </summary>
+public sealed class KeysController(IApimKeyService keys) : ApiControllerBase
+{
+    /// <summary>The caller's key, masked to its last four characters; <c>isProvisioned = false</c> when they have none.</summary>
+    [HttpGet("me")]
+    [ProducesResponseType<ApiKeyResponse>(StatusCodes.Status200OK)]
+    public Task<ApiKeyResponse> GetMineAsync(CancellationToken cancellationToken) =>
+        keys.GetMineAsync(cancellationToken);
+
+    /// <summary>
+    /// Decrypts and returns the caller's full key once (spec &#167;11: fetched directly, never stored in
+    /// the browser). Audited as <c>key.revealed</c>. 404 when the caller has no key.
+    /// </summary>
+    [HttpPost("me/reveal")]
+    [ProducesResponseType<ApiKeyRevealResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public Task<ApiKeyRevealResponse> RevealMineAsync(CancellationToken cancellationToken) =>
+        keys.RevealMineAsync(cancellationToken);
+
+    /// <summary>
+    /// Regenerates the caller's key — both the primary they hold and the never-issued secondary
+    /// (#117) — and returns the new primary once. The old key stops working immediately. 404 when
+    /// the caller has no key; 409 when the APIM subscription behind it has vanished.
+    /// </summary>
+    [HttpPost("me/rotate")]
+    [ProducesResponseType<ApiKeyRevealResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public Task<ApiKeyRevealResponse> RotateMineAsync(CancellationToken cancellationToken) =>
+        keys.RotateMineAsync(cancellationToken);
+
+    /// <summary>
+    /// Admin: provisions a key for a user who has none, under the quota-tier product
+    /// <paramref name="tier"/> (<c>standard</c> | <c>power</c> | <c>unlimited</c>; defaults to
+    /// <see cref="GatewayTiers.Default"/>). Returns the plaintext once. 404 unknown user; 409 when the
+    /// user already has a key or is deactivated; 400 for an unknown tier.
+    /// </summary>
+    /// <remarks>
+    /// The tier is caller-supplied for now. Once the quota wave lands (#32/#33, epic #64's lifecycle
+    /// orchestrator) the user's <em>resolved</em> tier is supplied by the quota resolution service and
+    /// this parameter becomes an override at most — see epic #64 for the wiring.
+    /// </remarks>
+    [HttpPost("{userId:int}/provision")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ProducesResponseType<ApiKeyRevealResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public Task<ApiKeyRevealResponse> ProvisionAsync(int userId, [FromQuery] string tier = GatewayTiers.Default, CancellationToken cancellationToken = default) =>
+        keys.ProvisionForUserAsync(userId, tier, cancellationToken);
+
+    /// <summary>Admin: rotates any user's key (both APIM keys regenerated, #117) and returns the new primary once. 404 unknown user or no key.</summary>
+    [HttpPost("{userId:int}/rotate")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ProducesResponseType<ApiKeyRevealResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public Task<ApiKeyRevealResponse> RotateAsync(int userId, CancellationToken cancellationToken) =>
+        keys.RotateForUserAsync(userId, cancellationToken);
+
+    /// <summary>
+    /// Admin: key-only revocation (#116) — deletes the APIM subscription and clears the stored key;
+    /// the user stays active and can be re-provisioned. Idempotent: 204 whether or not a key existed.
+    /// Deactivating the user is <c>POST /users/{id}/deactivate</c>, not this. 404 unknown user.
+    /// </summary>
+    [HttpDelete("{userId:int}")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RevokeAsync(int userId, CancellationToken cancellationToken)
+    {
+        _ = await keys.RevokeForUserAsync(userId, cancellationToken);
+        return NoContent();
+    }
+}

--- a/src/FoundryGate.Api/Controllers/KeysController.cs
+++ b/src/FoundryGate.Api/Controllers/KeysController.cs
@@ -25,6 +25,7 @@ public sealed class KeysController(IApimKeyService keys) : ApiControllerBase
     /// Decrypts and returns the caller's full key once (spec &#167;11: fetched directly, never stored in
     /// the browser). Audited as <c>key.revealed</c>. 404 when the caller has no key.
     /// </summary>
+    /// <remarks>Not yet rate-limited — a leaked bearer token can call this repeatedly; #136 adds a per-user limiter.</remarks>
     [HttpPost("me/reveal")]
     [ProducesResponseType<ApiKeyRevealResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/FoundryGate.Api/Controllers/KeysController.cs
+++ b/src/FoundryGate.Api/Controllers/KeysController.cs
@@ -50,9 +50,10 @@ public sealed class KeysController(IApimKeyService keys) : ApiControllerBase
     /// user already has a key or is deactivated; 400 for an unknown tier.
     /// </summary>
     /// <remarks>
-    /// The tier is caller-supplied for now. Once the quota wave lands (#32/#33, epic #64's lifecycle
-    /// orchestrator) the user's <em>resolved</em> tier is supplied by the quota resolution service and
-    /// this parameter becomes an override at most — see epic #64 for the wiring.
+    /// The tier is caller-supplied for now. #118 (<c>ApimGatewayTierSync</c>) wires the quota wave's
+    /// resolution (#32/#33) to <c>IApimKeyService.MoveToProductAsync</c>, after which the user's
+    /// <em>resolved</em> tier drives the product and this parameter becomes an override at most; the
+    /// lifecycle orchestrator (epic #64) then owns the provision call itself.
     /// </remarks>
     [HttpPost("{userId:int}/provision")]
     [Authorize(Policy = PolicyNames.AdminOnly)]

--- a/src/FoundryGate.Api/FoundryGate.Api.csproj
+++ b/src/FoundryGate.Api/FoundryGate.Api.csproj
@@ -3,6 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.ResourceManager.ApiManagement" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Imagile.Framework.Configuration" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />

--- a/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
+using FoundryGate.Api.Services.Keys;
+using FoundryGate.Api.Services.Security;
 
 namespace FoundryGate.Api.Services;
 
@@ -20,6 +22,8 @@ public static class ApiServiceCollectionExtensions
 
         services.AddIdentityServices();
         services.AddAuditServices();
+        services.AddSecurityServices();
+        services.AddKeysServices();
 
         return services;
     }

--- a/src/FoundryGate.Api/Services/Keys/ApimKeyService.cs
+++ b/src/FoundryGate.Api/Services/Keys/ApimKeyService.cs
@@ -3,11 +3,13 @@ using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Api.Services.Security;
 using FoundryGate.Data;
+using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Exceptions;
 using FoundryGate.Domain.Keys;
 using FoundryGate.Domain.Keys.Contracts;
+using Microsoft.EntityFrameworkCore;
 
 namespace FoundryGate.Api.Services.Keys;
 
@@ -17,17 +19,19 @@ namespace FoundryGate.Api.Services.Keys;
 /// key protector it composes are singletons.
 /// </summary>
 /// <remarks>
-/// Failure ordering, per plan 21's compensation table: APIM is called <em>before</em> the row is
-/// touched, so an APIM failure leaves the database untouched (the caller sees the ARM error), and a
-/// database failure after APIM succeeded leaves an orphan subscription that the next
-/// <see cref="ProvisionAsync"/> finds by name and reuses (regenerating its keys). Nothing here is
-/// retried; ARM's own retry policy covers transient faults.
+/// Failure ordering, per plan 21's compensation table: the row is claimed (provision) or the actor
+/// resolved first, APIM is called next, and the row is written last — so an APIM failure leaves the
+/// database as it was (the provision claim rolls back with its transaction), and a database failure
+/// after APIM succeeded leaves an orphan subscription that the next <see cref="ProvisionAsync"/>
+/// finds by name and adopts (regenerating its keys). Nothing here is retried; ARM's own retry policy
+/// covers transient faults.
 /// </remarks>
 public sealed class ApimKeyService(
     AppDbContext dbContext,
     IApimManagementClient apim,
     IKeyProtector keyProtector,
     IAuditService audit,
+    IAuditWriter auditWriter,
     ICurrentUserAccessor currentUser,
     TimeProvider timeProvider,
     ILogger<ApimKeyService> logger) : IApimKeyService
@@ -37,6 +41,11 @@ public sealed class ApimKeyService(
 
     /// <summary>APIM caps a subscription's display name at 100 characters.</summary>
     private const int ApimDisplayNameMaxLength = 100;
+
+    /// <summary>The only APIM subscription state a developer key is usable in.</summary>
+    private const string ActiveState = "active";
+
+    private const string RotationFailureRemedy = "Rotate again (POST /keys/{userId}/rotate) or revoke and re-provision (DELETE /keys/{userId}, then POST /keys/{userId}/provision).";
 
     /// <inheritdoc />
     public async Task<ApiKeyRevealResponse> ProvisionAsync(User user, string tierProductId, CancellationToken cancellationToken)
@@ -51,16 +60,44 @@ public sealed class ApimKeyService(
 
         if (HasKey(user))
         {
-            throw new ConflictException(
-                $"User {user.UserId} already has an APIM key. Rotate it (POST /keys/{user.UserId}/rotate) or revoke it (DELETE /keys/{user.UserId}) before provisioning a new one.");
+            throw AlreadyHasKey(user);
         }
 
         await EnsureActorAsync(cancellationToken);
         var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+        var resourceId = apim.GetSubscriptionResourceId(subscriptionName);
+
+        // Claim the row before touching APIM. Inside a transaction we own — unless the caller (plan 21's
+        // orchestrator) already opened one, in which case the claim and the save simply join it — so an
+        // APIM failure below rolls the claim back and never leaves a half-provisioned row. On SQL Server
+        // the claimed row stays locked until commit, so a concurrent provisioner blocks, then sees 0 rows.
+        await using var transaction = dbContext.Database.CurrentTransaction is null
+            ? await dbContext.Database.BeginTransactionAsync(cancellationToken)
+            : null;
+
+        var claimed = await dbContext.Users
+            .Where(u => u.UserId == user.UserId && u.ApimSubscriptionId == string.Empty)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(u => u.ApimSubscriptionId, resourceId), cancellationToken);
+        if (claimed == 0)
+        {
+            throw AlreadyHasKey(user);
+        }
 
         // Orphan detection (plan 21 / #66): a previous provision may have created the subscription and
-        // then failed to save. Reuse it rather than erroring — but never trust its existing keys.
+        // then failed to save. Reuse it rather than erroring — but never trust its existing keys, and
+        // never adopt one that is not active (its regenerated key would still 401 at the gateway).
         var existing = await apim.GetSubscriptionAsync(subscriptionName, cancellationToken);
+        if (existing is not null && !string.Equals(existing.State, ActiveState, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning(
+                "Orphan APIM subscription {SubscriptionName} for user {UserId} is in state '{State}', not active; deleting it and creating a fresh one.",
+                subscriptionName,
+                user.UserId,
+                existing.State);
+            _ = await apim.DeleteSubscriptionAsync(subscriptionName, cancellationToken);
+            existing = null;
+        }
+
         ApimSubscription subscription;
         ApimSubscriptionKeys keys;
         var reusedOrphan = existing is not null;
@@ -95,6 +132,11 @@ public sealed class ApimKeyService(
             cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
 
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+
         logger.LogInformation(
             "Provisioned APIM subscription {SubscriptionName} for user {UserId} under product {ProductId} (orphan reused: {ReusedOrphan}).",
             subscriptionName,
@@ -113,7 +155,6 @@ public sealed class ApimKeyService(
         await EnsureActorAsync(cancellationToken);
 
         var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
-        ApimSubscriptionKeys keys;
 
         try
         {
@@ -121,23 +162,39 @@ public sealed class ApimKeyService(
             // live credential whose lifetime exceeds every primary the developer has ever held.
             await apim.RegeneratePrimaryKeyAsync(subscriptionName, cancellationToken);
             await apim.RegenerateSecondaryKeyAsync(subscriptionName, cancellationToken);
-            keys = await apim.ListSecretsAsync(subscriptionName, cancellationToken);
         }
         catch (ApimSubscriptionNotFoundException exception)
         {
             throw SubscriptionMissing(user, exception);
         }
 
-        var issuedDate = timeProvider.GetUtcNow();
-        await StoreKeyAsync(user, user.ApimSubscriptionId, keys.PrimaryKey, issuedDate, cancellationToken);
+        // From here on APIM holds new keys; anything that stops us storing the new primary leaves the
+        // row's ciphertext stale. Keep the previous values so the failure path can restore them and
+        // leave a trail instead of a silently unrevealable key.
+        var previous = (user.ApimSubscriptionKey, user.ApimSubscriptionKeyHint, user.ApimKeyIssuedDate);
+        AuditLog? rotatedRow = null;
+        DateTimeOffset issuedDate;
+        ApimSubscriptionKeys keys;
 
-        await audit.LogAsync(
-            AuditActions.KeyRotated,
-            AuditTargetTypes.ApiKey,
-            TargetId(user),
-            new { apimSubscriptionId = user.ApimSubscriptionId, subscriptionName, keysRegenerated = new[] { "primary", "secondary" } },
-            cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            keys = await apim.ListSecretsAsync(subscriptionName, cancellationToken);
+            issuedDate = timeProvider.GetUtcNow();
+            await StoreKeyAsync(user, user.ApimSubscriptionId, keys.PrimaryKey, issuedDate, cancellationToken);
+
+            rotatedRow = await audit.LogAsync(
+                AuditActions.KeyRotated,
+                AuditTargetTypes.ApiKey,
+                TargetId(user),
+                new { apimSubscriptionId = user.ApimSubscriptionId, subscriptionName, keysRegenerated = new[] { "primary", "secondary" } },
+                cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await RecordRotationFailureAsync(user, subscriptionName, previous, rotatedRow, exception, cancellationToken);
+            throw;
+        }
 
         logger.LogInformation("Rotated APIM subscription {SubscriptionName} for user {UserId} (primary and secondary regenerated).", subscriptionName, user.UserId);
 
@@ -155,27 +212,28 @@ public sealed class ApimKeyService(
         }
 
         await EnsureActorAsync(cancellationToken);
-        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
-        var apimSubscriptionId = user.ApimSubscriptionId;
 
-        var existedInApim = await apim.DeleteSubscriptionAsync(subscriptionName, cancellationToken);
-
-        user.ApimSubscriptionId = string.Empty;
-        user.ApimSubscriptionKey = string.Empty;
-        user.ApimSubscriptionKeyHint = string.Empty;
-        user.ApimKeyIssuedDate = null;
-
-        await audit.LogAsync(
-            AuditActions.KeyRevoked,
-            AuditTargetTypes.ApiKey,
-            TargetId(user),
-            new { apimSubscriptionId, subscriptionName, existedInApim },
+        return await RevokeCoreAsync(
+            user,
+            details => audit.LogAsync(AuditActions.KeyRevoked, AuditTargetTypes.ApiKey, TargetId(user), new { details.apimSubscriptionId, details.subscriptionName, details.existedInApim }, cancellationToken),
             cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 
-        logger.LogInformation("Revoked APIM subscription {SubscriptionName} for user {UserId} (existed in APIM: {ExistedInApim}); user remains {IsActive}.", subscriptionName, user.UserId, existedInApim, user.IsActive ? "active" : "inactive");
+    /// <inheritdoc />
+    public async Task<bool> RevokeAsSystemAsync(User user, string reason, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
 
-        return true;
+        if (!HasKey(user))
+        {
+            return false;
+        }
+
+        return await RevokeCoreAsync(
+            user,
+            details => Task.FromResult(auditWriter.AddSystem(AuditActions.KeyRevoked, AuditTargetTypes.ApiKey, TargetId(user), new { details.apimSubscriptionId, details.subscriptionName, details.existedInApim, reason })),
+            cancellationToken);
     }
 
     /// <inheritdoc />
@@ -232,6 +290,11 @@ public sealed class ApimKeyService(
         RequireKey(user);
         await EnsureActorAsync(cancellationToken);
 
+        // HasKey ⇒ ApimKeyIssuedDate set is an invariant this service writes; a violation is corrupt
+        // data to surface, not a date to make up.
+        var issuedDate = user.ApimKeyIssuedDate
+            ?? throw new InvalidOperationException($"User {user.UserId} has an APIM key but no ApimKeyIssuedDate; the row is inconsistent.");
+
         var plaintext = await keyProtector.UnprotectAsync(user.ApimSubscriptionKey, cancellationToken);
 
         await audit.LogAsync(
@@ -244,7 +307,7 @@ public sealed class ApimKeyService(
 
         logger.LogInformation("Revealed APIM key for user {UserId}.", user.UserId);
 
-        return Reveal(user, plaintext, user.ApimKeyIssuedDate ?? timeProvider.GetUtcNow());
+        return Reveal(user, plaintext, issuedDate);
     }
 
     /// <inheritdoc />
@@ -279,6 +342,81 @@ public sealed class ApimKeyService(
     /// <inheritdoc />
     public async Task<bool> RevokeForUserAsync(int userId, CancellationToken cancellationToken) =>
         await RevokeAsync(await FindUserAsync(userId, cancellationToken), cancellationToken);
+
+    /// <summary>The shared revoke body; <paramref name="addAudit"/> decides who the row is attributed to.</summary>
+    private async Task<bool> RevokeCoreAsync(
+        User user,
+        Func<(string apimSubscriptionId, string subscriptionName, bool existedInApim), Task<AuditLog>> addAudit,
+        CancellationToken cancellationToken)
+    {
+        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+        var apimSubscriptionId = user.ApimSubscriptionId;
+
+        var existedInApim = await apim.DeleteSubscriptionAsync(subscriptionName, cancellationToken);
+
+        user.ApimSubscriptionId = string.Empty;
+        user.ApimSubscriptionKey = string.Empty;
+        user.ApimSubscriptionKeyHint = string.Empty;
+        user.ApimKeyIssuedDate = null;
+
+        _ = await addAudit((apimSubscriptionId, subscriptionName, existedInApim));
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Revoked APIM subscription {SubscriptionName} for user {UserId} (existed in APIM: {ExistedInApim}); user remains {ActiveState}.",
+            subscriptionName,
+            user.UserId,
+            existedInApim,
+            user.IsActive ? "active" : "inactive");
+
+        return true;
+    }
+
+    /// <summary>
+    /// APIM regenerated the keys but the new primary was not stored. Restore the previous (stale)
+    /// values so the row is at least self-consistent, drop the unsaved <c>key.rotated</c> row, log at
+    /// Error with the remedy, and try to leave a <c>key.rotation-failed</c> audit row (best effort — the
+    /// database itself may be what failed).
+    /// </summary>
+    private async Task RecordRotationFailureAsync(
+        User user,
+        string subscriptionName,
+        (string Key, string Hint, DateTimeOffset? IssuedDate) previous,
+        AuditLog? rotatedRow,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        user.ApimSubscriptionKey = previous.Key;
+        user.ApimSubscriptionKeyHint = previous.Hint;
+        user.ApimKeyIssuedDate = previous.IssuedDate;
+
+        if (rotatedRow is not null)
+        {
+            dbContext.Entry(rotatedRow).State = EntityState.Detached;
+        }
+
+        logger.LogError(
+            exception,
+            "APIM regenerated the keys of subscription {SubscriptionName} but the new key could not be stored; the ciphertext on user {UserId} is now STALE and reveal will return a dead key. {Remedy}",
+            subscriptionName,
+            user.UserId,
+            RotationFailureRemedy);
+
+        try
+        {
+            await audit.LogAsync(
+                AuditActions.KeyRotationFailed,
+                AuditTargetTypes.ApiKey,
+                TargetId(user),
+                new { apimSubscriptionId = user.ApimSubscriptionId, subscriptionName, error = exception.GetType().Name, remedy = RotationFailureRemedy },
+                cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception auditException) when (auditException is not OperationCanceledException)
+        {
+            logger.LogError(auditException, "Could not record the key.rotation-failed audit row for user {UserId}; the log line above is the only trail.", user.UserId);
+        }
+    }
 
     /// <summary>
     /// Resolves the audit actor <em>before</em> any APIM side effect. <c>IAuditService.LogAsync</c> would
@@ -329,6 +467,9 @@ public sealed class ApimKeyService(
             throw new KeyNotFoundException($"User {user.UserId} has no APIM key. An administrator can provision one with POST /keys/{user.UserId}/provision.");
         }
     }
+
+    private static ConflictException AlreadyHasKey(User user) =>
+        new($"User {user.UserId} already has an APIM key (or one is being provisioned right now). Rotate it (POST /keys/{user.UserId}/rotate) or revoke it (DELETE /keys/{user.UserId}) before provisioning a new one.");
 
     private static ConflictException SubscriptionMissing(User user, ApimSubscriptionNotFoundException inner) =>
         new(

--- a/src/FoundryGate.Api/Services/Keys/ApimKeyService.cs
+++ b/src/FoundryGate.Api/Services/Keys/ApimKeyService.cs
@@ -1,0 +1,360 @@
+using System.Globalization;
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Api.Services.Security;
+using FoundryGate.Data;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
+using FoundryGate.Domain.Keys;
+using FoundryGate.Domain.Keys.Contracts;
+
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>
+/// Default <see cref="IApimKeyService"/>. Scoped (shares the request's <see cref="AppDbContext"/> with
+/// <see cref="IAuditService"/> so each mutation and its audit row save together); the APIM client and
+/// key protector it composes are singletons.
+/// </summary>
+/// <remarks>
+/// Failure ordering, per plan 21's compensation table: APIM is called <em>before</em> the row is
+/// touched, so an APIM failure leaves the database untouched (the caller sees the ARM error), and a
+/// database failure after APIM succeeded leaves an orphan subscription that the next
+/// <see cref="ProvisionAsync"/> finds by name and reuses (regenerating its keys). Nothing here is
+/// retried; ARM's own retry policy covers transient faults.
+/// </remarks>
+public sealed class ApimKeyService(
+    AppDbContext dbContext,
+    IApimManagementClient apim,
+    IKeyProtector keyProtector,
+    IAuditService audit,
+    ICurrentUserAccessor currentUser,
+    TimeProvider timeProvider,
+    ILogger<ApimKeyService> logger) : IApimKeyService
+{
+    /// <summary>Eight bullets then the hint — the shape <c>ApiKeyResponse.MaskedKey</c> documents.</summary>
+    private const string MaskPrefix = "••••••••";
+
+    /// <summary>APIM caps a subscription's display name at 100 characters.</summary>
+    private const int ApimDisplayNameMaxLength = 100;
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> ProvisionAsync(User user, string tierProductId, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        var productId = NormalizeTier(tierProductId);
+
+        if (user.UserId <= 0)
+        {
+            throw new InvalidOperationException("The user must be saved (have a UserId) before an APIM subscription can be named after it.");
+        }
+
+        if (HasKey(user))
+        {
+            throw new ConflictException(
+                $"User {user.UserId} already has an APIM key. Rotate it (POST /keys/{user.UserId}/rotate) or revoke it (DELETE /keys/{user.UserId}) before provisioning a new one.");
+        }
+
+        await EnsureActorAsync(cancellationToken);
+        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+
+        // Orphan detection (plan 21 / #66): a previous provision may have created the subscription and
+        // then failed to save. Reuse it rather than erroring — but never trust its existing keys.
+        var existing = await apim.GetSubscriptionAsync(subscriptionName, cancellationToken);
+        ApimSubscription subscription;
+        ApimSubscriptionKeys keys;
+        var reusedOrphan = existing is not null;
+
+        if (existing is not null)
+        {
+            if (!string.Equals(existing.ProductId, productId, StringComparison.OrdinalIgnoreCase))
+            {
+                await apim.UpdateScopeAsync(subscriptionName, productId, cancellationToken);
+            }
+
+            await apim.RegeneratePrimaryKeyAsync(subscriptionName, cancellationToken);
+            await apim.RegenerateSecondaryKeyAsync(subscriptionName, cancellationToken);
+            keys = await apim.ListSecretsAsync(subscriptionName, cancellationToken);
+            subscription = existing;
+        }
+        else
+        {
+            var created = await apim.CreateOrUpdateSubscriptionAsync(subscriptionName, DisplayNameFor(user), productId, cancellationToken);
+            subscription = created.Subscription;
+            keys = created.Keys;
+        }
+
+        var issuedDate = timeProvider.GetUtcNow();
+        await StoreKeyAsync(user, subscription.ResourceId, keys.PrimaryKey, issuedDate, cancellationToken);
+
+        await audit.LogAsync(
+            AuditActions.KeyProvisioned,
+            AuditTargetTypes.ApiKey,
+            TargetId(user),
+            new { apimSubscriptionId = subscription.ResourceId, subscriptionName, productId, reusedOrphan },
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Provisioned APIM subscription {SubscriptionName} for user {UserId} under product {ProductId} (orphan reused: {ReusedOrphan}).",
+            subscriptionName,
+            user.UserId,
+            productId,
+            reusedOrphan);
+
+        return Reveal(user, keys.PrimaryKey, issuedDate);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> RotateAsync(User user, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        RequireKey(user);
+        await EnsureActorAsync(cancellationToken);
+
+        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+        ApimSubscriptionKeys keys;
+
+        try
+        {
+            // Both keys (#117): the secondary is never issued, but leaving it unrotated would leave a
+            // live credential whose lifetime exceeds every primary the developer has ever held.
+            await apim.RegeneratePrimaryKeyAsync(subscriptionName, cancellationToken);
+            await apim.RegenerateSecondaryKeyAsync(subscriptionName, cancellationToken);
+            keys = await apim.ListSecretsAsync(subscriptionName, cancellationToken);
+        }
+        catch (ApimSubscriptionNotFoundException exception)
+        {
+            throw SubscriptionMissing(user, exception);
+        }
+
+        var issuedDate = timeProvider.GetUtcNow();
+        await StoreKeyAsync(user, user.ApimSubscriptionId, keys.PrimaryKey, issuedDate, cancellationToken);
+
+        await audit.LogAsync(
+            AuditActions.KeyRotated,
+            AuditTargetTypes.ApiKey,
+            TargetId(user),
+            new { apimSubscriptionId = user.ApimSubscriptionId, subscriptionName, keysRegenerated = new[] { "primary", "secondary" } },
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Rotated APIM subscription {SubscriptionName} for user {UserId} (primary and secondary regenerated).", subscriptionName, user.UserId);
+
+        return Reveal(user, keys.PrimaryKey, issuedDate);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RevokeAsync(User user, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        if (!HasKey(user))
+        {
+            return false;
+        }
+
+        await EnsureActorAsync(cancellationToken);
+        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+        var apimSubscriptionId = user.ApimSubscriptionId;
+
+        var existedInApim = await apim.DeleteSubscriptionAsync(subscriptionName, cancellationToken);
+
+        user.ApimSubscriptionId = string.Empty;
+        user.ApimSubscriptionKey = string.Empty;
+        user.ApimSubscriptionKeyHint = string.Empty;
+        user.ApimKeyIssuedDate = null;
+
+        await audit.LogAsync(
+            AuditActions.KeyRevoked,
+            AuditTargetTypes.ApiKey,
+            TargetId(user),
+            new { apimSubscriptionId, subscriptionName, existedInApim },
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Revoked APIM subscription {SubscriptionName} for user {UserId} (existed in APIM: {ExistedInApim}); user remains {IsActive}.", subscriptionName, user.UserId, existedInApim, user.IsActive ? "active" : "inactive");
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task MoveToProductAsync(User user, string tierProductId, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        var productId = NormalizeTier(tierProductId);
+        RequireKey(user);
+        await EnsureActorAsync(cancellationToken);
+
+        var subscriptionName = ApimSubscriptionNames.ForUser(user.UserId);
+        var current = await apim.GetSubscriptionAsync(subscriptionName, cancellationToken)
+            ?? throw SubscriptionMissing(user, new ApimSubscriptionNotFoundException(subscriptionName));
+
+        if (string.Equals(current.ProductId, productId, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            await apim.UpdateScopeAsync(subscriptionName, productId, cancellationToken);
+        }
+        catch (ApimSubscriptionNotFoundException exception)
+        {
+            throw SubscriptionMissing(user, exception);
+        }
+
+        await audit.LogAsync(
+            AuditActions.KeyTierChanged,
+            AuditTargetTypes.ApiKey,
+            TargetId(user),
+            new { apimSubscriptionId = user.ApimSubscriptionId, subscriptionName, before = current.ProductId, after = productId },
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Moved APIM subscription {SubscriptionName} for user {UserId} from product {Before} to {After}.", subscriptionName, user.UserId, current.ProductId, productId);
+    }
+
+    /// <inheritdoc />
+    public ApiKeyResponse GetMasked(User user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        return HasKey(user)
+            ? new ApiKeyResponse(true, Mask(user.ApimSubscriptionKeyHint), user.ApimSubscriptionId)
+            : new ApiKeyResponse(false, null, null);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> RevealAsync(User user, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        RequireKey(user);
+        await EnsureActorAsync(cancellationToken);
+
+        var plaintext = await keyProtector.UnprotectAsync(user.ApimSubscriptionKey, cancellationToken);
+
+        await audit.LogAsync(
+            AuditActions.KeyRevealed,
+            AuditTargetTypes.ApiKey,
+            TargetId(user),
+            new { apimSubscriptionId = user.ApimSubscriptionId },
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Revealed APIM key for user {UserId}.", user.UserId);
+
+        return Reveal(user, plaintext, user.ApimKeyIssuedDate ?? timeProvider.GetUtcNow());
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiKeyResponse> GetMineAsync(CancellationToken cancellationToken) =>
+        GetMasked(await currentUser.GetRequiredUserAsync(cancellationToken));
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> RevealMineAsync(CancellationToken cancellationToken) =>
+        await RevealAsync(await GetActiveCallerAsync(cancellationToken), cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> RotateMineAsync(CancellationToken cancellationToken) =>
+        await RotateAsync(await GetActiveCallerAsync(cancellationToken), cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> ProvisionForUserAsync(int userId, string tierProductId, CancellationToken cancellationToken)
+    {
+        var user = await FindUserAsync(userId, cancellationToken);
+
+        if (!user.IsActive)
+        {
+            throw new ConflictException($"User {userId} is deactivated. Re-activate them (POST /users/{userId}/activate) to issue a key; provisioning alone would leave an inactive user holding a working key.");
+        }
+
+        return await ProvisionAsync(user, tierProductId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiKeyRevealResponse> RotateForUserAsync(int userId, CancellationToken cancellationToken) =>
+        await RotateAsync(await FindUserAsync(userId, cancellationToken), cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> RevokeForUserAsync(int userId, CancellationToken cancellationToken) =>
+        await RevokeAsync(await FindUserAsync(userId, cancellationToken), cancellationToken);
+
+    /// <summary>
+    /// Resolves the audit actor <em>before</em> any APIM side effect. <c>IAuditService.LogAsync</c> would
+    /// throw the same 403 later, but by then the subscription would already exist — an orphan created
+    /// by a request that was refused. Cheap: the accessor caches the row for the rest of the request.
+    /// </summary>
+    private async Task EnsureActorAsync(CancellationToken cancellationToken) =>
+        _ = await currentUser.GetRequiredUserAsync(cancellationToken);
+
+    private async Task<User> GetActiveCallerAsync(CancellationToken cancellationToken)
+    {
+        var user = await currentUser.GetRequiredUserAsync(cancellationToken);
+
+        if (!user.IsActive)
+        {
+            throw new UnauthorizedAccessException("Your FoundryGate account is deactivated; key operations are not available. Contact an administrator.");
+        }
+
+        return user;
+    }
+
+    private async Task<User> FindUserAsync(int userId, CancellationToken cancellationToken) =>
+        await dbContext.Users.FindAsync([userId], cancellationToken)
+        ?? throw new KeyNotFoundException($"User {userId} was not found.");
+
+    private async Task StoreKeyAsync(User user, string apimSubscriptionId, string plaintextKey, DateTimeOffset issuedDate, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(plaintextKey))
+        {
+            throw new InvalidOperationException("APIM returned an empty primary key; refusing to store it.");
+        }
+
+        user.ApimSubscriptionKey = await keyProtector.ProtectAsync(plaintextKey, cancellationToken);
+        user.ApimSubscriptionId = apimSubscriptionId;
+        user.ApimSubscriptionKeyHint = Hint(plaintextKey);
+        user.ApimKeyIssuedDate = issuedDate;
+    }
+
+    private static ApiKeyRevealResponse Reveal(User user, string plaintextKey, DateTimeOffset issuedDate) =>
+        new(plaintextKey, Mask(Hint(plaintextKey)), user.ApimSubscriptionId, issuedDate);
+
+    private static bool HasKey(User user) => !string.IsNullOrEmpty(user.ApimSubscriptionId);
+
+    private static void RequireKey(User user)
+    {
+        if (!HasKey(user))
+        {
+            throw new KeyNotFoundException($"User {user.UserId} has no APIM key. An administrator can provision one with POST /keys/{user.UserId}/provision.");
+        }
+    }
+
+    private static ConflictException SubscriptionMissing(User user, ApimSubscriptionNotFoundException inner) =>
+        new(
+            $"The APIM subscription behind user {user.UserId}'s key no longer exists on the gateway (deleted outside FoundryGate?). " +
+            $"Revoke the key (DELETE /keys/{user.UserId}) and provision a new one.",
+            inner);
+
+    /// <summary>Validates against <see cref="GatewayTiers.All"/>; tier ids are lower-case product ids, so the comparison is case-insensitive and the result normalized.</summary>
+    private static string NormalizeTier(string tierProductId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tierProductId);
+
+        var match = GatewayTiers.All.FirstOrDefault(tier => string.Equals(tier, tierProductId.Trim(), StringComparison.OrdinalIgnoreCase));
+        return match
+            ?? throw new ArgumentException($"'{tierProductId}' is not a gateway tier. Valid tiers: {string.Join(", ", GatewayTiers.All)}.", nameof(tierProductId));
+    }
+
+    private static string TargetId(User user) => user.UserId.ToString(CultureInfo.InvariantCulture);
+
+    private static string Hint(string plaintextKey) => plaintextKey.Length <= 4 ? plaintextKey : plaintextKey[^4..];
+
+    private static string Mask(string hint) => MaskPrefix + hint;
+
+    private static string DisplayNameFor(User user)
+    {
+        var displayName = $"FoundryGate {user.Email}";
+        return displayName.Length <= ApimDisplayNameMaxLength ? displayName : displayName[..ApimDisplayNameMaxLength];
+    }
+}

--- a/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
@@ -19,8 +19,7 @@ namespace FoundryGate.Api.Services.Keys;
 /// Scope values are written as the <em>full</em> product ARM id (<c>{apim}/products/{id}</c>) because
 /// that is the form ARM echoes back, so <see cref="ApimSubscription.Scope"/> compares stably with what
 /// this class writes. Live behaviour of the SDK against a real APIM instance is validated manually
-/// per the checklist in the follow-up issue this wave filed (see PR body) — the unit suite covers
-/// everything above this seam with a fake.
+/// per the checklist in #132 — the unit suite covers everything above this seam with a fake.
 /// </remarks>
 public sealed class ArmApimManagementClient : IApimManagementClient
 {

--- a/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
@@ -1,0 +1,206 @@
+using Azure;
+using Azure.Core;
+using Azure.ResourceManager;
+using Azure.ResourceManager.ApiManagement;
+using Azure.ResourceManager.ApiManagement.Models;
+using FoundryGate.Api.Configuration;
+
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>
+/// <see cref="IApimManagementClient"/> over <c>Azure.ResourceManager.ApiManagement</c>, addressed by
+/// <see cref="GatewayOptions"/> (<c>Gateway__SubscriptionId/ResourceGroup/ApimName</c> from
+/// <c>infra/modules/control-plane.bicep</c>) and authenticated with the app's
+/// <see cref="TokenCredential"/> — the API identity holds API Management Service Contributor on the
+/// instance (<c>control-plane-rbac.bicep</c>). No APIM credentials are ever stored (spec &#167;5).
+/// Singleton: <see cref="ArmClient"/> is thread-safe and caches its pipeline.
+/// </summary>
+/// <remarks>
+/// Scope values are written as the <em>full</em> product ARM id (<c>{apim}/products/{id}</c>) because
+/// that is the form ARM echoes back, so <see cref="ApimSubscription.Scope"/> compares stably with what
+/// this class writes. Live behaviour of the SDK against a real APIM instance is validated manually
+/// per the checklist in the follow-up issue this wave filed (see PR body) — the unit suite covers
+/// everything above this seam with a fake.
+/// </remarks>
+public sealed class ArmApimManagementClient : IApimManagementClient
+{
+    private readonly ArmClient _armClient;
+    private readonly ResourceIdentifier _serviceId;
+    private readonly string _subscriptionId;
+    private readonly string _resourceGroup;
+    private readonly string _apimName;
+
+    public ArmApimManagementClient(GatewayOptions gateway, TokenCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(gateway);
+        ArgumentNullException.ThrowIfNull(credential);
+
+        if (!gateway.IsApimConfigured)
+        {
+            throw new ArgumentException("Gateway:SubscriptionId, Gateway:ResourceGroup and Gateway:ApimName must all be set to address APIM.", nameof(gateway));
+        }
+
+        _subscriptionId = gateway.SubscriptionId!;
+        _resourceGroup = gateway.ResourceGroup!;
+        _apimName = gateway.ApimName!;
+        _serviceId = ApiManagementServiceResource.CreateResourceIdentifier(_subscriptionId, _resourceGroup, _apimName);
+        _armClient = new ArmClient(credential, _subscriptionId);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(productId);
+
+        var content = new ApiManagementSubscriptionCreateOrUpdateContent
+        {
+            Scope = ProductScope(productId),
+            DisplayName = displayName,
+            State = SubscriptionState.Active,
+        };
+
+        var subscriptions = _armClient.GetApiManagementServiceResource(_serviceId).GetApiManagementSubscriptions();
+        var operation = await subscriptions.CreateOrUpdateAsync(WaitUntil.Completed, subscriptionName, content, notify: false, cancellationToken: cancellationToken);
+        var data = operation.Value.Data;
+
+        // ARM fills the keys on PUT but not on GET; fall back to listSecrets if this ever changes.
+        var keys = data.PrimaryKey is { Length: > 0 } && data.SecondaryKey is { Length: > 0 }
+            ? new ApimSubscriptionKeys(data.PrimaryKey, data.SecondaryKey)
+            : Map((await operation.Value.GetSecretsAsync(cancellationToken)).Value);
+
+        return new ApimSubscriptionWithKeys(Map(subscriptionName, data), keys);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApimSubscription?> GetSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        var subscriptions = _armClient.GetApiManagementServiceResource(_serviceId).GetApiManagementSubscriptions();
+        var response = await subscriptions.GetIfExistsAsync(subscriptionName, cancellationToken);
+
+        return response.HasValue && response.Value is { } resource ? Map(subscriptionName, resource.Data) : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApimSubscriptionKeys> ListSecretsAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        try
+        {
+            var response = await Subscription(subscriptionName).GetSecretsAsync(cancellationToken);
+            return Map(response.Value);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            throw new ApimSubscriptionNotFoundException(subscriptionName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task RegeneratePrimaryKeyAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        try
+        {
+            _ = await Subscription(subscriptionName).RegeneratePrimaryKeyAsync(cancellationToken);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            throw new ApimSubscriptionNotFoundException(subscriptionName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task RegenerateSecondaryKeyAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        try
+        {
+            _ = await Subscription(subscriptionName).RegenerateSecondaryKeyAsync(cancellationToken);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            throw new ApimSubscriptionNotFoundException(subscriptionName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateScopeAsync(string subscriptionName, string productId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(productId);
+
+        var patch = new ApiManagementSubscriptionPatch { Scope = ProductScope(productId) };
+
+        try
+        {
+            _ = await Subscription(subscriptionName).UpdateAsync(ETag.All, patch, notify: false, cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            throw new ApimSubscriptionNotFoundException(subscriptionName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        try
+        {
+            _ = await Subscription(subscriptionName).DeleteAsync(WaitUntil.Completed, ETag.All, cancellationToken);
+            return true;
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            return false;
+        }
+    }
+
+    private ApiManagementSubscriptionResource Subscription(string subscriptionName) =>
+        _armClient.GetApiManagementSubscriptionResource(
+            ApiManagementSubscriptionResource.CreateResourceIdentifier(_subscriptionId, _resourceGroup, _apimName, subscriptionName));
+
+    private string ProductScope(string productId) => $"{_serviceId}/products/{productId}";
+
+    private ApimSubscription Map(string subscriptionName, SubscriptionContractData data)
+    {
+        var scope = data.Scope ?? string.Empty;
+        var resourceId = data.Id?.ToString()
+            ?? ApiManagementSubscriptionResource.CreateResourceIdentifier(_subscriptionId, _resourceGroup, _apimName, subscriptionName).ToString();
+
+        return new ApimSubscription(
+            subscriptionName,
+            resourceId,
+            data.DisplayName ?? string.Empty,
+            scope,
+            ProductIdFromScope(scope),
+            data.State?.ToString() ?? string.Empty);
+    }
+
+    private static ApimSubscriptionKeys Map(SubscriptionKeysContract keys) =>
+        new(keys.PrimaryKey ?? string.Empty, keys.SecondaryKey ?? string.Empty);
+
+    /// <summary>The segment after <c>/products/</c> in a scope id; <see langword="null"/> for non-product scopes (<c>/apis</c>, a single API, …).</summary>
+    public static string? ProductIdFromScope(string scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+
+        const string Marker = "/products/";
+        var index = scope.LastIndexOf(Marker, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            return null;
+        }
+
+        var productId = scope[(index + Marker.Length)..].Trim('/');
+        return productId.Length == 0 ? null : productId;
+    }
+}

--- a/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/ArmApimManagementClient.cs
@@ -47,6 +47,14 @@ public sealed class ArmApimManagementClient : IApimManagementClient
     }
 
     /// <inheritdoc />
+    public string GetSubscriptionResourceId(string subscriptionName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
+
+        return ApiManagementSubscriptionResource.CreateResourceIdentifier(_subscriptionId, _resourceGroup, _apimName, subscriptionName).ToString();
+    }
+
+    /// <inheritdoc />
     public async Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);

--- a/src/FoundryGate.Api/Services/Keys/IApimKeyService.cs
+++ b/src/FoundryGate.Api/Services/Keys/IApimKeyService.cs
@@ -1,0 +1,118 @@
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Exceptions;
+using FoundryGate.Domain.Keys.Contracts;
+
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>
+/// <para>
+/// APIM subscription-key lifecycle for a developer (spec &#167;4.5, &#167;5.1–5.3; issues #36, #37;
+/// plans/09 and 21). Two layers in one interface:
+/// </para>
+/// <para>
+/// <b>Building blocks</b> take a tracked <see cref="User"/> and are what plan 21's
+/// <c>IUserLifecycleService</c> (#65) composes into the provision/deprovision pipelines: each does
+/// its APIM call(s), mutates the user, adds its audit row through <c>IAuditService</c>, and
+/// <c>SaveChangesAsync</c> — mutation and audit commit together (CONVENTIONS.md). An orchestrator
+/// that needs several of these to be atomic wraps them in a database transaction; the saves inside
+/// then join it.
+/// </para>
+/// <para>
+/// <b>Endpoint entry points</b> (<c>…Mine…</c> / <c>…ForUser…</c>) resolve the user — the caller via
+/// <c>ICurrentUserAccessor</c> (403 when unprovisioned), or by <c>UserId</c> (404) — and delegate,
+/// so <c>KeysController</c> stays an expression-bodied delegation.
+/// </para>
+/// <para>
+/// Key material rules: the plaintext key crosses the API boundary exactly once per mint (in an
+/// <see cref="ApiKeyRevealResponse"/>) or per explicit reveal; it is stored only through
+/// <c>IKeyProtector</c>; it is never logged and never placed in an audit <c>details</c> payload. The
+/// APIM secondary key is never issued or stored — rotation regenerates it too so its lifetime never
+/// exceeds the primary's (#117).
+/// </para>
+/// </summary>
+public interface IApimKeyService
+{
+    /// <summary>
+    /// Mints the user's APIM subscription — <c>foundrygate-{UserId}</c>, display name carrying the
+    /// email, scoped to <c>/products/{tierProductId}</c> — stores the encrypted primary key, resource
+    /// id, hint and issue date on <paramref name="user"/>, audits <c>key.provisioned</c>, saves, and
+    /// returns the plaintext once. If a subscription with that name already exists in APIM (an
+    /// orphan left by a save that failed after APIM succeeded — plan 21's compensation table) it is
+    /// reused: re-scoped to the requested tier if needed and both keys regenerated, so whatever key
+    /// the orphan held is dead and the returned one is fresh.
+    /// </summary>
+    /// <exception cref="ConflictException"><paramref name="user"/> already has a key (<c>ApimSubscriptionId</c> set) → 409.</exception>
+    /// <exception cref="ArgumentException"><paramref name="tierProductId"/> is not a <c>GatewayTiers</c> value → 400.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="user"/> has not been saved (<c>UserId</c> is 0) — a programming error, not a caller error.</exception>
+    Task<ApiKeyRevealResponse> ProvisionAsync(User user, string tierProductId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Regenerates <em>both</em> APIM keys (primary and secondary, #117), stores the new encrypted
+    /// primary, audits <c>key.rotated</c>, saves, and returns the new plaintext once. The old primary
+    /// is rejected by the gateway immediately.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
+    /// <exception cref="ConflictException">The APIM subscription behind the key no longer exists → 409 with "revoke and re-provision" guidance.</exception>
+    Task<ApiKeyRevealResponse> RotateAsync(User user, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Key-only revocation (#116 ruling; plan 21 deprovision step 1 + 5): deletes the APIM
+    /// subscription, clears <c>ApimSubscriptionId/Key/KeyHint/KeyIssuedDate</c>, audits
+    /// <c>key.revoked</c>, saves. <c>IsActive</c> is untouched — deactivation is
+    /// <c>POST /users/{id}/deactivate</c>'s job, which calls this as its first step. Idempotent: a
+    /// user with no key is a no-op that returns <see langword="false"/> (nothing audited); a
+    /// subscription already gone from APIM still clears the row and audits.
+    /// </summary>
+    /// <returns><see langword="true"/> when a key was revoked.</returns>
+    Task<bool> RevokeAsync(User user, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves the subscription to another quota-tier product (#82: tier change = re-scope). Keys are
+    /// unchanged; the gateway's monthly counter is per subscription-within-product, so the developer's
+    /// used-so-far restarts under the new tier. Audits <c>key.tier-changed</c> with before/after
+    /// product ids. Called by the quota wave when a user's resolved tier changes (#64).
+    /// </summary>
+    /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
+    /// <exception cref="ArgumentException"><paramref name="tierProductId"/> is not a <c>GatewayTiers</c> value → 400.</exception>
+    /// <exception cref="ConflictException">The APIM subscription behind the key no longer exists → 409.</exception>
+    Task MoveToProductAsync(User user, string tierProductId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The masked view (<c>••••••••1a2b</c>) from the stored hint — no decryption, no Key Vault
+    /// round trip, so profile reads stay cheap. <c>IsProvisioned = false</c> with null fields when the
+    /// user has no key.
+    /// </summary>
+    ApiKeyResponse GetMasked(User user);
+
+    /// <summary>
+    /// Decrypts and returns the full key (spec &#167;11: "reveal action fetches directly, not stored in
+    /// browser"). Audits <c>key.revealed</c> and saves that row; nothing is cached.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
+    Task<ApiKeyRevealResponse> RevealAsync(User user, CancellationToken cancellationToken);
+
+    /// <summary><c>GET /keys/me</c>: <see cref="GetMasked"/> for the caller.</summary>
+    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row → 403 ("call GET /users/me first").</exception>
+    Task<ApiKeyResponse> GetMineAsync(CancellationToken cancellationToken);
+
+    /// <summary><c>POST /keys/me/reveal</c>: <see cref="RevealAsync"/> for the caller.</summary>
+    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row, or is deactivated → 403.</exception>
+    Task<ApiKeyRevealResponse> RevealMineAsync(CancellationToken cancellationToken);
+
+    /// <summary><c>POST /keys/me/rotate</c>: <see cref="RotateAsync"/> for the caller.</summary>
+    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row, or is deactivated → 403.</exception>
+    Task<ApiKeyRevealResponse> RotateMineAsync(CancellationToken cancellationToken);
+
+    /// <summary><c>POST /keys/{userId}/provision</c> (admin): <see cref="ProvisionAsync"/> for <paramref name="userId"/>.</summary>
+    /// <exception cref="KeyNotFoundException">No such user → 404.</exception>
+    /// <exception cref="ConflictException">The user is deactivated (re-activate them instead — plan 21 Trigger C) or already has a key → 409.</exception>
+    Task<ApiKeyRevealResponse> ProvisionForUserAsync(int userId, string tierProductId, CancellationToken cancellationToken);
+
+    /// <summary><c>POST /keys/{userId}/rotate</c> (admin): <see cref="RotateAsync"/> for <paramref name="userId"/>.</summary>
+    /// <exception cref="KeyNotFoundException">No such user, or the user has no key → 404.</exception>
+    Task<ApiKeyRevealResponse> RotateForUserAsync(int userId, CancellationToken cancellationToken);
+
+    /// <summary><c>DELETE /keys/{userId}</c> (admin): <see cref="RevokeAsync"/> for <paramref name="userId"/>.</summary>
+    /// <exception cref="KeyNotFoundException">No such user → 404 (a user with no key is a successful no-op).</exception>
+    Task<bool> RevokeForUserAsync(int userId, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/Keys/IApimKeyService.cs
+++ b/src/FoundryGate.Api/Services/Keys/IApimKeyService.cs
@@ -14,13 +14,19 @@ namespace FoundryGate.Api.Services.Keys;
 /// <c>IUserLifecycleService</c> (#65) composes into the provision/deprovision pipelines: each does
 /// its APIM call(s), mutates the user, adds its audit row through <c>IAuditService</c>, and
 /// <c>SaveChangesAsync</c> — mutation and audit commit together (CONVENTIONS.md). An orchestrator
-/// that needs several of these to be atomic wraps them in a database transaction; the saves inside
-/// then join it.
+/// that needs several of these to be atomic opens a database transaction first; the saves (and
+/// <see cref="ProvisionAsync"/>'s claim) then join it instead of opening their own.
 /// </para>
 /// <para>
 /// <b>Endpoint entry points</b> (<c>…Mine…</c> / <c>…ForUser…</c>) resolve the user — the caller via
 /// <c>ICurrentUserAccessor</c> (403 when unprovisioned), or by <c>UserId</c> (404) — and delegate,
 /// so <c>KeysController</c> stays an expression-bodied delegation.
+/// </para>
+/// <para>
+/// Actor: every building block except <see cref="RevokeAsSystemAsync"/> attributes its audit row to
+/// the current HTTP caller and resolves that caller <em>before</em> any APIM side effect (403 with no
+/// orphan left behind). <see cref="RevokeAsSystemAsync"/> exists for the paths with no caller — plan
+/// 21 deprovision Trigger B (Entra departure detected by a sync job) — and writes a system audit row.
 /// </para>
 /// <para>
 /// Key material rules: the plaintext key crosses the API boundary exactly once per mint (in an
@@ -36,12 +42,26 @@ public interface IApimKeyService
     /// Mints the user's APIM subscription — <c>foundrygate-{UserId}</c>, display name carrying the
     /// email, scoped to <c>/products/{tierProductId}</c> — stores the encrypted primary key, resource
     /// id, hint and issue date on <paramref name="user"/>, audits <c>key.provisioned</c>, saves, and
-    /// returns the plaintext once. If a subscription with that name already exists in APIM (an
-    /// orphan left by a save that failed after APIM succeeded — plan 21's compensation table) it is
-    /// reused: re-scoped to the requested tier if needed and both keys regenerated, so whatever key
-    /// the orphan held is dead and the returned one is fresh.
+    /// returns the plaintext once.
     /// </summary>
-    /// <exception cref="ConflictException"><paramref name="user"/> already has a key (<c>ApimSubscriptionId</c> set) → 409.</exception>
+    /// <remarks>
+    /// <para>
+    /// <b>Concurrency:</b> before calling APIM the row is <em>claimed</em> with a conditional update
+    /// (<c>ApimSubscriptionId = '' → resource id</c>) inside a transaction. A second provisioner for the
+    /// same user therefore fails the claim (409) instead of issuing a second PUT that would regenerate
+    /// — and kill — the first caller's key. If APIM then fails, the transaction rolls the claim back;
+    /// if the process dies after APIM succeeded but before the commit, the claim rolls back too and
+    /// the subscription is left as an orphan for the next provision to adopt.
+    /// </para>
+    /// <para>
+    /// <b>Orphans</b> (plan 21's compensation table): a subscription that already exists under this
+    /// name is reused — re-scoped to the requested tier if needed and <em>both keys regenerated</em>, so
+    /// whatever key it held is dead and the returned one is fresh. An orphan whose state is not
+    /// <c>active</c> (suspended or hand-made) is deleted and created afresh instead, because a
+    /// regenerated key on a suspended subscription would still 401 at the gateway.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ConflictException"><paramref name="user"/> already has a key, or another request is provisioning one right now → 409.</exception>
     /// <exception cref="ArgumentException"><paramref name="tierProductId"/> is not a <c>GatewayTiers</c> value → 400.</exception>
     /// <exception cref="InvalidOperationException"><paramref name="user"/> has not been saved (<c>UserId</c> is 0) — a programming error, not a caller error.</exception>
     Task<ApiKeyRevealResponse> ProvisionAsync(User user, string tierProductId, CancellationToken cancellationToken);
@@ -49,7 +69,9 @@ public interface IApimKeyService
     /// <summary>
     /// Regenerates <em>both</em> APIM keys (primary and secondary, #117), stores the new encrypted
     /// primary, audits <c>key.rotated</c>, saves, and returns the new plaintext once. The old primary
-    /// is rejected by the gateway immediately.
+    /// is rejected by the gateway immediately. If storing the new key fails after APIM regenerated it,
+    /// the previous (now stale) ciphertext is kept, an error is logged and a <c>key.rotation-failed</c>
+    /// audit row records the remedy: rotate again, or revoke and re-provision.
     /// </summary>
     /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
     /// <exception cref="ConflictException">The APIM subscription behind the key no longer exists → 409 with "revoke and re-provision" guidance.</exception>
@@ -58,19 +80,33 @@ public interface IApimKeyService
     /// <summary>
     /// Key-only revocation (#116 ruling; plan 21 deprovision step 1 + 5): deletes the APIM
     /// subscription, clears <c>ApimSubscriptionId/Key/KeyHint/KeyIssuedDate</c>, audits
-    /// <c>key.revoked</c>, saves. <c>IsActive</c> is untouched — deactivation is
-    /// <c>POST /users/{id}/deactivate</c>'s job, which calls this as its first step. Idempotent: a
-    /// user with no key is a no-op that returns <see langword="false"/> (nothing audited); a
-    /// subscription already gone from APIM still clears the row and audits.
+    /// <c>key.revoked</c> attributed to the current caller, saves. <c>IsActive</c> is untouched —
+    /// deactivation is <c>POST /users/{id}/deactivate</c>'s job, which calls this as its first step.
+    /// Idempotent: a user with no key is a no-op that returns <see langword="false"/> (nothing
+    /// audited); a subscription already gone from APIM still clears the row and audits.
     /// </summary>
     /// <returns><see langword="true"/> when a key was revoked.</returns>
+    /// <exception cref="UnauthorizedAccessException">No current caller with a <c>User</c> row → 403. Use <see cref="RevokeAsSystemAsync"/> from jobs.</exception>
     Task<bool> RevokeAsync(User user, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// <see cref="RevokeAsync"/> for code paths with no HTTP caller — plan 21 deprovision Trigger B, the
+    /// Entra sync detecting a departed user (#40/#65) — attributing the <c>key.revoked</c> row to the
+    /// system (<c>ActorUserId = null</c>, via <c>IAuditWriter.AddSystem</c>) with
+    /// <paramref name="reason"/> in its details. Never resolves <c>ICurrentUserAccessor</c>, so it is
+    /// safe from a background job or a request whose principal is not a FoundryGate user.
+    /// </summary>
+    /// <param name="user">The tracked user whose key is revoked.</param>
+    /// <param name="reason">Why the system revoked it (e.g. <c>"entra-departure"</c>); stored in the audit details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when a key was revoked.</returns>
+    Task<bool> RevokeAsSystemAsync(User user, string reason, CancellationToken cancellationToken);
 
     /// <summary>
     /// Moves the subscription to another quota-tier product (#82: tier change = re-scope). Keys are
     /// unchanged; the gateway's monthly counter is per subscription-within-product, so the developer's
     /// used-so-far restarts under the new tier. Audits <c>key.tier-changed</c> with before/after
-    /// product ids. Called by the quota wave when a user's resolved tier changes (#64).
+    /// product ids. Called by the quota wave when a user's resolved tier changes (#118).
     /// </summary>
     /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
     /// <exception cref="ArgumentException"><paramref name="tierProductId"/> is not a <c>GatewayTiers</c> value → 400.</exception>
@@ -87,6 +123,7 @@ public interface IApimKeyService
     /// <summary>
     /// Decrypts and returns the full key (spec &#167;11: "reveal action fetches directly, not stored in
     /// browser"). Audits <c>key.revealed</c> and saves that row; nothing is cached.
+    /// <c>IssuedDate</c> is when the key was minted or last rotated, never the reveal time.
     /// </summary>
     /// <exception cref="KeyNotFoundException"><paramref name="user"/> has no key → 404.</exception>
     Task<ApiKeyRevealResponse> RevealAsync(User user, CancellationToken cancellationToken);

--- a/src/FoundryGate.Api/Services/Keys/IApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/IApimManagementClient.cs
@@ -1,0 +1,80 @@
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>
+/// The thin seam over the APIM management plane (<c>Azure.ResourceManager.ApiManagement</c>) for
+/// subscription lifecycle: exactly the seven operations <see cref="ApimKeyService"/> needs, in
+/// FoundryGate's vocabulary (subscription <em>name</em> = <c>foundrygate-{UserId}</c>, product =
+/// quota-tier id), so the key service is testable with an in-memory fake and the ARM SDK's resource
+/// graph stays in one class (<see cref="ArmApimManagementClient"/>). No live Azure in tests.
+/// </summary>
+/// <remarks>
+/// Error contract: a subscription that does not exist is <see langword="null"/> from
+/// <see cref="GetSubscriptionAsync"/>, <see langword="false"/> from <see cref="DeleteSubscriptionAsync"/>,
+/// and <see cref="ApimSubscriptionNotFoundException"/> from every operation that needs it to exist.
+/// Other ARM failures (auth, throttling, 5xx) surface as <c>Azure.RequestFailedException</c> — an
+/// unmapped 500 for the caller, which is correct: they are operational faults, not caller errors.
+/// </remarks>
+public interface IApimManagementClient
+{
+    /// <summary>
+    /// Creates (or, if a subscription with this name exists, re-PUTs) an <c>active</c> subscription
+    /// scoped to <c>/products/{productId}</c> and returns it with both of its keys — the one call
+    /// that returns key material without a separate secrets read.
+    /// </summary>
+    /// <param name="subscriptionName">ARM name (<c>sid</c>), from <c>ApimSubscriptionNames.ForUser</c>.</param>
+    /// <param name="displayName">Human label shown in the APIM portal (≤ 100 chars; APIM's limit).</param>
+    /// <param name="productId">Quota-tier product id (a <c>GatewayTiers</c> value).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken);
+
+    /// <summary>The subscription's metadata (no key material), or <see langword="null"/> when it does not exist — the orphan-detection probe plan 21 relies on.</summary>
+    Task<ApimSubscription?> GetSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken);
+
+    /// <summary>Both current keys (APIM's <c>listSecrets</c>).</summary>
+    /// <exception cref="ApimSubscriptionNotFoundException">No such subscription.</exception>
+    Task<ApimSubscriptionKeys> ListSecretsAsync(string subscriptionName, CancellationToken cancellationToken);
+
+    /// <summary>Invalidates the primary key and mints a new one (APIM returns no body; follow with <see cref="ListSecretsAsync"/>).</summary>
+    /// <exception cref="ApimSubscriptionNotFoundException">No such subscription.</exception>
+    Task RegeneratePrimaryKeyAsync(string subscriptionName, CancellationToken cancellationToken);
+
+    /// <summary>Invalidates the secondary key and mints a new one. FoundryGate never issues the secondary; regenerating it alongside the primary bounds its lifetime (#117).</summary>
+    /// <exception cref="ApimSubscriptionNotFoundException">No such subscription.</exception>
+    Task RegenerateSecondaryKeyAsync(string subscriptionName, CancellationToken cancellationToken);
+
+    /// <summary>Re-scopes the subscription to <c>/products/{productId}</c> — how a developer changes quota tier (#82). Keys are unchanged.</summary>
+    /// <exception cref="ApimSubscriptionNotFoundException">No such subscription.</exception>
+    Task UpdateScopeAsync(string subscriptionName, string productId, CancellationToken cancellationToken);
+
+    /// <summary>Deletes the subscription (the key stops working immediately). <see langword="false"/> when it was already gone — deletion is idempotent.</summary>
+    Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken);
+}
+
+/// <summary>A subscription as the management plane reports it, minus key material.</summary>
+/// <param name="Name">ARM name (<c>sid</c>).</param>
+/// <param name="ResourceId">Full ARM resource id — what <c>User.ApimSubscriptionId</c> stores.</param>
+/// <param name="DisplayName">Portal label.</param>
+/// <param name="Scope">Full scope ARM id (<c>.../products/{productId}</c>).</param>
+/// <param name="ProductId">The product segment of <paramref name="Scope"/>, or <see langword="null"/> when the scope is not a product (e.g. all-APIs).</param>
+/// <param name="State">APIM subscription state (<c>active</c>, <c>suspended</c>, …), lower-case as ARM reports it.</param>
+public sealed record ApimSubscription(string Name, string ResourceId, string DisplayName, string Scope, string? ProductId, string State);
+
+/// <summary>Both keys of a subscription. Only <see cref="PrimaryKey"/> is ever issued to a developer.</summary>
+public sealed record ApimSubscriptionKeys(string PrimaryKey, string SecondaryKey);
+
+/// <summary>Result of <see cref="IApimManagementClient.CreateOrUpdateSubscriptionAsync"/>.</summary>
+public sealed record ApimSubscriptionWithKeys(ApimSubscription Subscription, ApimSubscriptionKeys Keys);
+
+/// <summary>
+/// An operation needed an APIM subscription that does not exist — the database says a user has a key
+/// but the management plane has no such subscription (deleted in the portal, or a different APIM
+/// instance is configured). Deliberately not <see cref="KeyNotFoundException"/>: that would map to a
+/// 404 "resource missing", whereas this is a state conflict the key service turns into a 409 with
+/// "revoke and re-provision" guidance.
+/// </summary>
+public sealed class ApimSubscriptionNotFoundException(string subscriptionName)
+    : Exception($"APIM subscription '{subscriptionName}' does not exist on the configured APIM instance.")
+{
+    /// <summary>The subscription name that was looked up.</summary>
+    public string SubscriptionName { get; } = subscriptionName;
+}

--- a/src/FoundryGate.Api/Services/Keys/IApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/IApimManagementClient.cs
@@ -17,6 +17,13 @@ namespace FoundryGate.Api.Services.Keys;
 public interface IApimManagementClient
 {
     /// <summary>
+    /// The ARM resource id a subscription named <paramref name="subscriptionName"/> has (or would have)
+    /// on the configured APIM instance — deterministic, no call made. The key service writes it into
+    /// <c>User.ApimSubscriptionId</c> as the provisioning claim <em>before</em> the APIM PUT.
+    /// </summary>
+    string GetSubscriptionResourceId(string subscriptionName);
+
+    /// <summary>
     /// Creates (or, if a subscription with this name exists, re-PUTs) an <c>active</c> subscription
     /// scoped to <c>/products/{productId}</c> and returns it with both of its keys — the one call
     /// that returns key material without a separate secrets read.

--- a/src/FoundryGate.Api/Services/Keys/KeysServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Keys/KeysServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+using Azure.Core;
+using FoundryGate.Api.Configuration;
+using FoundryGate.Domain.Common;
+using Imagile.Framework.Configuration.Exceptions;
+
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>DI registration for the <c>Services/Keys</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class KeysServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IApimManagementClient"/> (singleton: <see cref="ArmApimManagementClient"/>
+    /// when <c>Gateway:*</c> addresses an APIM instance, otherwise
+    /// <see cref="UnconfiguredApimManagementClient"/> — allowed in <c>local</c> only, resolved eagerly
+    /// so a cloud host without APIM configuration refuses to start) and the scoped
+    /// <see cref="IApimKeyService"/>.
+    /// </summary>
+    public static IServiceCollection AddKeysServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IApimManagementClient>(serviceProvider =>
+        {
+            var gateway = serviceProvider.GetRequiredService<AppSettings>().Gateway;
+            if (gateway.IsApimConfigured)
+            {
+                return new ArmApimManagementClient(gateway, serviceProvider.GetRequiredService<TokenCredential>());
+            }
+
+            var environment = serviceProvider.GetRequiredService<AppEnvironment.Types>();
+            if (environment != AppEnvironment.Types.local)
+            {
+                throw new ConfigurationValidationException(
+                    $"Gateway:SubscriptionId, Gateway:ResourceGroup and Gateway:ApimName are required in the '{environment}' environment " +
+                    "(infra sets Gateway__* on the Container App); without them no APIM subscription key can be provisioned.");
+            }
+
+            return new UnconfiguredApimManagementClient();
+        });
+        services.AddResolveOnStartup<IApimManagementClient>();
+
+        services.AddScoped<IApimKeyService, ApimKeyService>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Keys/UnconfiguredApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/UnconfiguredApimManagementClient.cs
@@ -1,0 +1,44 @@
+namespace FoundryGate.Api.Services.Keys;
+
+/// <summary>
+/// The <see cref="IApimManagementClient"/> registered when <c>Gateway:SubscriptionId/ResourceGroup/
+/// ApimName</c> are absent — permitted in the <c>local</c> environment only (a cloud host without them
+/// fails at startup; see <see cref="KeysServiceCollectionExtensions"/>). Every call throws the same
+/// explanatory <see cref="InvalidOperationException"/> (→ 500, logged), so a developer running the
+/// Api against docker SQL with no Azure gets "APIM is not configured" from the key endpoints and
+/// everything else works.
+/// </summary>
+public sealed class UnconfiguredApimManagementClient : IApimManagementClient
+{
+    private const string Message =
+        "APIM is not configured: set Gateway:SubscriptionId, Gateway:ResourceGroup and Gateway:ApimName " +
+        "(infra sets Gateway__* on the Container App) to enable APIM subscription-key operations.";
+
+    /// <inheritdoc />
+    public Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task<ApimSubscription?> GetSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task<ApimSubscriptionKeys> ListSecretsAsync(string subscriptionName, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task RegeneratePrimaryKeyAsync(string subscriptionName, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task RegenerateSecondaryKeyAsync(string subscriptionName, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task UpdateScopeAsync(string subscriptionName, string productId, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
+    public Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(Message);
+}

--- a/src/FoundryGate.Api/Services/Keys/UnconfiguredApimManagementClient.cs
+++ b/src/FoundryGate.Api/Services/Keys/UnconfiguredApimManagementClient.cs
@@ -15,6 +15,10 @@ public sealed class UnconfiguredApimManagementClient : IApimManagementClient
         "(infra sets Gateway__* on the Container App) to enable APIM subscription-key operations.";
 
     /// <inheritdoc />
+    public string GetSubscriptionResourceId(string subscriptionName) =>
+        throw new InvalidOperationException(Message);
+
+    /// <inheritdoc />
     public Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken) =>
         throw new InvalidOperationException(Message);
 

--- a/src/FoundryGate.Api/Services/Security/DataProtectionKeyProtector.cs
+++ b/src/FoundryGate.Api/Services/Security/DataProtectionKeyProtector.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>
+/// <see cref="IKeyProtector"/> for the <c>local</c> environment only: ASP.NET Core Data Protection
+/// with the machine-local key ring, so local dev and the integration tests need no Azure at all.
+/// Stored as <c>dp1:{token}</c> (<see cref="KeyEnvelope"/>). <see cref="KeyProtectorFactory"/>
+/// refuses to construct this outside <c>local</c> — a machine-local key ring is not an
+/// at-rest-encryption story for a shared database (the keys live next to the app, not in an HSM,
+/// and a redeployed container loses them).
+/// </summary>
+public sealed class DataProtectionKeyProtector : IKeyProtector
+{
+    /// <summary>Purpose string; changing it invalidates every locally stored key (fine — local rows are disposable).</summary>
+    public const string Purpose = "FoundryGate.ApimSubscriptionKey.v1";
+
+    private readonly IDataProtector _protector;
+
+    public DataProtectionKeyProtector(IDataProtectionProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        _protector = provider.CreateProtector(Purpose);
+    }
+
+    /// <inheritdoc />
+    public Task<string> ProtectAsync(string plaintext, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(plaintext);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(new KeyEnvelope(KeyEnvelope.DataProtectionScheme, null, _protector.Protect(plaintext)).ToString());
+    }
+
+    /// <inheritdoc />
+    public Task<string> UnprotectAsync(string ciphertext, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var envelope = KeyEnvelope.ParseFor(ciphertext, KeyEnvelope.DataProtectionScheme);
+        return Task.FromResult(_protector.Unprotect(envelope.Payload));
+    }
+}

--- a/src/FoundryGate.Api/Services/Security/IKeyProtector.cs
+++ b/src/FoundryGate.Api/Services/Security/IKeyProtector.cs
@@ -1,0 +1,25 @@
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>
+/// Encrypts an APIM subscription key for storage in <c>User.ApimSubscriptionKey</c> and decrypts it
+/// back for the one-time reveal (#95; spec &#167;11 "APIM keys encrypted: stored encrypted in SQL
+/// using Azure Key Vault key wrapping"). Two implementations, selected by
+/// <c>KeyProtection:Provider</c>: <see cref="KeyVaultKeyProtector"/> (cloud) and
+/// <see cref="DataProtectionKeyProtector"/> (local only). Both produce a self-describing
+/// <see cref="KeyEnvelope"/> string so a stored value says which scheme — and, for Key Vault, which
+/// key version — can open it.
+/// </summary>
+/// <remarks>
+/// Implementations must never log, throw, or otherwise emit the plaintext; the caller treats the
+/// returned plaintext as a one-shot value (returned once in an <c>ApiKeyRevealResponse</c>, never
+/// cached). Singleton-safe.
+/// </remarks>
+public interface IKeyProtector
+{
+    /// <summary>Encrypts <paramref name="plaintext"/> into an envelope string fit for <c>User.ApimSubscriptionKey</c>.</summary>
+    Task<string> ProtectAsync(string plaintext, CancellationToken cancellationToken);
+
+    /// <summary>Decrypts an envelope produced by <see cref="ProtectAsync"/>.</summary>
+    /// <exception cref="InvalidOperationException">The envelope was produced by a different provider than the one configured (e.g. a <c>kv1</c> value under the Data Protection provider), or is not a recognized envelope at all.</exception>
+    Task<string> UnprotectAsync(string ciphertext, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/Security/KeyEnvelope.cs
+++ b/src/FoundryGate.Api/Services/Security/KeyEnvelope.cs
@@ -1,0 +1,93 @@
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>
+/// The stored shape of an encrypted APIM key: <c>{scheme}:{payload}</c>, or for Key Vault
+/// <c>{scheme}:{keyId}:{payload}</c> where <c>keyId</c> is the <em>versioned</em> Key Vault key URI
+/// that performed the wrap. A versioned scheme tag means a future algorithm change can coexist with
+/// existing rows; recording the key version means a Key Vault key rotation is detectable per row and
+/// old rows keep unwrapping with the version that wrapped them (Key Vault retains prior versions).
+/// </summary>
+/// <param name="Scheme">One of <see cref="KeyVaultScheme"/> / <see cref="DataProtectionScheme"/>.</param>
+/// <param name="KeyId">The versioned Key Vault key URI for <see cref="KeyVaultScheme"/>; <see langword="null"/> otherwise.</param>
+/// <param name="Payload">The ciphertext: base64 for Key Vault, the Data Protection token otherwise. Never contains <c>:</c>.</param>
+public sealed record KeyEnvelope(string Scheme, string? KeyId, string Payload)
+{
+    /// <summary>Key Vault RSA-OAEP-256 wrap, version 1: <c>kv1:{keyId}:{base64}</c>.</summary>
+    public const string KeyVaultScheme = "kv1";
+
+    /// <summary>ASP.NET Core Data Protection, version 1: <c>dp1:{token}</c>.</summary>
+    public const string DataProtectionScheme = "dp1";
+
+    private const char Separator = ':';
+
+    /// <summary>Renders the envelope as the string stored in <c>User.ApimSubscriptionKey</c>.</summary>
+    public override string ToString() =>
+        KeyId is null ? $"{Scheme}{Separator}{Payload}" : $"{Scheme}{Separator}{KeyId}{Separator}{Payload}";
+
+    /// <summary>
+    /// Parses a stored value. The key id (a URI) itself contains <c>:</c>, so the payload is taken
+    /// from the <em>last</em> separator — payloads are base64/base64url and never contain one.
+    /// </summary>
+    public static bool TryParse(string? value, out KeyEnvelope? envelope)
+    {
+        envelope = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var firstSeparator = value.IndexOf(Separator, StringComparison.Ordinal);
+        if (firstSeparator <= 0)
+        {
+            return false;
+        }
+
+        var scheme = value[..firstSeparator];
+        var rest = value[(firstSeparator + 1)..];
+
+        if (string.Equals(scheme, KeyVaultScheme, StringComparison.Ordinal))
+        {
+            var lastSeparator = rest.LastIndexOf(Separator);
+            if (lastSeparator <= 0 || lastSeparator == rest.Length - 1)
+            {
+                return false;
+            }
+
+            envelope = new KeyEnvelope(scheme, rest[..lastSeparator], rest[(lastSeparator + 1)..]);
+            return true;
+        }
+
+        if (string.Equals(scheme, DataProtectionScheme, StringComparison.Ordinal))
+        {
+            if (rest.Length == 0)
+            {
+                return false;
+            }
+
+            envelope = new KeyEnvelope(scheme, null, rest);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Parses or throws the <see cref="InvalidOperationException"/> <see cref="IKeyProtector.UnprotectAsync"/> documents, checking the scheme matches <paramref name="expectedScheme"/>.</summary>
+    public static KeyEnvelope ParseFor(string? value, string expectedScheme)
+    {
+        if (!TryParse(value, out var envelope) || envelope is null)
+        {
+            throw new InvalidOperationException(
+                "The stored APIM key is not a recognized encryption envelope; it cannot be decrypted.");
+        }
+
+        if (!string.Equals(envelope.Scheme, expectedScheme, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"The stored APIM key was encrypted with the '{envelope.Scheme}' scheme but the configured key protector only opens '{expectedScheme}'. " +
+                "Check KeyProtection:Provider — a value written under one provider cannot be read under the other.");
+        }
+
+        return envelope;
+    }
+}

--- a/src/FoundryGate.Api/Services/Security/KeyProtectorFactory.cs
+++ b/src/FoundryGate.Api/Services/Security/KeyProtectorFactory.cs
@@ -1,4 +1,5 @@
 using Azure.Core;
+using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using FoundryGate.Api.Configuration;
 using FoundryGate.Domain.Common;
@@ -17,8 +18,9 @@ public static class KeyProtectorFactory
 {
     /// <summary>
     /// Rules: <see cref="KeyProtectionProviderType.KeyVault"/> needs
-    /// <see cref="GatewayOptions.KeyEncryptionKeyUri"/>; <see cref="KeyProtectionProviderType.DataProtection"/>
-    /// is permitted in <see cref="AppEnvironment.Types.local"/> only.
+    /// <see cref="GatewayOptions.KeyEncryptionKeyUri"/> (an https Key Vault key URI);
+    /// <see cref="KeyProtectionProviderType.DataProtection"/> is permitted in
+    /// <see cref="AppEnvironment.Types.local"/> only.
     /// </summary>
     /// <exception cref="ConfigurationValidationException">A rule above is violated.</exception>
     public static IKeyProtector Create(
@@ -26,26 +28,35 @@ public static class KeyProtectorFactory
         GatewayOptions gateway,
         AppEnvironment.Types environment,
         TokenCredential credential,
-        IDataProtectionProvider dataProtectionProvider)
+        IDataProtectionProvider dataProtectionProvider,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(keyProtection);
         ArgumentNullException.ThrowIfNull(gateway);
         ArgumentNullException.ThrowIfNull(credential);
         ArgumentNullException.ThrowIfNull(dataProtectionProvider);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         switch (keyProtection.Provider)
         {
             case KeyProtectionProviderType.KeyVault:
-                if (!Uri.TryCreate(gateway.KeyEncryptionKeyUri, UriKind.Absolute, out var keyUri))
+                if (!Uri.TryCreate(gateway.KeyEncryptionKeyUri, UriKind.Absolute, out var keyUri)
+                    || keyUri.Scheme != Uri.UriSchemeHttps
+                    || KeyVaultKeyProtector.KeyNameOf(keyUri) is null)
                 {
                     throw new ConfigurationValidationException(
-                        "KeyProtection:Provider is 'KeyVault' but Gateway:KeyEncryptionKeyUri is not set. " +
-                        "Set it to the versionless URI of the Key Vault key that wraps APIM subscription keys " +
+                        "KeyProtection:Provider is 'KeyVault' but Gateway:KeyEncryptionKeyUri is not a Key Vault key URI. " +
+                        "Set it to the versionless URI (https://{vault}/keys/{name}) of the Key Vault key that wraps APIM subscription keys " +
                         "(infra output 'keyEncryptionKeyUri' / env var Gateway__KeyEncryptionKeyUri), or use " +
                         "KeyProtection:Provider = 'DataProtection' in the local environment only.");
                 }
 
-                return new KeyVaultKeyProtector(keyUri, keyId => new CryptographyClient(keyId, credential));
+                var vaultUri = new Uri(keyUri.GetLeftPart(UriPartial.Authority));
+                return new KeyVaultKeyProtector(
+                    keyUri,
+                    new KeyClient(vaultUri, credential),
+                    keyId => new CryptographyClient(keyId, credential),
+                    timeProvider);
 
             case KeyProtectionProviderType.DataProtection:
                 if (environment != AppEnvironment.Types.local)

--- a/src/FoundryGate.Api/Services/Security/KeyProtectorFactory.cs
+++ b/src/FoundryGate.Api/Services/Security/KeyProtectorFactory.cs
@@ -1,0 +1,64 @@
+using Azure.Core;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using FoundryGate.Api.Configuration;
+using FoundryGate.Domain.Common;
+using Imagile.Framework.Configuration.Exceptions;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>
+/// Chooses and fail-fast-validates the <see cref="IKeyProtector"/> for the current configuration and
+/// environment. Invoked from DI at startup (<see cref="SecurityServiceCollectionExtensions"/> resolves
+/// the singleton eagerly) so a misconfiguration is a refused start, never a 500 on the first key
+/// operation. Kept as a pure static so the rules are unit-testable without a host.
+/// </summary>
+public static class KeyProtectorFactory
+{
+    /// <summary>
+    /// Rules: <see cref="KeyProtectionProviderType.KeyVault"/> needs
+    /// <see cref="GatewayOptions.KeyEncryptionKeyUri"/>; <see cref="KeyProtectionProviderType.DataProtection"/>
+    /// is permitted in <see cref="AppEnvironment.Types.local"/> only.
+    /// </summary>
+    /// <exception cref="ConfigurationValidationException">A rule above is violated.</exception>
+    public static IKeyProtector Create(
+        KeyProtectionOptions keyProtection,
+        GatewayOptions gateway,
+        AppEnvironment.Types environment,
+        TokenCredential credential,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        ArgumentNullException.ThrowIfNull(keyProtection);
+        ArgumentNullException.ThrowIfNull(gateway);
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(dataProtectionProvider);
+
+        switch (keyProtection.Provider)
+        {
+            case KeyProtectionProviderType.KeyVault:
+                if (!Uri.TryCreate(gateway.KeyEncryptionKeyUri, UriKind.Absolute, out var keyUri))
+                {
+                    throw new ConfigurationValidationException(
+                        "KeyProtection:Provider is 'KeyVault' but Gateway:KeyEncryptionKeyUri is not set. " +
+                        "Set it to the versionless URI of the Key Vault key that wraps APIM subscription keys " +
+                        "(infra output 'keyEncryptionKeyUri' / env var Gateway__KeyEncryptionKeyUri), or use " +
+                        "KeyProtection:Provider = 'DataProtection' in the local environment only.");
+                }
+
+                return new KeyVaultKeyProtector(keyUri, keyId => new CryptographyClient(keyId, credential));
+
+            case KeyProtectionProviderType.DataProtection:
+                if (environment != AppEnvironment.Types.local)
+                {
+                    throw new ConfigurationValidationException(
+                        $"KeyProtection:Provider 'DataProtection' is only permitted in the local environment, not '{environment}'. " +
+                        "Cloud environments must use 'KeyVault' so APIM keys are wrapped by a Key Vault key (spec §11, #95).");
+                }
+
+                return new DataProtectionKeyProtector(dataProtectionProvider);
+
+            default:
+                throw new ConfigurationValidationException($"KeyProtection:Provider '{keyProtection.Provider}' is not a supported provider.");
+        }
+    }
+}

--- a/src/FoundryGate.Api/Services/Security/KeyVaultKeyProtector.cs
+++ b/src/FoundryGate.Api/Services/Security/KeyVaultKeyProtector.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text;
+using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace FoundryGate.Api.Services.Security;
@@ -14,30 +15,68 @@ namespace FoundryGate.Api.Services.Security;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Stored as <c>kv1:{versionedKeyId}:{base64}</c> (<see cref="KeyEnvelope"/>). Wrapping targets the
-/// configured, <em>versionless</em> URI so Key Vault picks the current version; Key Vault reports the
-/// version it actually used and that is what gets recorded. Unwrapping targets the recorded version,
-/// so after a Key Vault key rotation every existing row still opens (old versions stay enabled) while
-/// new writes move to the new version — no re-encryption sweep is needed to rotate, and an operator
-/// can find rows still on an old version with a <c>LIKE 'kv1:%/{oldVersion}:%'</c> query.
+/// Stored as <c>kv1:{versionedKeyId}:{base64}</c> (<see cref="KeyEnvelope"/>). <b>Wrapping resolves
+/// the key's current version explicitly</b> — <see cref="KeyClient.GetKeyAsync"/> on the key name,
+/// cached for <see cref="CurrentVersionTtl"/> — and wraps with a <see cref="CryptographyClient"/>
+/// bound to that <em>versioned</em> id. This matters because a <see cref="CryptographyClient"/> given a
+/// versionless URI fetches the key once and caches it for its lifetime, so a long-lived singleton
+/// would keep wrapping under a version that Key Vault has since rotated away from (and that an
+/// operator may then disable). With per-version clients, new writes follow a Key Vault rotation
+/// within the TTL; unwrapping always targets the version recorded in the envelope, so every
+/// existing row keeps opening (old versions stay enabled) and no re-encryption sweep is needed.
+/// Rows still on an old version are findable with <c>LIKE 'kv1:%/{oldVersion}:%'</c>.
 /// </para>
 /// <para>
-/// One <see cref="CryptographyClient"/> per key version, cached: the clients are thread-safe and this
-/// class is a singleton. The factory is injected so tests can substitute a client that never
-/// touches Azure.
+/// Unwrap only honours a key id on the <em>configured</em> vault host and key name. A database row is
+/// not a trusted pointer: a tampered envelope must not be able to steer the API identity at another
+/// vault or key it happens to have access to.
+/// </para>
+/// <para>
+/// One <see cref="CryptographyClient"/> per key version, cached: versions are immutable, the clients
+/// are thread-safe, and this class is a singleton. The clients are injected as factories so tests can
+/// substitute ones that never touch Azure.
 /// </para>
 /// </remarks>
-public sealed class KeyVaultKeyProtector(Uri keyEncryptionKeyUri, Func<Uri, CryptographyClient> clientFactory) : IKeyProtector
+public sealed class KeyVaultKeyProtector : IKeyProtector
 {
+    /// <summary>How long a resolved "current version" is trusted before <see cref="KeyClient"/> is asked again — the maximum lag between a Key Vault rotation and new writes using the new version.</summary>
+    public static readonly TimeSpan CurrentVersionTtl = TimeSpan.FromMinutes(5);
+
+    private readonly Uri _keyEncryptionKeyUri;
+    private readonly string _keyName;
+    private readonly KeyClient _keyClient;
+    private readonly Func<Uri, CryptographyClient> _clientFactory;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, CryptographyClient> _clients = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _resolveLock = new(1, 1);
+    private (Uri KeyId, DateTimeOffset ExpiresAt)? _currentVersion;
+
+    /// <param name="keyEncryptionKeyUri">The (normally versionless) Key Vault key URI, <c>https://{vault}/keys/{name}</c>.</param>
+    /// <param name="keyClient">Client for the vault that owns the key; used only to resolve the current version.</param>
+    /// <param name="clientFactory">Creates a <see cref="CryptographyClient"/> for a <em>versioned</em> key id.</param>
+    /// <param name="timeProvider">Clock for the version cache.</param>
+    public KeyVaultKeyProtector(Uri keyEncryptionKeyUri, KeyClient keyClient, Func<Uri, CryptographyClient> clientFactory, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(keyEncryptionKeyUri);
+        ArgumentNullException.ThrowIfNull(keyClient);
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _keyEncryptionKeyUri = keyEncryptionKeyUri;
+        _keyName = KeyNameOf(keyEncryptionKeyUri)
+            ?? throw new ArgumentException($"'{keyEncryptionKeyUri}' is not a Key Vault key URI (expected https://{{vault}}/keys/{{name}}).", nameof(keyEncryptionKeyUri));
+        _keyClient = keyClient;
+        _clientFactory = clientFactory;
+        _timeProvider = timeProvider;
+    }
 
     /// <inheritdoc />
     public async Task<string> ProtectAsync(string plaintext, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrEmpty(plaintext);
 
-        var client = GetClient(keyEncryptionKeyUri);
-        var result = await client.WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Encoding.UTF8.GetBytes(plaintext), cancellationToken);
+        var keyId = await GetCurrentVersionAsync(cancellationToken);
+        var result = await GetClient(keyId).WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Encoding.UTF8.GetBytes(plaintext), cancellationToken);
 
         return new KeyEnvelope(KeyEnvelope.KeyVaultScheme, result.KeyId, Convert.ToBase64String(result.EncryptedKey)).ToString();
     }
@@ -46,18 +85,84 @@ public sealed class KeyVaultKeyProtector(Uri keyEncryptionKeyUri, Func<Uri, Cryp
     public async Task<string> UnprotectAsync(string ciphertext, CancellationToken cancellationToken)
     {
         var envelope = KeyEnvelope.ParseFor(ciphertext, KeyEnvelope.KeyVaultScheme);
+        var keyId = ValidateEnvelopeKeyId(envelope.KeyId);
 
-        if (!Uri.TryCreate(envelope.KeyId, UriKind.Absolute, out var keyId))
-        {
-            throw new InvalidOperationException("The stored APIM key envelope carries a key id that is not an absolute URI; it cannot be decrypted.");
-        }
-
-        var client = GetClient(keyId);
-        var result = await client.UnwrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Convert.FromBase64String(envelope.Payload), cancellationToken);
+        var result = await GetClient(keyId).UnwrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Convert.FromBase64String(envelope.Payload), cancellationToken);
 
         return Encoding.UTF8.GetString(result.Key);
     }
 
+    /// <summary>The envelope's key id must be a versioned id of the configured key on the configured vault.</summary>
+    private Uri ValidateEnvelopeKeyId(string? keyIdText)
+    {
+        if (!Uri.TryCreate(keyIdText, UriKind.Absolute, out var keyId))
+        {
+            throw new InvalidOperationException("The stored APIM key envelope carries a key id that is not an absolute URI; it cannot be decrypted.");
+        }
+
+        var sameVault = string.Equals(keyId.Host, _keyEncryptionKeyUri.Host, StringComparison.OrdinalIgnoreCase)
+            && keyId.Scheme == Uri.UriSchemeHttps;
+        var sameKey = string.Equals(KeyNameOf(keyId), _keyName, StringComparison.OrdinalIgnoreCase);
+
+        if (!sameVault || !sameKey || VersionOf(keyId) is null)
+        {
+            throw new InvalidOperationException(
+                $"The stored APIM key envelope points at '{keyId}', which is not a version of the configured key '{_keyEncryptionKeyUri}'. " +
+                "Refusing to decrypt with a key the configuration does not name.");
+        }
+
+        return keyId;
+    }
+
+    private async Task<Uri> GetCurrentVersionAsync(CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        if (_currentVersion is { } cached && cached.ExpiresAt > now)
+        {
+            return cached.KeyId;
+        }
+
+        await _resolveLock.WaitAsync(cancellationToken);
+        try
+        {
+            now = _timeProvider.GetUtcNow();
+            if (_currentVersion is { } refreshed && refreshed.ExpiresAt > now)
+            {
+                return refreshed.KeyId;
+            }
+
+            var key = (await _keyClient.GetKeyAsync(_keyName, cancellationToken: cancellationToken)).Value;
+            if (key.Properties.Enabled == false)
+            {
+                throw new InvalidOperationException(
+                    $"The current version of Key Vault key '{_keyName}' ({key.Id}) is disabled; APIM keys cannot be encrypted until it is enabled or a new version is created.");
+            }
+
+            _currentVersion = (key.Id, now + CurrentVersionTtl);
+            return key.Id;
+        }
+        finally
+        {
+            _resolveLock.Release();
+        }
+    }
+
     private CryptographyClient GetClient(Uri keyId) =>
-        _clients.GetOrAdd(keyId.AbsoluteUri, static (_, state) => state.Factory(state.KeyId), (Factory: clientFactory, KeyId: keyId));
+        _clients.GetOrAdd(keyId.AbsoluteUri, static (_, state) => state.Factory(state.KeyId), (Factory: _clientFactory, KeyId: keyId));
+
+    /// <summary><c>/keys/{name}[/{version}]</c> → <c>name</c>; <see langword="null"/> when the path is not a key path.</summary>
+    internal static string? KeyNameOf(Uri keyUri)
+    {
+        var segments = keyUri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length is 2 or 3 && string.Equals(segments[0], "keys", StringComparison.OrdinalIgnoreCase)
+            ? segments[1]
+            : null;
+    }
+
+    /// <summary><c>/keys/{name}/{version}</c> → <c>version</c>; <see langword="null"/> when versionless.</summary>
+    internal static string? VersionOf(Uri keyUri)
+    {
+        var segments = keyUri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 3 ? segments[2] : null;
+    }
 }

--- a/src/FoundryGate.Api/Services/Security/KeyVaultKeyProtector.cs
+++ b/src/FoundryGate.Api/Services/Security/KeyVaultKeyProtector.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Azure.Security.KeyVault.Keys.Cryptography;
+
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>
+/// <see cref="IKeyProtector"/> backed by Azure Key Vault key wrapping (spec &#167;11, #95): the APIM
+/// key bytes are wrapped directly with RSA-OAEP-256 under the RSA key
+/// <c>GatewayOptions.KeyEncryptionKeyUri</c> (RSA-3072 wraps up to 318 bytes; APIM keys are 32
+/// characters, so no data-encryption-key indirection is needed). The private key never leaves the
+/// vault — wrap/unwrap run inside Key Vault, authorized by the API identity's Key Vault Crypto User
+/// role (<c>infra/modules/control-plane-rbac.bicep</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stored as <c>kv1:{versionedKeyId}:{base64}</c> (<see cref="KeyEnvelope"/>). Wrapping targets the
+/// configured, <em>versionless</em> URI so Key Vault picks the current version; Key Vault reports the
+/// version it actually used and that is what gets recorded. Unwrapping targets the recorded version,
+/// so after a Key Vault key rotation every existing row still opens (old versions stay enabled) while
+/// new writes move to the new version — no re-encryption sweep is needed to rotate, and an operator
+/// can find rows still on an old version with a <c>LIKE 'kv1:%/{oldVersion}:%'</c> query.
+/// </para>
+/// <para>
+/// One <see cref="CryptographyClient"/> per key version, cached: the clients are thread-safe and this
+/// class is a singleton. The factory is injected so tests can substitute a client that never
+/// touches Azure.
+/// </para>
+/// </remarks>
+public sealed class KeyVaultKeyProtector(Uri keyEncryptionKeyUri, Func<Uri, CryptographyClient> clientFactory) : IKeyProtector
+{
+    private readonly ConcurrentDictionary<string, CryptographyClient> _clients = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public async Task<string> ProtectAsync(string plaintext, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(plaintext);
+
+        var client = GetClient(keyEncryptionKeyUri);
+        var result = await client.WrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Encoding.UTF8.GetBytes(plaintext), cancellationToken);
+
+        return new KeyEnvelope(KeyEnvelope.KeyVaultScheme, result.KeyId, Convert.ToBase64String(result.EncryptedKey)).ToString();
+    }
+
+    /// <inheritdoc />
+    public async Task<string> UnprotectAsync(string ciphertext, CancellationToken cancellationToken)
+    {
+        var envelope = KeyEnvelope.ParseFor(ciphertext, KeyEnvelope.KeyVaultScheme);
+
+        if (!Uri.TryCreate(envelope.KeyId, UriKind.Absolute, out var keyId))
+        {
+            throw new InvalidOperationException("The stored APIM key envelope carries a key id that is not an absolute URI; it cannot be decrypted.");
+        }
+
+        var client = GetClient(keyId);
+        var result = await client.UnwrapKeyAsync(KeyWrapAlgorithm.RsaOaep256, Convert.FromBase64String(envelope.Payload), cancellationToken);
+
+        return Encoding.UTF8.GetString(result.Key);
+    }
+
+    private CryptographyClient GetClient(Uri keyId) =>
+        _clients.GetOrAdd(keyId.AbsoluteUri, static (_, state) => state.Factory(state.KeyId), (Factory: clientFactory, KeyId: keyId));
+}

--- a/src/FoundryGate.Api/Services/Security/SecurityServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Security/SecurityServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+using Azure.Core;
+using FoundryGate.Api.Configuration;
+using FoundryGate.Domain.Common;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace FoundryGate.Api.Services.Security;
+
+/// <summary>DI registration for the <c>Services/Security</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class SecurityServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="IKeyProtector"/> singleton chosen by <see cref="KeyProtectorFactory"/>
+    /// from the bound <see cref="AppSettings"/> and the <see cref="AppEnvironment.Types"/> singleton,
+    /// resolved eagerly at host start so a bad <c>KeyProtection</c>/<c>Gateway</c> combination refuses
+    /// to boot. Also registers Data Protection (idempotent) for the local provider.
+    /// </summary>
+    public static IServiceCollection AddSecurityServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddDataProtection();
+
+        services.AddSingleton(serviceProvider =>
+        {
+            var settings = serviceProvider.GetRequiredService<AppSettings>();
+            return KeyProtectorFactory.Create(
+                settings.KeyProtection,
+                settings.Gateway,
+                serviceProvider.GetRequiredService<AppEnvironment.Types>(),
+                serviceProvider.GetRequiredService<TokenCredential>(),
+                serviceProvider.GetRequiredService<IDataProtectionProvider>());
+        });
+        services.AddResolveOnStartup<IKeyProtector>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Security/SecurityServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Security/SecurityServiceCollectionExtensions.cs
@@ -28,7 +28,8 @@ public static class SecurityServiceCollectionExtensions
                 settings.Gateway,
                 serviceProvider.GetRequiredService<AppEnvironment.Types>(),
                 serviceProvider.GetRequiredService<TokenCredential>(),
-                serviceProvider.GetRequiredService<IDataProtectionProvider>());
+                serviceProvider.GetRequiredService<IDataProtectionProvider>(),
+                serviceProvider.GetRequiredService<TimeProvider>());
         });
         services.AddResolveOnStartup<IKeyProtector>();
 

--- a/src/FoundryGate.Api/Services/StartupResolutionExtensions.cs
+++ b/src/FoundryGate.Api/Services/StartupResolutionExtensions.cs
@@ -1,0 +1,35 @@
+namespace FoundryGate.Api.Services;
+
+/// <summary>
+/// Fail-fast for singletons whose construction validates configuration (CONVENTIONS.md
+/// "Options pattern, fail-fast"): a singleton registered through a factory is otherwise built on
+/// its first use, turning a startup misconfiguration into a 500 on the first request. Registering
+/// <see cref="AddResolveOnStartup{TService}"/> next to such a factory makes the host resolve it in
+/// <see cref="IHostedService.StartAsync"/> — before the server accepts traffic — so the factory's
+/// exception aborts startup instead. The same mechanism <c>OptionsBuilder.ValidateOnStart()</c>
+/// uses, without requiring the options pattern's <c>IOptions&lt;T&gt;</c> plumbing.
+/// </summary>
+public static class StartupResolutionExtensions
+{
+    /// <summary>Resolves <typeparamref name="TService"/> once when the host starts, propagating any construction exception as a startup failure.</summary>
+    public static IServiceCollection AddResolveOnStartup<TService>(this IServiceCollection services)
+        where TService : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHostedService<ResolveOnStartupHostedService<TService>>();
+        return services;
+    }
+
+    private sealed class ResolveOnStartupHostedService<TService>(IServiceProvider serviceProvider) : IHostedService
+        where TService : class
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _ = serviceProvider.GetRequiredService<TService>();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/FoundryGate.Api/appsettings.json
+++ b/src/FoundryGate.Api/appsettings.json
@@ -11,5 +11,14 @@
   },
   "Cors": {
     "AllowedOrigins": []
+  },
+  "KeyProtection": {
+    "Provider": "KeyVault"
+  },
+  "Gateway": {
+    "SubscriptionId": "",
+    "ResourceGroup": "",
+    "ApimName": "",
+    "KeyEncryptionKeyUri": ""
   }
 }

--- a/src/FoundryGate.Api/appsettings.local.json
+++ b/src/FoundryGate.Api/appsettings.local.json
@@ -10,5 +10,8 @@
   },
   "Cors": {
     "AllowedOrigins": [ "http://localhost:5000" ]
+  },
+  "KeyProtection": {
+    "Provider": "DataProtection"
   }
 }

--- a/src/FoundryGate.Data/Entities/User.cs
+++ b/src/FoundryGate.Data/Entities/User.cs
@@ -49,12 +49,37 @@ public class User : ICreatedDate
     /// <summary>Per-user override; <see langword="null"/> means "fall through to group/system default" (spec §3.2).</summary>
     public long? MonthlyTokenQuota { get; set; }
 
+    /// <summary>
+    /// ARM resource id of this developer's APIM subscription
+    /// (<c>.../Microsoft.ApiManagement/service/{apim}/subscriptions/foundrygate-{UserId}</c>); empty
+    /// when no key is provisioned. Not a secret — it is an address, not a credential — so it is
+    /// stored in the clear (#95).
+    /// </summary>
     [StringLength(500)]
     public string ApimSubscriptionId { get; set; } = string.Empty;
 
-    /// <summary>Encrypted at rest (encryption is applied by the service layer, not this column).</summary>
-    [StringLength(500)]
+    /// <summary>
+    /// The APIM primary subscription key, <b>encrypted</b> by the Api's <c>IKeyProtector</c> before it
+    /// is written (#95): a versioned envelope, <c>kv1:{keyVaultKeyId}:{base64}</c> for the Key Vault
+    /// RSA-OAEP-256 wrap used in cloud environments or <c>dp1:{payload}</c> for the local-only
+    /// Data Protection provider. Plaintext never touches this column. Sized for an RSA-4096 wrap
+    /// (684 base64 chars) plus a versioned Key Vault key id (~110) with headroom. Empty when no key
+    /// is provisioned.
+    /// </summary>
+    [StringLength(1000)]
     public string ApimSubscriptionKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The last four characters of the plaintext key, kept so <c>GET /keys/me</c> can show the
+    /// masked form (<c>••••••••1a2b</c>) without a Key Vault unwrap on every profile read. Four
+    /// characters of a 32-character key is exactly the disclosure the masked display makes by
+    /// design. Empty when no key is provisioned.
+    /// </summary>
+    [StringLength(4)]
+    public string ApimSubscriptionKeyHint { get; set; } = string.Empty;
+
+    /// <summary>When the current key value was minted (provisioning) or last regenerated (rotation); <see langword="null"/> when no key is provisioned.</summary>
+    public DateTimeOffset? ApimKeyIssuedDate { get; set; }
 
     public DateTimeOffset CreatedDate { get; set; }
 

--- a/src/FoundryGate.Data/Entities/User.cs
+++ b/src/FoundryGate.Data/Entities/User.cs
@@ -14,9 +14,11 @@ public class User : ICreatedDate
     public int UserId { get; set; }
 
     /// <summary>
-    /// Stable id referenced by external systems that need to name resources after this user
-    /// without exposing the identity/mutable <see cref="UserId"/> (e.g. the APIM subscription
-    /// name minted for this developer).
+    /// Stable, non-sequential id for external systems that should not learn the identity-generated
+    /// <see cref="UserId"/> (CONVENTIONS.md <c>{Entity}Unique</c> rule). Not used for the APIM
+    /// subscription name — that is <c>foundrygate-{UserId}</c> (<c>Domain.Keys.ApimSubscriptionNames</c>),
+    /// because plan 21 names it so and the usage-reconciliation job needs the trivial inverse mapping;
+    /// the int is already exposed in every admin URL. Nothing names anything after this Guid yet.
     /// </summary>
     public Guid UserUnique { get; set; } = Guid.NewGuid();
 

--- a/src/FoundryGate.Database/dbo/Tables/Users.sql
+++ b/src/FoundryGate.Database/dbo/Tables/Users.sql
@@ -9,7 +9,9 @@ CREATE TABLE [dbo].[Users] (
     [IsUnlimited]         BIT               NOT NULL,
     [MonthlyTokenQuota]   BIGINT            NULL,
     [ApimSubscriptionId]  NVARCHAR (500)    NOT NULL,
-    [ApimSubscriptionKey] NVARCHAR (500)    NOT NULL,
+    [ApimSubscriptionKey] NVARCHAR (1000)   NOT NULL,
+    [ApimSubscriptionKeyHint] NVARCHAR (4)  NOT NULL,
+    [ApimKeyIssuedDate]   DATETIMEOFFSET (7) NULL,
     [CreatedDate]         DATETIMEOFFSET (7) NOT NULL,
     [LastSyncedDate]      DATETIMEOFFSET (7) NULL
 );

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -71,6 +71,9 @@ public static class AuditActions
     /// <summary>A developer revealing their own full key (spec &#167;11: "reveal action fetches directly, not stored in browser").</summary>
     public const string KeyRevealed = "key.revealed";
 
+    /// <summary>The APIM subscription behind a key was re-scoped to another quota-tier product (#82: a tier change moves the subscription between tier products).</summary>
+    public const string KeyTierChanged = "key.tier-changed";
+
     // -- Usage sync (spec 5.4, issue #39) --
 
     /// <summary>The Log Analytics → <c>QuotaAllocation.TokensUsed</c> reconciliation job (reconciliation, not enforcement).</summary>

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -74,6 +74,13 @@ public static class AuditActions
     /// <summary>The APIM subscription behind a key was re-scoped to another quota-tier product (#82: a tier change moves the subscription between tier products).</summary>
     public const string KeyTierChanged = "key.tier-changed";
 
+    /// <summary>
+    /// APIM regenerated the keys but the new primary could not be stored — the ciphertext on the user is
+    /// now stale and the remedy (rotate again, or revoke and re-provision) is in the details. Written so
+    /// an unrevealable key has a trail, not just a log line.
+    /// </summary>
+    public const string KeyRotationFailed = "key.rotation-failed";
+
     // -- Usage sync (spec 5.4, issue #39) --
 
     /// <summary>The Log Analytics → <c>QuotaAllocation.TokensUsed</c> reconciliation job (reconciliation, not enforcement).</summary>

--- a/src/FoundryGate.Domain/Keys/ApimSubscriptionNames.cs
+++ b/src/FoundryGate.Domain/Keys/ApimSubscriptionNames.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+
+namespace FoundryGate.Domain.Keys;
+
+/// <summary>
+/// The naming contract between a FoundryGate user and their APIM subscription (spec &#167;5.1,
+/// plans/21-provision-deprovision.md): the subscription's ARM name (<c>sid</c>) is
+/// <c>foundrygate-{UserId}</c>. Lives in Domain — not the Api's key service — because two hosts
+/// depend on it: the Api mints the name when provisioning, and the Functions usage-reconciliation
+/// job (#84) reads the subscription id back out of <c>ApiManagementGatewayLlmLog</c> rows and needs
+/// the inverse mapping to attribute tokens to a user. One definition, no drift.
+/// </summary>
+public static class ApimSubscriptionNames
+{
+    /// <summary>Prefix every FoundryGate-minted subscription name carries.</summary>
+    public const string Prefix = "foundrygate-";
+
+    /// <summary>The APIM subscription name for <paramref name="userId"/>, e.g. <c>foundrygate-42</c>.</summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="userId"/> is not positive — an unsaved <c>User</c> (identity not yet assigned) must not be named.</exception>
+    public static string ForUser(int userId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(userId);
+
+        return Prefix + userId.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Recovers the <c>UserId</c> from a subscription name minted by <see cref="ForUser"/>. Returns
+    /// <see langword="false"/> for anything else — APIM's built-in <c>master</c> subscription,
+    /// subscriptions created by hand in the portal, or a malformed suffix — so callers can skip
+    /// rows that are not FoundryGate developers.
+    /// </summary>
+    public static bool TryGetUserId(string? subscriptionName, out int userId)
+    {
+        userId = 0;
+
+        if (subscriptionName is null || !subscriptionName.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Substring rather than AsSpan: the span overload drags System.Memory into Domain's
+        // reference set, which DomainArchitectureTests pins to an exact BCL allowlist.
+        return int.TryParse(subscriptionName.Substring(Prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out userId)
+            && userId > 0;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
@@ -1,3 +1,4 @@
+using FoundryGate.Api.Services.Keys;
 using FoundryGate.Data;
 using FoundryGate.Data.Entities;
 using FoundryGate.Data.Interceptors;
@@ -5,6 +6,7 @@ using FoundryGate.Data.Seeding;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Tests.Predeployment.Support;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -48,6 +50,12 @@ public sealed class ApiTestFactory : WebApplicationFactory<Program>
 
     /// <summary>The host's <see cref="System.TimeProvider"/>: <c>2026-09-01T12:00:00Z</c> until a test moves it.</summary>
     public MutableTimeProvider TimeProvider { get; } = new(DefaultNow);
+
+    /// <summary>
+    /// The in-memory APIM standing in for the management plane (<see cref="IApimManagementClient"/>):
+    /// seed orphan subscriptions, read back keys, or assert on calls. One per factory, like the database.
+    /// </summary>
+    public FakeApimManagementClient Apim => Services.GetRequiredService<FakeApimManagementClient>();
 
     /// <summary>
     /// A client authenticated as <paramref name="oid"/> (with the <c>FoundryGate.Admin</c> role when
@@ -147,6 +155,9 @@ public sealed class ApiTestFactory : WebApplicationFactory<Program>
                 ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
                 ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000000",
                 ["AzureAd:Audience"] = "api://00000000-0000-0000-0000-000000000000",
+                // Local-only key protector (#95): no Key Vault in tests; Gateway:* stays empty so the
+                // APIM client would be the "unconfigured" one — replaced with the fake below anyway.
+                ["KeyProtection:Provider"] = "DataProtection",
             }));
 
         builder.ConfigureTestServices(services =>
@@ -164,6 +175,15 @@ public sealed class ApiTestFactory : WebApplicationFactory<Program>
 
             services.RemoveAll<TimeProvider>();
             services.AddSingleton<TimeProvider>(TimeProvider);
+
+            // APIM management plane → in-memory fake (no Azure); exposed as its concrete type too so
+            // tests can seed/inspect it. Data Protection → ephemeral keys, so the local key protector
+            // never writes a key ring to the machine running the tests.
+            services.RemoveAll<IApimManagementClient>();
+            services.AddSingleton<FakeApimManagementClient>();
+            services.AddSingleton<IApimManagementClient>(serviceProvider => serviceProvider.GetRequiredService<FakeApimManagementClient>());
+            services.RemoveAll<IDataProtectionProvider>();
+            services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider());
 
             // Registered after Program.cs's AddMicrosoftIdentityWebApiAuthentication, so this
             // Configure<AuthenticationOptions> runs last and wins the default-scheme selection. The

--- a/src/FoundryGate.Tests.Predeployment/Api/Configuration/AppSettingsValidationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Configuration/AppSettingsValidationTests.cs
@@ -44,6 +44,53 @@ public class AppSettingsValidationTests
         Assert.Null(exception);
     }
 
+    [Fact]
+    public void ValidateRecursively_partially_addressed_APIM_throws_naming_the_three_Gateway_members()
+    {
+        var appSettings = ValidAppSettings();
+        appSettings.Gateway.ApimName = "apim-foundrygate-dev";
+
+        var exception = Assert.Throws<ConfigurationValidationException>(appSettings.ValidateRecursively);
+
+        Assert.Contains("SubscriptionId", exception.Message);
+        Assert.Contains("ResourceGroup", exception.Message);
+        Assert.Contains("ApimName", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateRecursively_fully_addressed_APIM_does_not_throw()
+    {
+        var appSettings = ValidAppSettings();
+        appSettings.Gateway.SubscriptionId = "00000000-0000-0000-0000-000000000000";
+        appSettings.Gateway.ResourceGroup = "rg-foundrygate-dev";
+        appSettings.Gateway.ApimName = "apim-foundrygate-dev";
+
+        Assert.Null(Record.Exception(appSettings.ValidateRecursively));
+        Assert.True(appSettings.Gateway.IsApimConfigured);
+    }
+
+    [Theory]
+    [InlineData("http://kv.vault.azure.net/keys/fg-apim-key-encryption")]
+    [InlineData("kv.vault.azure.net/keys/fg-apim-key-encryption")]
+    public void ValidateRecursively_non_https_key_encryption_uri_throws(string uri)
+    {
+        var appSettings = ValidAppSettings();
+        appSettings.Gateway.KeyEncryptionKeyUri = uri;
+
+        var exception = Assert.Throws<ConfigurationValidationException>(appSettings.ValidateRecursively);
+
+        Assert.Contains("KeyEncryptionKeyUri", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateRecursively_empty_Gateway_section_is_valid_local_dev_has_no_APIM()
+    {
+        var appSettings = ValidAppSettings();
+
+        Assert.Null(Record.Exception(appSettings.ValidateRecursively));
+        Assert.False(appSettings.Gateway.IsApimConfigured);
+    }
+
     private static AppSettings ValidAppSettings() =>
         new()
         {

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/KeysEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/KeysEndpointTests.cs
@@ -1,0 +1,242 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Keys;
+using FoundryGate.Domain.Keys.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// <c>/api/v1/keys</c> through the real pipeline (auth filter, exception handler, controller, DI) with
+/// the in-memory APIM and the local key protector: the auth matrix (401/403/200/204/404/409/400) and
+/// the user-visible key semantics — plaintext once, masked afterwards, rotation replaces, revocation
+/// is key-only.
+/// </summary>
+public class KeysEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string KeysPath = "/api/v1/keys";
+
+    [Fact]
+    public async Task Anonymous_request_returns_401()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri($"{KeysPath}/me", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Authenticated_caller_without_a_User_row_returns_403_on_me_routes()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString());
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.GetAsync(new Uri($"{KeysPath}/me", UriKind.Relative))).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.PostAsync(new Uri($"{KeysPath}/me/reveal", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.PostAsync(new Uri($"{KeysPath}/me/rotate", UriKind.Relative), null)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Non_admin_returns_403_on_admin_routes()
+    {
+        var developer = await factory.SeedUserAsync();
+        using var client = factory.CreateClientAs(developer.EntraObjectId, isAdmin: false);
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/rotate", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await client.DeleteAsync(new Uri($"{KeysPath}/{developer.UserId}", UriKind.Relative))).StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_without_a_User_row_returns_403_on_provision_because_the_audit_row_needs_an_actor()
+    {
+        var developer = await factory.SeedUserAsync();
+        using var admin = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.False(factory.Apim.Contains(ApimSubscriptionNames.ForUser(developer.UserId)));
+    }
+
+    [Fact]
+    public async Task Unprovisioned_developer_sees_not_provisioned_and_404_on_reveal_and_rotate()
+    {
+        var developer = await factory.SeedUserAsync();
+        using var client = factory.CreateClientAs(developer.EntraObjectId);
+
+        var response = await client.GetAsync(new Uri($"{KeysPath}/me", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var key = await response.Content.ReadFromJsonAsync<ApiKeyResponse>(JsonOptions);
+        Assert.NotNull(key);
+        Assert.False(key.IsProvisioned);
+        Assert.Null(key.MaskedKey);
+        Assert.Null(key.ApimSubscriptionId);
+        Assert.Equal(HttpStatusCode.NotFound, (await client.PostAsync(new Uri($"{KeysPath}/me/reveal", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await client.PostAsync(new Uri($"{KeysPath}/me/rotate", UriKind.Relative), null)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_provisions_a_key_default_tier_returns_plaintext_once_and_the_developer_then_sees_it_masked()
+    {
+        var (adminUser, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync(email: "dev.two@contoso.test");
+        using var developerClient = factory.CreateClientAs(developer.EntraObjectId);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+
+        var response = await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var reveal = await response.Content.ReadFromJsonAsync<ApiKeyRevealResponse>(JsonOptions);
+        Assert.NotNull(reveal);
+        Assert.Equal(factory.Apim.KeysOf(name).PrimaryKey, reveal.PlaintextKey);
+        Assert.Equal(GatewayTiers.Default, factory.Apim.ProductOf(name));
+        Assert.Equal(factory.TimeProvider.GetUtcNow(), reveal.IssuedDate);
+
+        // The developer's own view is masked and never returns the plaintext.
+        var mine = await developerClient.GetFromJsonAsync<ApiKeyResponse>(new Uri($"{KeysPath}/me", UriKind.Relative), JsonOptions);
+        Assert.NotNull(mine);
+        Assert.True(mine.IsProvisioned);
+        Assert.Equal(reveal.MaskedKey, mine.MaskedKey);
+        Assert.Equal(reveal.ApimSubscriptionId, mine.ApimSubscriptionId);
+        Assert.Equal("••••••••" + reveal.PlaintextKey[^4..], mine.MaskedKey);
+
+        // Stored encrypted; audited to the admin.
+        await using var dbContext = factory.CreateDbContext();
+        var saved = await dbContext.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.StartsWith("dp1:", saved.ApimSubscriptionKey, StringComparison.Ordinal);
+        Assert.DoesNotContain(reveal.PlaintextKey, saved.ApimSubscriptionKey, StringComparison.OrdinalIgnoreCase);
+        var audit = await dbContext.AuditLogs.AsNoTracking().SingleAsync(a =>
+            a.Action == AuditActions.KeyProvisioned && a.TargetId == developer.UserId.ToString());
+        Assert.Equal(adminUser.UserId, audit.ActorUserId);
+    }
+
+    [Fact]
+    public async Task Provision_honours_the_tier_query_parameter_and_rejects_an_unknown_one()
+    {
+        var (_, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync();
+
+        var bad = await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision?tier=gold", UriKind.Relative), null);
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        var good = await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision?tier=power", UriKind.Relative), null);
+        Assert.Equal(HttpStatusCode.OK, good.StatusCode);
+        Assert.Equal("power", factory.Apim.ProductOf(ApimSubscriptionNames.ForUser(developer.UserId)));
+    }
+
+    [Fact]
+    public async Task Second_provision_returns_409_and_unknown_or_inactive_users_return_404_or_409()
+    {
+        var (_, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync();
+        var inactive = await factory.SeedUserAsync(isActive: false);
+        Assert.Equal(HttpStatusCode.OK, (await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null)).StatusCode);
+
+        Assert.Equal(HttpStatusCode.Conflict, (await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict, (await admin.PostAsync(new Uri($"{KeysPath}/{inactive.UserId}/provision", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await admin.PostAsync(new Uri($"{KeysPath}/999999/provision", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await admin.PostAsync(new Uri($"{KeysPath}/999999/rotate", UriKind.Relative), null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await admin.DeleteAsync(new Uri($"{KeysPath}/999999", UriKind.Relative))).StatusCode);
+    }
+
+    [Fact]
+    public async Task Developer_reveals_the_same_key_and_rotation_replaces_it()
+    {
+        var (_, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync();
+        using var developerClient = factory.CreateClientAs(developer.EntraObjectId);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        var provisioned = await PostAsync<ApiKeyRevealResponse>(admin, $"{KeysPath}/{developer.UserId}/provision");
+        var secondaryBefore = factory.Apim.KeysOf(name).SecondaryKey;
+
+        var revealed = await PostAsync<ApiKeyRevealResponse>(developerClient, $"{KeysPath}/me/reveal");
+        var rotated = await PostAsync<ApiKeyRevealResponse>(developerClient, $"{KeysPath}/me/rotate");
+
+        Assert.Equal(provisioned.PlaintextKey, revealed.PlaintextKey);
+        Assert.NotEqual(provisioned.PlaintextKey, rotated.PlaintextKey);
+        Assert.Equal(factory.Apim.KeysOf(name).PrimaryKey, rotated.PlaintextKey);
+        Assert.NotEqual(secondaryBefore, factory.Apim.KeysOf(name).SecondaryKey); // #117: both keys rotate
+
+        var afterRotate = await PostAsync<ApiKeyRevealResponse>(developerClient, $"{KeysPath}/me/reveal");
+        Assert.Equal(rotated.PlaintextKey, afterRotate.PlaintextKey);
+
+        await using var dbContext = factory.CreateDbContext();
+        var targetId = developer.UserId.ToString(CultureInfo.InvariantCulture);
+        var actions = await dbContext.AuditLogs.AsNoTracking()
+            .Where(a => a.TargetType == AuditTargetTypes.ApiKey && a.TargetId == targetId)
+            .OrderBy(a => a.AuditLogId)
+            .Select(a => new { a.Action, a.ActorUserId })
+            .ToListAsync();
+        Assert.Equal([AuditActions.KeyProvisioned, AuditActions.KeyRevealed, AuditActions.KeyRotated, AuditActions.KeyRevealed], actions.Select(a => a.Action));
+        Assert.All(actions.Skip(1), a => Assert.Equal(developer.UserId, a.ActorUserId));
+    }
+
+    [Fact]
+    public async Task Admin_rotates_any_users_key()
+    {
+        var (_, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync();
+        var provisioned = await PostAsync<ApiKeyRevealResponse>(admin, $"{KeysPath}/{developer.UserId}/provision");
+
+        var rotated = await PostAsync<ApiKeyRevealResponse>(admin, $"{KeysPath}/{developer.UserId}/rotate");
+
+        Assert.NotEqual(provisioned.PlaintextKey, rotated.PlaintextKey);
+        Assert.Equal(provisioned.ApimSubscriptionId, rotated.ApimSubscriptionId);
+    }
+
+    [Fact]
+    public async Task Delete_revokes_the_key_only_the_user_stays_active_and_a_repeat_is_still_204()
+    {
+        var (_, admin) = await CreateAdminAsync();
+        var developer = await factory.SeedUserAsync();
+        using var developerClient = factory.CreateClientAs(developer.EntraObjectId);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        _ = await PostAsync<ApiKeyRevealResponse>(admin, $"{KeysPath}/{developer.UserId}/provision");
+
+        var response = await admin.DeleteAsync(new Uri($"{KeysPath}/{developer.UserId}", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.False(factory.Apim.Contains(name));
+        await using var dbContext = factory.CreateDbContext();
+        var saved = await dbContext.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.True(saved.IsActive);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionId);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionKey);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionKeyHint);
+        Assert.Null(saved.ApimKeyIssuedDate);
+        Assert.Single(await dbContext.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.KeyRevoked && a.TargetId == developer.UserId.ToString()).ToListAsync());
+
+        var mine = await developerClient.GetFromJsonAsync<ApiKeyResponse>(new Uri($"{KeysPath}/me", UriKind.Relative), JsonOptions);
+        Assert.NotNull(mine);
+        Assert.False(mine.IsProvisioned);
+
+        // Idempotent: no key → still 204, no second audit row.
+        Assert.Equal(HttpStatusCode.NoContent, (await admin.DeleteAsync(new Uri($"{KeysPath}/{developer.UserId}", UriKind.Relative))).StatusCode);
+        Assert.Single(await dbContext.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.KeyRevoked && a.TargetId == developer.UserId.ToString()).ToListAsync());
+
+        // ...and the user can be provisioned again.
+        Assert.Equal(HttpStatusCode.OK, (await admin.PostAsync(new Uri($"{KeysPath}/{developer.UserId}/provision", UriKind.Relative), null)).StatusCode);
+    }
+
+    private async Task<(FoundryGate.Data.Entities.User User, HttpClient Client)> CreateAdminAsync()
+    {
+        var adminUser = await factory.SeedUserAsync(displayName: "Ada Admin");
+        return (adminUser, factory.CreateClientAs(adminUser.EntraObjectId, isAdmin: true));
+    }
+
+    private static async Task<T> PostAsync<T>(HttpClient client, string path)
+    {
+        var response = await client.PostAsync(new Uri(path, UriKind.Relative), null);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+        Assert.NotNull(body);
+        return body;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ApimKeyServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ApimKeyServiceTests.cs
@@ -183,6 +183,142 @@ public class ApimKeyServiceTests : InMemoryDatabaseTest
         Assert.Equal(string.Empty, developer.ApimSubscriptionId);
         Assert.Equal(string.Empty, developer.ApimSubscriptionKey);
         Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.TargetId == developer.UserId.ToString()).ToListAsync());
+        // The provisioning claim was written before APIM was called and must have rolled back with the transaction.
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionId);
+        Assert.Null(Context.Database.CurrentTransaction);
+
+        // ...and the user is provisionable once APIM is healthy again.
+        _apim.ThrowOnCreate = null;
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Provision_throws_Conflict_when_a_concurrent_request_already_claimed_the_row_and_never_calls_APIM()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        // Another request (other scope) won the race: the database row now carries a claim while this
+        // request's tracked entity still says "no key".
+        _ = await Context.Users.Where(u => u.UserId == developer.UserId)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(u => u.ApimSubscriptionId, "claimed-by-the-other-request"));
+        Assert.Equal(string.Empty, developer.ApimSubscriptionId);
+
+        await Assert.ThrowsAsync<ConflictException>(() => service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None));
+
+        Assert.Empty(_apim.Calls);
+        Assert.Null(Context.Database.CurrentTransaction);
+    }
+
+    [Fact]
+    public async Task Provision_joins_a_transaction_the_caller_already_opened_instead_of_starting_its_own()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        await using var transaction = await Context.Database.BeginTransactionAsync();
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        Assert.Same(transaction, Context.Database.CurrentTransaction); // still ours, not committed by the service
+        await transaction.RollbackAsync();
+
+        Context.ChangeTracker.Clear();
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionId); // the orchestrator's rollback took the provision with it
+    }
+
+    [Fact]
+    public async Task Provision_replaces_an_orphan_that_is_not_active_instead_of_adopting_it()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        _ = _apim.Seed(name, GatewayTiers.Standard);
+        _apim.SetState(name, "suspended");
+
+        var reveal = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        Assert.Contains($"Delete:{name}", _apim.Calls);
+        Assert.Contains($"CreateOrUpdate:{name}:standard", _apim.Calls);
+        Assert.DoesNotContain(_apim.Calls, call => call.StartsWith("Regenerate", StringComparison.Ordinal));
+        var subscription = await _apim.GetSubscriptionAsync(name, CancellationToken.None);
+        Assert.Equal("active", subscription!.State);
+        Assert.Equal(_apim.KeysOf(name).PrimaryKey, reveal.PlaintextKey);
+        var audit = await SingleAuditAsync(AuditActions.KeyProvisioned, developer.UserId);
+        Assert.Contains("\"reusedOrphan\":false", audit.Details, StringComparison.Ordinal);
+        Assert.Contains(_logs.Entries, entry => entry.Contains("suspended", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Rotate_failure_after_APIM_regenerated_keeps_the_previous_ciphertext_logs_an_error_and_audits_rotation_failed()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var provisioned = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var envelopeBefore = developer.ApimSubscriptionKey;
+        _apim.ThrowOnListSecrets = new IOException("ARM timed out");
+
+        var exception = await Assert.ThrowsAsync<IOException>(() => service.RotateAsync(developer, CancellationToken.None));
+
+        Assert.Equal("ARM timed out", exception.Message);
+        // Row is self-consistent (previous values), even though APIM now holds different keys.
+        Assert.Equal(envelopeBefore, developer.ApimSubscriptionKey);
+        Assert.Equal(provisioned.PlaintextKey[^4..], developer.ApimSubscriptionKeyHint);
+        Assert.Equal(provisioned.IssuedDate, developer.ApimKeyIssuedDate);
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.Equal(envelopeBefore, saved.ApimSubscriptionKey);
+        // Trail: no key.rotated, one key.rotation-failed naming the remedy, and an Error log.
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.KeyRotated).ToListAsync());
+        var failed = await SingleAuditAsync(AuditActions.KeyRotationFailed, developer.UserId);
+        Assert.Equal(admin.UserId, failed.ActorUserId);
+        Assert.Contains("rotate again", failed.Details, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"error\":\"IOException\"", failed.Details, StringComparison.Ordinal);
+        Assert.Contains(_logs.Entries, entry => entry.Contains("STALE", StringComparison.Ordinal) && entry.Contains("Rotate again", StringComparison.Ordinal));
+
+        // Remedy works: a second rotate stores a fresh, revealable key.
+        _apim.ThrowOnListSecrets = null;
+        var rotated = await service.RotateAsync(developer, CancellationToken.None);
+        Assert.Equal(rotated.PlaintextKey, (await service.RevealAsync(developer, CancellationToken.None)).PlaintextKey);
+    }
+
+    [Fact]
+    public async Task RevokeAsSystem_deletes_the_subscription_and_writes_a_system_audit_row_without_any_HTTP_caller()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        var callerless = CreateCallerlessService();
+
+        // The caller-attributed variant cannot run here; the system variant can.
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => callerless.RevokeAsync(developer, CancellationToken.None));
+        Assert.True(_apim.Contains(name));
+
+        var revoked = await callerless.RevokeAsSystemAsync(developer, "entra-departure", CancellationToken.None);
+
+        Assert.True(revoked);
+        Assert.False(_apim.Contains(name));
+        Assert.Equal(string.Empty, developer.ApimSubscriptionId);
+        Assert.True(developer.IsActive);
+        var audit = await SingleAuditAsync(AuditActions.KeyRevoked, developer.UserId);
+        Assert.Null(audit.ActorUserId);
+        Assert.Contains("\"reason\":\"entra-departure\"", audit.Details, StringComparison.Ordinal);
+        Assert.Contains("\"existedInApim\":true", audit.Details, StringComparison.Ordinal);
+
+        Assert.False(await callerless.RevokeAsSystemAsync(developer, "entra-departure", CancellationToken.None)); // idempotent
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => callerless.RevokeAsSystemAsync(developer, " ", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Reveal_refuses_a_row_that_has_a_key_but_no_issued_date_rather_than_inventing_one()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        developer.ApimKeyIssuedDate = null;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.RevealAsync(developer, CancellationToken.None));
+
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.KeyRevealed).ToListAsync());
     }
 
     [Fact]
@@ -496,10 +632,20 @@ public class ApimKeyServiceTests : InMemoryDatabaseTest
             nameType: ClaimConstants.Name,
             roleType: ClaimConstants.Roles);
         var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(new DefaultHttpContext { User = new ClaimsPrincipal(identity) }), Context);
-        var audit = new AuditService(Context, new AuditWriter(Context, _timeProvider), accessor);
+        var writer = new AuditWriter(Context, _timeProvider);
+        var audit = new AuditService(Context, writer, accessor);
 
-        var service = new ApimKeyService(Context, _apim, _protector, audit, accessor, _timeProvider, _logs.CreateLogger<ApimKeyService>());
+        var service = new ApimKeyService(Context, _apim, _protector, audit, writer, accessor, _timeProvider, _logs.CreateLogger<ApimKeyService>());
         return (service, admin);
+    }
+
+    /// <summary>A service with no HTTP caller at all — what a sync job or a Functions host would build.</summary>
+    private ApimKeyService CreateCallerlessService()
+    {
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(null), Context);
+        var writer = new AuditWriter(Context, _timeProvider);
+        var audit = new AuditService(Context, writer, accessor);
+        return new ApimKeyService(Context, _apim, _protector, audit, writer, accessor, _timeProvider, _logs.CreateLogger<ApimKeyService>());
     }
 
     private async Task<User> SeedUserAsync(string displayName, string email, bool isActive = true)

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ApimKeyServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ApimKeyServiceTests.cs
@@ -1,0 +1,525 @@
+using System.Globalization;
+using System.Security.Claims;
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Api.Services.Keys;
+using FoundryGate.Api.Services.Security;
+using FoundryGate.Data.Audit;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
+using FoundryGate.Domain.Keys;
+using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Keys;
+
+/// <summary>
+/// <see cref="ApimKeyService"/> over a real SQLite context, the real audit path (<see cref="AuditService"/>
+/// + <see cref="AuditWriter"/> + <see cref="CurrentUserAccessor"/>), the local Data Protection
+/// protector, and <see cref="FakeApimManagementClient"/>. The acting caller is a seeded admin; the
+/// target is a seeded developer.
+/// </summary>
+public class ApimKeyServiceTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly MutableTimeProvider _timeProvider = new(Now);
+    private readonly FakeApimManagementClient _apim = new();
+    private readonly CapturingLoggerProvider _logs = new();
+    private readonly DataProtectionKeyProtector _protector = new(new EphemeralDataProtectionProvider());
+
+    [Fact]
+    public async Task Provision_creates_the_subscription_under_the_tier_product_and_stores_only_ciphertext()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev One", "dev.one@contoso.test");
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+
+        var reveal = await service.ProvisionAsync(developer, GatewayTiers.Power, CancellationToken.None);
+
+        // APIM side
+        Assert.Contains($"CreateOrUpdate:{name}:power", _apim.Calls);
+        Assert.Equal("power", _apim.ProductOf(name));
+        var apimKeys = _apim.KeysOf(name);
+        Assert.Equal(apimKeys.PrimaryKey, reveal.PlaintextKey);
+
+        // Response
+        Assert.Equal($"{FakeApimManagementClient.ServiceId}/subscriptions/{name}", reveal.ApimSubscriptionId);
+        Assert.Equal("••••••••" + apimKeys.PrimaryKey[^4..], reveal.MaskedKey);
+        Assert.Equal(Now, reveal.IssuedDate);
+
+        // Row: encrypted, never plaintext
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.Equal(reveal.ApimSubscriptionId, saved.ApimSubscriptionId);
+        Assert.StartsWith("dp1:", saved.ApimSubscriptionKey, StringComparison.Ordinal);
+        Assert.DoesNotContain(reveal.PlaintextKey, saved.ApimSubscriptionKey, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(reveal.PlaintextKey, await _protector.UnprotectAsync(saved.ApimSubscriptionKey, CancellationToken.None));
+        Assert.Equal(reveal.PlaintextKey[^4..], saved.ApimSubscriptionKeyHint);
+        Assert.Equal(Now, saved.ApimKeyIssuedDate);
+        Assert.True(saved.IsActive);
+
+        // Audit: actor = admin, target = the developer's key, details carry no key material
+        var audit = await SingleAuditAsync(AuditActions.KeyProvisioned, developer.UserId);
+        Assert.Equal(admin.UserId, audit.ActorUserId);
+        Assert.Contains("\"productId\":\"power\"", audit.Details, StringComparison.Ordinal);
+        Assert.Contains("\"reusedOrphan\":false", audit.Details, StringComparison.Ordinal);
+        Assert.DoesNotContain(reveal.PlaintextKey, audit.Details, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Provision_display_name_carries_the_email_within_APIMs_100_char_limit()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", new string('x', 300) + "@contoso.test");
+
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        var subscription = await _apim.GetSubscriptionAsync(ApimSubscriptionNames.ForUser(developer.UserId), CancellationToken.None);
+        Assert.NotNull(subscription);
+        Assert.StartsWith("FoundryGate xxx", subscription.DisplayName, StringComparison.Ordinal);
+        Assert.Equal(100, subscription.DisplayName.Length);
+    }
+
+    [Fact]
+    public async Task Provision_accepts_tier_ids_case_insensitively_and_normalizes_them()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        _ = await service.ProvisionAsync(developer, " Standard ", CancellationToken.None);
+
+        Assert.Equal("standard", _apim.ProductOf(ApimSubscriptionNames.ForUser(developer.UserId)));
+    }
+
+    [Fact]
+    public async Task Provision_throws_Conflict_when_the_user_already_has_a_key_without_touching_APIM()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var callsBefore = _apim.Calls.Count;
+
+        await Assert.ThrowsAsync<ConflictException>(() => service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None));
+
+        Assert.Equal(callsBefore, _apim.Calls.Count);
+    }
+
+    [Theory]
+    [InlineData("gold")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Provision_rejects_an_unknown_tier_before_calling_APIM(string tier)
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => service.ProvisionAsync(developer, tier, CancellationToken.None));
+
+        Assert.Empty(_apim.Calls);
+        Assert.Empty(Context.ChangeTracker.Entries<AuditLog>());
+    }
+
+    [Fact]
+    public async Task Provision_refuses_an_unsaved_user()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var unsaved = new User { EntraObjectId = Guid.NewGuid().ToString(), DisplayName = "New", Email = "new@contoso.test" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.ProvisionAsync(unsaved, GatewayTiers.Standard, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Provision_reuses_an_orphan_subscription_rescopes_it_and_regenerates_both_keys()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        var orphanKeys = _apim.Seed(name, GatewayTiers.Power);
+
+        var reveal = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        Assert.DoesNotContain(_apim.Calls, call => call.StartsWith("CreateOrUpdate:", StringComparison.Ordinal));
+        Assert.Contains($"UpdateScope:{name}:standard", _apim.Calls);
+        Assert.Contains($"RegeneratePrimary:{name}", _apim.Calls);
+        Assert.Contains($"RegenerateSecondary:{name}", _apim.Calls);
+        var current = _apim.KeysOf(name);
+        Assert.NotEqual(orphanKeys.PrimaryKey, current.PrimaryKey);
+        Assert.NotEqual(orphanKeys.SecondaryKey, current.SecondaryKey);
+        Assert.Equal(current.PrimaryKey, reveal.PlaintextKey);
+        Assert.Equal("standard", _apim.ProductOf(name));
+
+        var audit = await SingleAuditAsync(AuditActions.KeyProvisioned, developer.UserId);
+        Assert.Contains("\"reusedOrphan\":true", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Provision_reusing_an_orphan_already_on_the_right_product_does_not_rescope()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        _ = _apim.Seed(name, GatewayTiers.Standard);
+
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        Assert.DoesNotContain(_apim.Calls, call => call.StartsWith("UpdateScope:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Provision_when_APIM_fails_leaves_the_row_and_audit_trail_untouched()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _apim.ThrowOnCreate = new InvalidOperationException("ARM said no");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None));
+
+        Assert.Equal("ARM said no", exception.Message);
+        Assert.Equal(string.Empty, developer.ApimSubscriptionId);
+        Assert.Equal(string.Empty, developer.ApimSubscriptionKey);
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.TargetId == developer.UserId.ToString()).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Rotate_regenerates_both_APIM_keys_stores_the_new_primary_and_audits()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var first = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        var keysBefore = _apim.KeysOf(name);
+        var envelopeBefore = developer.ApimSubscriptionKey;
+        _timeProvider.Advance(TimeSpan.FromDays(3));
+
+        var rotated = await service.RotateAsync(developer, CancellationToken.None);
+
+        var keysAfter = _apim.KeysOf(name);
+        Assert.NotEqual(keysBefore.PrimaryKey, keysAfter.PrimaryKey);
+        Assert.NotEqual(keysBefore.SecondaryKey, keysAfter.SecondaryKey);
+        Assert.Equal(keysAfter.PrimaryKey, rotated.PlaintextKey);
+        Assert.NotEqual(first.PlaintextKey, rotated.PlaintextKey);
+        Assert.Equal(first.ApimSubscriptionId, rotated.ApimSubscriptionId);
+        Assert.Equal(Now.AddDays(3), rotated.IssuedDate);
+
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.NotEqual(envelopeBefore, saved.ApimSubscriptionKey);
+        Assert.Equal(rotated.PlaintextKey, await _protector.UnprotectAsync(saved.ApimSubscriptionKey, CancellationToken.None));
+        Assert.Equal(rotated.PlaintextKey[^4..], saved.ApimSubscriptionKeyHint);
+        Assert.Equal(Now.AddDays(3), saved.ApimKeyIssuedDate);
+
+        var audit = await SingleAuditAsync(AuditActions.KeyRotated, developer.UserId);
+        Assert.Equal(admin.UserId, audit.ActorUserId);
+        Assert.Contains("\"keysRegenerated\":[\"primary\",\"secondary\"]", audit.Details, StringComparison.Ordinal);
+        Assert.DoesNotContain(rotated.PlaintextKey, audit.Details, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(first.PlaintextKey, audit.Details, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Rotate_without_a_key_throws_KeyNotFound()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.RotateAsync(developer, CancellationToken.None));
+
+        Assert.Empty(_apim.Calls);
+    }
+
+    [Fact]
+    public async Task Rotate_when_the_subscription_vanished_from_APIM_throws_Conflict_with_reprovision_guidance()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        Assert.True(_apim.Remove(ApimSubscriptionNames.ForUser(developer.UserId)));
+
+        var exception = await Assert.ThrowsAsync<ConflictException>(() => service.RotateAsync(developer, CancellationToken.None));
+
+        Assert.Contains($"DELETE /keys/{developer.UserId}", exception.Message, StringComparison.Ordinal);
+        Assert.IsType<ApimSubscriptionNotFoundException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task Revoke_deletes_the_subscription_clears_every_key_field_keeps_the_user_active_and_audits()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var provisioned = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+
+        var revoked = await service.RevokeAsync(developer, CancellationToken.None);
+
+        Assert.True(revoked);
+        Assert.False(_apim.Contains(name));
+        var saved = await Context.Users.AsNoTracking().SingleAsync(u => u.UserId == developer.UserId);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionId);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionKey);
+        Assert.Equal(string.Empty, saved.ApimSubscriptionKeyHint);
+        Assert.Null(saved.ApimKeyIssuedDate);
+        Assert.True(saved.IsActive); // key-only revocation (#116)
+
+        var audit = await SingleAuditAsync(AuditActions.KeyRevoked, developer.UserId);
+        Assert.Equal(admin.UserId, audit.ActorUserId);
+        Assert.Contains(provisioned.ApimSubscriptionId, audit.Details, StringComparison.Ordinal);
+        Assert.Contains("\"existedInApim\":true", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Revoke_without_a_key_is_a_no_op()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        var revoked = await service.RevokeAsync(developer, CancellationToken.None);
+
+        Assert.False(revoked);
+        Assert.Empty(_apim.Calls);
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.TargetId == developer.UserId.ToString()).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Revoke_when_APIM_already_lost_the_subscription_still_clears_the_row_and_audits()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        Assert.True(_apim.Remove(ApimSubscriptionNames.ForUser(developer.UserId)));
+
+        var revoked = await service.RevokeAsync(developer, CancellationToken.None);
+
+        Assert.True(revoked);
+        Assert.Equal(string.Empty, developer.ApimSubscriptionId);
+        var audit = await SingleAuditAsync(AuditActions.KeyRevoked, developer.UserId);
+        Assert.Contains("\"existedInApim\":false", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task After_revoke_the_user_can_be_provisioned_again_with_a_fresh_key()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var first = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        _ = await service.RevokeAsync(developer, CancellationToken.None);
+
+        var second = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        Assert.NotEqual(first.PlaintextKey, second.PlaintextKey);
+        Assert.Equal(first.ApimSubscriptionId, second.ApimSubscriptionId); // same name → same resource id
+    }
+
+    [Fact]
+    public async Task GetMasked_shows_exactly_the_last_four_characters_and_nothing_else_of_the_key()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var reveal = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        var masked = service.GetMasked(developer);
+
+        Assert.True(masked.IsProvisioned);
+        Assert.Equal(reveal.ApimSubscriptionId, masked.ApimSubscriptionId);
+        Assert.NotNull(masked.MaskedKey);
+        Assert.EndsWith(reveal.PlaintextKey[^4..], masked.MaskedKey, StringComparison.Ordinal);
+        Assert.Equal("••••••••" + reveal.PlaintextKey[^4..], masked.MaskedKey);
+        // No 5-character window of the key survives into the masked form.
+        for (var i = 0; i + 5 <= reveal.PlaintextKey.Length; i++)
+        {
+            Assert.DoesNotContain(reveal.PlaintextKey.Substring(i, 5), masked.MaskedKey, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task GetMasked_for_an_unprovisioned_user_reports_not_provisioned()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        var masked = service.GetMasked(developer);
+
+        Assert.False(masked.IsProvisioned);
+        Assert.Null(masked.MaskedKey);
+        Assert.Null(masked.ApimSubscriptionId);
+    }
+
+    [Fact]
+    public async Task Reveal_decrypts_the_stored_key_and_audits_without_calling_APIM()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var provisioned = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var callsBefore = _apim.Calls.Count;
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+
+        var revealed = await service.RevealAsync(developer, CancellationToken.None);
+
+        Assert.Equal(provisioned.PlaintextKey, revealed.PlaintextKey);
+        Assert.Equal(provisioned.MaskedKey, revealed.MaskedKey);
+        Assert.Equal(provisioned.IssuedDate, revealed.IssuedDate); // when it was minted, not when it was revealed
+        Assert.Equal(callsBefore, _apim.Calls.Count);
+        var audit = await SingleAuditAsync(AuditActions.KeyRevealed, developer.UserId);
+        Assert.Equal(admin.UserId, audit.ActorUserId);
+        Assert.DoesNotContain(revealed.PlaintextKey, audit.Details, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Reveal_without_a_key_throws_KeyNotFound()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.RevealAsync(developer, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MoveToProduct_rescopes_the_subscription_and_audits_before_and_after()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+        var keysBefore = _apim.KeysOf(name);
+
+        await service.MoveToProductAsync(developer, GatewayTiers.Unlimited, CancellationToken.None);
+
+        Assert.Equal("unlimited", _apim.ProductOf(name));
+        Assert.Equal(keysBefore, _apim.KeysOf(name)); // keys untouched by a tier move
+        var audit = await SingleAuditAsync(AuditActions.KeyTierChanged, developer.UserId);
+        Assert.Contains("\"before\":\"standard\"", audit.Details, StringComparison.Ordinal);
+        Assert.Contains("\"after\":\"unlimited\"", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MoveToProduct_to_the_current_product_is_a_no_op()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+
+        await service.MoveToProductAsync(developer, "STANDARD", CancellationToken.None);
+
+        Assert.DoesNotContain(_apim.Calls, call => call.StartsWith("UpdateScope:", StringComparison.Ordinal));
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.KeyTierChanged).ToListAsync());
+    }
+
+    [Fact]
+    public async Task MoveToProduct_without_a_key_throws_KeyNotFound_and_with_a_bad_tier_throws_Argument()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.MoveToProductAsync(developer, GatewayTiers.Power, CancellationToken.None));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => service.MoveToProductAsync(developer, "gold", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MoveToProduct_when_the_subscription_vanished_throws_Conflict()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        _ = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        Assert.True(_apim.Remove(ApimSubscriptionNames.ForUser(developer.UserId)));
+
+        await Assert.ThrowsAsync<ConflictException>(() => service.MoveToProductAsync(developer, GatewayTiers.Power, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProvisionForUser_refuses_a_deactivated_user_and_an_unknown_user()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var inactive = await SeedUserAsync("Gone", "gone@contoso.test", isActive: false);
+
+        await Assert.ThrowsAsync<ConflictException>(() => service.ProvisionForUserAsync(inactive.UserId, GatewayTiers.Standard, CancellationToken.None));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.ProvisionForUserAsync(999_999, GatewayTiers.Standard, CancellationToken.None));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.RotateForUserAsync(999_999, CancellationToken.None));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => service.RevokeForUserAsync(999_999, CancellationToken.None));
+        Assert.Empty(_apim.Calls);
+    }
+
+    [Fact]
+    public async Task Mine_operations_act_on_the_caller_and_refuse_a_deactivated_caller()
+    {
+        var (service, admin) = await CreateServiceAsync();
+        _ = await service.ProvisionAsync(admin, GatewayTiers.Standard, CancellationToken.None);
+
+        var mine = await service.GetMineAsync(CancellationToken.None);
+        var revealed = await service.RevealMineAsync(CancellationToken.None);
+        var rotated = await service.RotateMineAsync(CancellationToken.None);
+
+        Assert.True(mine.IsProvisioned);
+        Assert.NotEqual(revealed.PlaintextKey, rotated.PlaintextKey);
+
+        admin.IsActive = false;
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => service.RevealMineAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => service.RotateMineAsync(CancellationToken.None));
+        Assert.True((await service.GetMineAsync(CancellationToken.None)).IsProvisioned); // reading the masked form is still fine
+    }
+
+    [Fact]
+    public async Task Plaintext_key_material_never_reaches_the_logger_or_an_audit_row()
+    {
+        var (service, _) = await CreateServiceAsync();
+        var developer = await SeedUserAsync("Dev", "d@contoso.test");
+        var name = ApimSubscriptionNames.ForUser(developer.UserId);
+
+        var provisioned = await service.ProvisionAsync(developer, GatewayTiers.Standard, CancellationToken.None);
+        var secondaryAfterProvision = _apim.KeysOf(name).SecondaryKey;
+        var revealed = await service.RevealAsync(developer, CancellationToken.None);
+        var rotated = await service.RotateAsync(developer, CancellationToken.None);
+        var secondaryAfterRotate = _apim.KeysOf(name).SecondaryKey;
+        await service.MoveToProductAsync(developer, GatewayTiers.Power, CancellationToken.None);
+        _ = await service.RevokeAsync(developer, CancellationToken.None);
+
+        string[] secrets = [provisioned.PlaintextKey, revealed.PlaintextKey, rotated.PlaintextKey, secondaryAfterProvision, secondaryAfterRotate];
+        Assert.NotEmpty(_logs.Entries);
+        var auditDetails = await Context.AuditLogs.AsNoTracking().Select(a => a.Details).ToListAsync();
+        Assert.NotEmpty(auditDetails);
+
+        foreach (var secret in secrets)
+        {
+            Assert.All(_logs.Entries, entry => Assert.DoesNotContain(secret, entry, StringComparison.OrdinalIgnoreCase));
+            Assert.All(auditDetails, details => Assert.DoesNotContain(secret, details, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>Wires the real accessor + audit path over this test's context as the DI container would per request, acting as a seeded admin.</summary>
+    private async Task<(ApimKeyService Service, User Admin)> CreateServiceAsync()
+    {
+        var admin = await SeedUserAsync("Ada Admin", "ada@contoso.test");
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimConstants.Oid, admin.EntraObjectId), new Claim(ClaimConstants.Roles, RoleNames.Admin)],
+            "TestAuth",
+            nameType: ClaimConstants.Name,
+            roleType: ClaimConstants.Roles);
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(new DefaultHttpContext { User = new ClaimsPrincipal(identity) }), Context);
+        var audit = new AuditService(Context, new AuditWriter(Context, _timeProvider), accessor);
+
+        var service = new ApimKeyService(Context, _apim, _protector, audit, accessor, _timeProvider, _logs.CreateLogger<ApimKeyService>());
+        return (service, admin);
+    }
+
+    private async Task<User> SeedUserAsync(string displayName, string email, bool isActive = true)
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = displayName,
+            Email = email,
+            IsActive = isActive,
+        };
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task<AuditLog> SingleAuditAsync(string action, int userId)
+    {
+        var targetId = userId.ToString(CultureInfo.InvariantCulture);
+        return await Context.AuditLogs.AsNoTracking()
+            .SingleAsync(a => a.Action == action && a.TargetType == AuditTargetTypes.ApiKey && a.TargetId == targetId);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ArmApimManagementClientTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Keys/ArmApimManagementClientTests.cs
@@ -1,0 +1,48 @@
+using FoundryGate.Api.Configuration;
+using FoundryGate.Api.Services.Keys;
+using FoundryGate.Tests.Predeployment.Support;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Keys;
+
+/// <summary>
+/// What can be tested of the ARM client without Azure: construction guards and the scope → product
+/// mapping. Live behaviour is the manual checklist in the follow-up issue this wave filed.
+/// </summary>
+public class ArmApimManagementClientTests
+{
+    private const string ServiceId = FakeApimManagementClient.ServiceId;
+
+    [Theory]
+    [InlineData(ServiceId + "/products/standard", "standard")]
+    [InlineData(ServiceId + "/products/Power/", "Power")]
+    [InlineData("/products/unlimited", "unlimited")]
+    [InlineData(ServiceId + "/apis", null)]
+    [InlineData(ServiceId + "/apis/anthropic", null)]
+    [InlineData(ServiceId + "/products/", null)]
+    [InlineData("", null)]
+    public void ProductIdFromScope_extracts_the_product_segment_or_null(string scope, string? expected) =>
+        Assert.Equal(expected, ArmApimManagementClient.ProductIdFromScope(scope));
+
+    [Fact]
+    public void Constructor_refuses_a_gateway_that_does_not_address_APIM()
+    {
+        var gateway = new GatewayOptions { ApimName = "apim-only" };
+
+        Assert.Throws<ArgumentException>(() => new ArmApimManagementClient(gateway, new StaticTokenCredential()));
+    }
+
+    [Fact]
+    public void Constructor_accepts_a_fully_addressed_gateway_without_calling_Azure()
+    {
+        var gateway = new GatewayOptions
+        {
+            SubscriptionId = "00000000-0000-0000-0000-000000000000",
+            ResourceGroup = "rg-foundrygate-test",
+            ApimName = "apim-foundrygate-test",
+        };
+
+        var client = new ArmApimManagementClient(gateway, new StaticTokenCredential());
+
+        Assert.NotNull(client);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/DataProtectionKeyProtectorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/DataProtectionKeyProtectorTests.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using FoundryGate.Api.Services.Security;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Security;
+
+/// <summary>The local-only protector: round trip, envelope shape, and refusal of foreign or tampered values.</summary>
+public class DataProtectionKeyProtectorTests
+{
+    private const string ApimKey = "3f9a1c2e4b6d8f0a1b2c3d4e5f607182";
+
+    private readonly DataProtectionKeyProtector _protector = new(new EphemeralDataProtectionProvider());
+
+    [Fact]
+    public async Task Protect_then_Unprotect_returns_the_original_key()
+    {
+        var ciphertext = await _protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.Equal(ApimKey, await _protector.UnprotectAsync(ciphertext, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Ciphertext_is_a_dp1_envelope_that_does_not_contain_the_plaintext()
+    {
+        var ciphertext = await _protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.StartsWith("dp1:", ciphertext, StringComparison.Ordinal);
+        Assert.DoesNotContain(ApimKey, ciphertext, StringComparison.OrdinalIgnoreCase);
+        Assert.True(KeyEnvelope.TryParse(ciphertext, out var envelope));
+        Assert.Equal(KeyEnvelope.DataProtectionScheme, envelope!.Scheme);
+        Assert.Null(envelope.KeyId);
+    }
+
+    [Fact]
+    public async Task Unprotect_refuses_a_Key_Vault_envelope()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _protector.UnprotectAsync("kv1:https://kv.vault.azure.net/keys/k/v1:AQID", CancellationToken.None));
+
+        Assert.Contains("'kv1'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Unprotect_refuses_a_tampered_payload()
+    {
+        var ciphertext = await _protector.ProtectAsync(ApimKey, CancellationToken.None);
+        var tampered = ciphertext[..^2] + (ciphertext[^2] == 'A' ? "BB" : "AA");
+
+        await Assert.ThrowsAsync<CryptographicException>(() => _protector.UnprotectAsync(tampered, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task A_value_protected_under_another_key_ring_cannot_be_opened()
+    {
+        var other = new DataProtectionKeyProtector(new EphemeralDataProtectionProvider());
+        var ciphertext = await other.ProtectAsync(ApimKey, CancellationToken.None);
+
+        await Assert.ThrowsAsync<CryptographicException>(() => _protector.UnprotectAsync(ciphertext, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task Protect_rejects_an_empty_key(string? plaintext) =>
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => _protector.ProtectAsync(plaintext!, CancellationToken.None));
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyEnvelopeTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyEnvelopeTests.cs
@@ -1,0 +1,63 @@
+using FoundryGate.Api.Services.Security;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Security;
+
+/// <summary>The stored-envelope grammar both protectors write and read.</summary>
+public class KeyEnvelopeTests
+{
+    private const string VersionedKeyId = "https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef";
+
+    [Fact]
+    public void KeyVault_envelope_round_trips_a_key_id_that_itself_contains_colons()
+    {
+        var envelope = new KeyEnvelope(KeyEnvelope.KeyVaultScheme, VersionedKeyId, "AQID");
+
+        var text = envelope.ToString();
+
+        Assert.Equal($"kv1:{VersionedKeyId}:AQID", text);
+        Assert.True(KeyEnvelope.TryParse(text, out var parsed));
+        Assert.Equal(envelope, parsed);
+    }
+
+    [Fact]
+    public void DataProtection_envelope_round_trips()
+    {
+        var envelope = new KeyEnvelope(KeyEnvelope.DataProtectionScheme, null, "CfDJ8token_base64url-payload");
+
+        var text = envelope.ToString();
+
+        Assert.Equal("dp1:CfDJ8token_base64url-payload", text);
+        Assert.True(KeyEnvelope.TryParse(text, out var parsed));
+        Assert.Equal(envelope, parsed);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("plaintext-apim-key-with-no-scheme")]
+    [InlineData(":payload")]
+    [InlineData("xx9:payload")]
+    [InlineData("kv1:no-separator-after-key-id")]
+    [InlineData("kv1:https://vault/keys/k/v:")]
+    [InlineData("dp1:")]
+    public void TryParse_rejects_anything_that_is_not_an_envelope(string? value)
+    {
+        Assert.False(KeyEnvelope.TryParse(value, out var parsed));
+        Assert.Null(parsed);
+    }
+
+    [Fact]
+    public void ParseFor_rejects_an_envelope_from_the_other_provider_with_a_configuration_hint()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => KeyEnvelope.ParseFor("dp1:abc", KeyEnvelope.KeyVaultScheme));
+
+        Assert.Contains("'dp1'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("'kv1'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("KeyProtection:Provider", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseFor_rejects_a_value_that_is_not_an_envelope_at_all() =>
+        Assert.Throws<InvalidOperationException>(() => KeyEnvelope.ParseFor("not-an-envelope", KeyEnvelope.DataProtectionScheme));
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyProtectorFactoryTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyProtectorFactoryTests.cs
@@ -1,0 +1,58 @@
+using FoundryGate.Api.Configuration;
+using FoundryGate.Api.Services.Security;
+using FoundryGate.Domain.Common;
+using FoundryGate.Tests.Predeployment.Support;
+using Imagile.Framework.Configuration.Exceptions;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Security;
+
+/// <summary>The fail-fast selection rules the host applies at startup (through <c>AddResolveOnStartup</c>).</summary>
+public class KeyProtectorFactoryTests
+{
+    private const string KeyUri = "https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption";
+
+    [Fact]
+    public void KeyVault_provider_without_a_key_uri_is_a_startup_configuration_error()
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Create(KeyProtectionProviderType.KeyVault, keyUri: null, AppEnvironment.Types.prod));
+
+        Assert.Contains("Gateway:KeyEncryptionKeyUri", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(AppEnvironment.Types.local)]
+    [InlineData(AppEnvironment.Types.qa)]
+    [InlineData(AppEnvironment.Types.prod)]
+    public void KeyVault_provider_with_a_key_uri_is_allowed_everywhere(AppEnvironment.Types environment) =>
+        Assert.IsType<KeyVaultKeyProtector>(Create(KeyProtectionProviderType.KeyVault, KeyUri, environment));
+
+    [Fact]
+    public void DataProtection_provider_is_allowed_locally() =>
+        Assert.IsType<DataProtectionKeyProtector>(Create(KeyProtectionProviderType.DataProtection, keyUri: null, AppEnvironment.Types.local));
+
+    [Theory]
+    [InlineData(AppEnvironment.Types.qa)]
+    [InlineData(AppEnvironment.Types.prod)]
+    public void DataProtection_provider_is_refused_outside_local(AppEnvironment.Types environment)
+    {
+        var exception = Assert.Throws<ConfigurationValidationException>(() =>
+            Create(KeyProtectionProviderType.DataProtection, KeyUri, environment));
+
+        Assert.Contains(environment.ToString(), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("KeyVault", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Default_options_select_KeyVault_so_a_cloud_host_that_forgets_the_section_fails_closed() =>
+        Assert.Equal(KeyProtectionProviderType.KeyVault, new KeyProtectionOptions().Provider);
+
+    private static IKeyProtector Create(KeyProtectionProviderType provider, string? keyUri, AppEnvironment.Types environment) =>
+        KeyProtectorFactory.Create(
+            new KeyProtectionOptions { Provider = provider },
+            new GatewayOptions { KeyEncryptionKeyUri = keyUri },
+            environment,
+            new StaticTokenCredential(),
+            new EphemeralDataProtectionProvider());
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyProtectorFactoryTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyProtectorFactoryTests.cs
@@ -12,11 +12,15 @@ public class KeyProtectorFactoryTests
 {
     private const string KeyUri = "https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption";
 
-    [Fact]
-    public void KeyVault_provider_without_a_key_uri_is_a_startup_configuration_error()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("http://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption")]
+    [InlineData("https://kv-fg-dev-abc12.vault.azure.net/secrets/fg-apim-key-encryption")]
+    public void KeyVault_provider_without_a_key_uri_is_a_startup_configuration_error(string? keyUri)
     {
         var exception = Assert.Throws<ConfigurationValidationException>(() =>
-            Create(KeyProtectionProviderType.KeyVault, keyUri: null, AppEnvironment.Types.prod));
+            Create(KeyProtectionProviderType.KeyVault, keyUri, AppEnvironment.Types.prod));
 
         Assert.Contains("Gateway:KeyEncryptionKeyUri", exception.Message, StringComparison.Ordinal);
     }
@@ -54,5 +58,6 @@ public class KeyProtectorFactoryTests
             new GatewayOptions { KeyEncryptionKeyUri = keyUri },
             environment,
             new StaticTokenCredential(),
-            new EphemeralDataProtectionProvider());
+            new EphemeralDataProtectionProvider(),
+            TimeProvider.System);
 }

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyVaultKeyProtectorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyVaultKeyProtectorTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using FoundryGate.Api.Services.Security;
+using FoundryGate.Tests.Predeployment.Support;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Security;
+
+/// <summary>
+/// The Key Vault protector against a real-RSA <see cref="FakeCryptographyClient"/>: envelope shape,
+/// version pinning across a Key Vault key rotation, client caching, and the column length budget.
+/// </summary>
+public sealed class KeyVaultKeyProtectorTests : IDisposable
+{
+    private const string ApimKey = "3f9a1c2e4b6d8f0a1b2c3d4e5f607182";
+    private const string VersionlessKeyUri = "https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption";
+    private const string Version1 = VersionlessKeyUri + "/0123456789abcdef0123456789abcdef";
+    private const string Version2 = VersionlessKeyUri + "/fedcba9876543210fedcba9876543210";
+
+    private readonly RSA _rsaV1 = RSA.Create(3072);
+    private readonly RSA _rsaV2 = RSA.Create(3072);
+    private readonly Dictionary<string, FakeCryptographyClient> _clients = new(StringComparer.Ordinal);
+    private readonly List<string> _factoryRequests = [];
+    private string _currentVersion = Version1;
+
+    [Fact]
+    public async Task Protect_then_Unprotect_returns_the_original_key()
+    {
+        var protector = CreateProtector();
+
+        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(ciphertext, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Envelope_records_the_versioned_key_id_Key_Vault_reports_not_the_versionless_one_configured()
+    {
+        var protector = CreateProtector();
+
+        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.True(KeyEnvelope.TryParse(ciphertext, out var envelope));
+        Assert.Equal(KeyEnvelope.KeyVaultScheme, envelope!.Scheme);
+        Assert.Equal(Version1, envelope.KeyId);
+        Assert.Equal(384, Convert.FromBase64String(envelope.Payload).Length); // RSA-3072 block
+        Assert.DoesNotContain(ApimKey, ciphertext, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Wrapping_targets_the_configured_versionless_uri_and_unwrapping_targets_the_recorded_version()
+    {
+        var protector = CreateProtector();
+
+        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        _ = await protector.UnprotectAsync(ciphertext, CancellationToken.None);
+
+        Assert.Equal([VersionlessKeyUri, Version1], _factoryRequests);
+    }
+
+    [Fact]
+    public async Task After_a_Key_Vault_key_rotation_old_rows_still_open_with_their_version_and_new_rows_use_the_new_one()
+    {
+        var protector = CreateProtector();
+        var before = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        _currentVersion = Version2; // the vault rotated: the versionless URI now resolves to v2
+        _clients.Remove(VersionlessKeyUri); // a fresh client would see v2 — but the protector caches per key id (see below)
+        var freshProtector = CreateProtector();
+        var after = await freshProtector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.Equal(Version1, KeyEnvelope.ParseFor(before, KeyEnvelope.KeyVaultScheme).KeyId);
+        Assert.Equal(Version2, KeyEnvelope.ParseFor(after, KeyEnvelope.KeyVaultScheme).KeyId);
+        Assert.Equal(ApimKey, await freshProtector.UnprotectAsync(before, CancellationToken.None));
+        Assert.Equal(ApimKey, await freshProtector.UnprotectAsync(after, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task One_client_per_key_id_is_created_and_reused()
+    {
+        var protector = CreateProtector();
+
+        var first = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        var second = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        _ = await protector.UnprotectAsync(first, CancellationToken.None);
+        _ = await protector.UnprotectAsync(second, CancellationToken.None);
+
+        Assert.Equal(2, _factoryRequests.Count);
+        Assert.Equal(2, _clients[VersionlessKeyUri].WrapCalls);
+        Assert.Equal(2, _clients[Version1].UnwrapCalls);
+    }
+
+    [Fact]
+    public async Task Envelope_fits_the_1000_character_column_even_for_an_RSA_4096_key_with_a_long_vault_name()
+    {
+        using var rsa4096 = RSA.Create(4096);
+        const string LongVersionedKeyId = "https://kv-foundrygate-production-westeurope.vault.azure.net/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef";
+        var protector = new KeyVaultKeyProtector(new Uri(VersionlessKeyUri), _ => new FakeCryptographyClient(LongVersionedKeyId, rsa4096));
+
+        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.InRange(ciphertext.Length, 1, 1000);
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(ciphertext, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Unprotect_refuses_a_DataProtection_envelope() =>
+        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateProtector().UnprotectAsync("dp1:abc", CancellationToken.None));
+
+    [Fact]
+    public async Task Unprotect_refuses_an_envelope_whose_key_id_is_not_a_uri() =>
+        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateProtector().UnprotectAsync("kv1:not a uri:AQID", CancellationToken.None));
+
+    public void Dispose()
+    {
+        _rsaV1.Dispose();
+        _rsaV2.Dispose();
+    }
+
+    private KeyVaultKeyProtector CreateProtector() => new(new Uri(VersionlessKeyUri), CreateClient);
+
+    /// <summary>Simulates Key Vault: the versionless URI resolves to the <em>current</em> version; a versioned URI resolves to exactly that version.</summary>
+    private CryptographyClient CreateClient(Uri keyId)
+    {
+        _factoryRequests.Add(keyId.AbsoluteUri);
+
+        var version = keyId.AbsoluteUri == VersionlessKeyUri ? _currentVersion : keyId.AbsoluteUri;
+        var rsa = version == Version1 ? _rsaV1 : _rsaV2;
+
+        var client = new FakeCryptographyClient(version, rsa);
+        _clients[keyId.AbsoluteUri] = client;
+        return client;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyVaultKeyProtectorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Security/KeyVaultKeyProtectorTests.cs
@@ -6,21 +6,31 @@ using FoundryGate.Tests.Predeployment.Support;
 namespace FoundryGate.Tests.Predeployment.Api.Services.Security;
 
 /// <summary>
-/// The Key Vault protector against a real-RSA <see cref="FakeCryptographyClient"/>: envelope shape,
-/// version pinning across a Key Vault key rotation, client caching, and the column length budget.
+/// The Key Vault protector against a real-RSA <see cref="FakeCryptographyClient"/> and a
+/// <see cref="FakeKeyClient"/>: envelope shape, explicit current-version resolution (so a long-lived
+/// singleton follows a Key Vault key rotation), version pinning on unwrap, vault/key pinning against
+/// tampered rows, client caching, and the column length budget.
 /// </summary>
 public sealed class KeyVaultKeyProtectorTests : IDisposable
 {
     private const string ApimKey = "3f9a1c2e4b6d8f0a1b2c3d4e5f607182";
-    private const string VersionlessKeyUri = "https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption";
+    private const string VaultUri = "https://kv-fg-dev-abc12.vault.azure.net";
+    private const string VersionlessKeyUri = VaultUri + "/keys/fg-apim-key-encryption";
     private const string Version1 = VersionlessKeyUri + "/0123456789abcdef0123456789abcdef";
     private const string Version2 = VersionlessKeyUri + "/fedcba9876543210fedcba9876543210";
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
 
     private readonly RSA _rsaV1 = RSA.Create(3072);
     private readonly RSA _rsaV2 = RSA.Create(3072);
     private readonly Dictionary<string, FakeCryptographyClient> _clients = new(StringComparer.Ordinal);
     private readonly List<string> _factoryRequests = [];
-    private string _currentVersion = Version1;
+    private readonly MutableTimeProvider _timeProvider = new(Now);
+    private readonly FakeKeyClient _keyClient;
+
+    public KeyVaultKeyProtectorTests()
+    {
+        _keyClient = new FakeKeyClient(new Uri(VaultUri), "fg-apim-key-encryption", _rsaV1) { CurrentVersionId = new Uri(Version1) };
+    }
 
     [Fact]
     public async Task Protect_then_Unprotect_returns_the_original_key()
@@ -33,7 +43,7 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
     }
 
     [Fact]
-    public async Task Envelope_records_the_versioned_key_id_Key_Vault_reports_not_the_versionless_one_configured()
+    public async Task Envelope_records_the_versioned_key_id_not_the_versionless_one_configured()
     {
         var protector = CreateProtector();
 
@@ -47,35 +57,60 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
     }
 
     [Fact]
-    public async Task Wrapping_targets_the_configured_versionless_uri_and_unwrapping_targets_the_recorded_version()
+    public async Task Wrapping_never_uses_a_client_bound_to_the_versionless_uri()
     {
+        // A CryptographyClient built on the versionless URI caches whatever version it first sees for
+        // its whole lifetime — the bug this design exists to avoid. The factory below throws on it.
         var protector = CreateProtector();
 
-        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
-        _ = await protector.UnprotectAsync(ciphertext, CancellationToken.None);
+        _ = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        _ = await protector.ProtectAsync(ApimKey, CancellationToken.None);
 
-        Assert.Equal([VersionlessKeyUri, Version1], _factoryRequests);
+        Assert.All(_factoryRequests, request => Assert.NotEqual(VersionlessKeyUri, request));
+        Assert.Equal([Version1], _factoryRequests);
     }
 
     [Fact]
-    public async Task After_a_Key_Vault_key_rotation_old_rows_still_open_with_their_version_and_new_rows_use_the_new_one()
+    public async Task Current_version_is_resolved_through_KeyClient_once_per_TTL_window()
+    {
+        var protector = CreateProtector();
+
+        _ = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        _ = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        Assert.Equal(1, _keyClient.Calls);
+
+        _timeProvider.Advance(KeyVaultKeyProtector.CurrentVersionTtl + TimeSpan.FromSeconds(1));
+        _ = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+
+        Assert.Equal(2, _keyClient.Calls);
+    }
+
+    [Fact]
+    public async Task After_a_Key_Vault_key_rotation_new_wraps_use_the_new_version_and_old_envelopes_still_unwrap()
     {
         var protector = CreateProtector();
         var before = await protector.ProtectAsync(ApimKey, CancellationToken.None);
 
-        _currentVersion = Version2; // the vault rotated: the versionless URI now resolves to v2
-        _clients.Remove(VersionlessKeyUri); // a fresh client would see v2 — but the protector caches per key id (see below)
-        var freshProtector = CreateProtector();
-        var after = await freshProtector.ProtectAsync(ApimKey, CancellationToken.None);
+        _keyClient.CurrentVersionId = new Uri(Version2); // the vault rotated
+        var withinTtl = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        _timeProvider.Advance(KeyVaultKeyProtector.CurrentVersionTtl + TimeSpan.FromSeconds(1));
+        var afterTtl = await protector.ProtectAsync(ApimKey, CancellationToken.None);
 
         Assert.Equal(Version1, KeyEnvelope.ParseFor(before, KeyEnvelope.KeyVaultScheme).KeyId);
-        Assert.Equal(Version2, KeyEnvelope.ParseFor(after, KeyEnvelope.KeyVaultScheme).KeyId);
-        Assert.Equal(ApimKey, await freshProtector.UnprotectAsync(before, CancellationToken.None));
-        Assert.Equal(ApimKey, await freshProtector.UnprotectAsync(after, CancellationToken.None));
+        Assert.Equal(Version1, KeyEnvelope.ParseFor(withinTtl, KeyEnvelope.KeyVaultScheme).KeyId); // documented ≤ TTL lag
+        Assert.Equal(Version2, KeyEnvelope.ParseFor(afterTtl, KeyEnvelope.KeyVaultScheme).KeyId);
+
+        var keyClientCalls = _keyClient.Calls;
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(before, CancellationToken.None));
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(withinTtl, CancellationToken.None));
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(afterTtl, CancellationToken.None));
+        Assert.Equal(keyClientCalls, _keyClient.Calls); // unwrap is pinned to the envelope's version; no lookup
+        Assert.Equal(2, _clients[Version1].UnwrapCalls); // `before` and `withinTtl` were both wrapped under v1
+        Assert.Equal(1, _clients[Version2].UnwrapCalls);
     }
 
     [Fact]
-    public async Task One_client_per_key_id_is_created_and_reused()
+    public async Task One_client_per_key_version_is_created_and_reused()
     {
         var protector = CreateProtector();
 
@@ -84,8 +119,8 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
         _ = await protector.UnprotectAsync(first, CancellationToken.None);
         _ = await protector.UnprotectAsync(second, CancellationToken.None);
 
-        Assert.Equal(2, _factoryRequests.Count);
-        Assert.Equal(2, _clients[VersionlessKeyUri].WrapCalls);
+        Assert.Equal([Version1], _factoryRequests);
+        Assert.Equal(2, _clients[Version1].WrapCalls);
         Assert.Equal(2, _clients[Version1].UnwrapCalls);
     }
 
@@ -93,8 +128,10 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
     public async Task Envelope_fits_the_1000_character_column_even_for_an_RSA_4096_key_with_a_long_vault_name()
     {
         using var rsa4096 = RSA.Create(4096);
-        const string LongVersionedKeyId = "https://kv-foundrygate-production-westeurope.vault.azure.net/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef";
-        var protector = new KeyVaultKeyProtector(new Uri(VersionlessKeyUri), _ => new FakeCryptographyClient(LongVersionedKeyId, rsa4096));
+        const string LongVault = "https://kv-foundrygate-production-westeurope.vault.azure.net";
+        const string LongVersionedKeyId = LongVault + "/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef";
+        var keyClient = new FakeKeyClient(new Uri(LongVault), "fg-apim-key-encryption", rsa4096) { CurrentVersionId = new Uri(LongVersionedKeyId) };
+        var protector = new KeyVaultKeyProtector(new Uri(LongVault + "/keys/fg-apim-key-encryption"), keyClient, id => new FakeCryptographyClient(id.AbsoluteUri, rsa4096), _timeProvider);
 
         var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
 
@@ -103,12 +140,47 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
     }
 
     [Fact]
-    public async Task Unprotect_refuses_a_DataProtection_envelope() =>
-        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateProtector().UnprotectAsync("dp1:abc", CancellationToken.None));
+    public async Task Protect_refuses_when_the_current_key_version_is_disabled()
+    {
+        _keyClient.CurrentEnabled = false;
+        var protector = CreateProtector();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => protector.ProtectAsync(ApimKey, CancellationToken.None));
+
+        Assert.Contains("disabled", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("dp1:abc")]
+    [InlineData("kv1:not a uri:AQID")]
+    [InlineData("kv1:https://kv-someone-else.vault.azure.net/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef:AQID")] // other vault
+    [InlineData("kv1:https://kv-fg-dev-abc12.vault.azure.net/keys/another-key/0123456789abcdef0123456789abcdef:AQID")] // other key
+    [InlineData("kv1:https://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption:AQID")] // versionless
+    [InlineData("kv1:http://kv-fg-dev-abc12.vault.azure.net/keys/fg-apim-key-encryption/0123456789abcdef0123456789abcdef:AQID")] // not https
+    public async Task Unprotect_refuses_envelopes_that_do_not_name_a_version_of_the_configured_key(string ciphertext)
+    {
+        var protector = CreateProtector();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => protector.UnprotectAsync(ciphertext, CancellationToken.None));
+
+        Assert.Empty(_factoryRequests); // never even built a client for the foreign id
+    }
 
     [Fact]
-    public async Task Unprotect_refuses_an_envelope_whose_key_id_is_not_a_uri() =>
-        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateProtector().UnprotectAsync("kv1:not a uri:AQID", CancellationToken.None));
+    public async Task Unprotect_accepts_a_versioned_id_of_the_configured_key_with_different_host_casing()
+    {
+        var protector = CreateProtector();
+        var ciphertext = await protector.ProtectAsync(ApimKey, CancellationToken.None);
+        var upperHost = ciphertext.Replace("kv-fg-dev-abc12.vault.azure.net", "KV-FG-DEV-ABC12.VAULT.AZURE.NET", StringComparison.Ordinal);
+
+        Assert.Equal(ApimKey, await protector.UnprotectAsync(upperHost, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("https://kv-fg-dev-abc12.vault.azure.net/secrets/not-a-key")]
+    [InlineData("https://kv-fg-dev-abc12.vault.azure.net/")]
+    public void Constructor_rejects_a_uri_that_is_not_a_key_uri(string uri) =>
+        Assert.Throws<ArgumentException>(() => new KeyVaultKeyProtector(new Uri(uri), _keyClient, CreateClient, _timeProvider));
 
     public void Dispose()
     {
@@ -116,16 +188,23 @@ public sealed class KeyVaultKeyProtectorTests : IDisposable
         _rsaV2.Dispose();
     }
 
-    private KeyVaultKeyProtector CreateProtector() => new(new Uri(VersionlessKeyUri), CreateClient);
+    private KeyVaultKeyProtector CreateProtector() => new(new Uri(VersionlessKeyUri), _keyClient, CreateClient, _timeProvider);
 
-    /// <summary>Simulates Key Vault: the versionless URI resolves to the <em>current</em> version; a versioned URI resolves to exactly that version.</summary>
+    /// <summary>
+    /// Models the SDK faithfully: a client is bound to exactly the version in its URI. A versionless
+    /// URI is refused outright — the protector must resolve the version first (see the class remarks).
+    /// </summary>
     private CryptographyClient CreateClient(Uri keyId)
     {
         _factoryRequests.Add(keyId.AbsoluteUri);
 
-        var version = keyId.AbsoluteUri == VersionlessKeyUri ? _currentVersion : keyId.AbsoluteUri;
-        var rsa = version == Version1 ? _rsaV1 : _rsaV2;
+        var version = keyId.AbsoluteUri;
+        if (version == VersionlessKeyUri)
+        {
+            throw new InvalidOperationException("The protector asked for a client on the versionless URI; that client would pin the first version it sees forever.");
+        }
 
+        var rsa = version == Version1 ? _rsaV1 : _rsaV2;
         var client = new FakeCryptographyClient(version, rsa);
         _clients[keyId.AbsoluteUri] = client;
         return client;

--- a/src/FoundryGate.Tests.Predeployment/Domain/ApimSubscriptionNamesTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/ApimSubscriptionNamesTests.cs
@@ -1,0 +1,43 @@
+using FoundryGate.Domain.Keys;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>The user ↔ APIM subscription naming contract shared by the Api (mint) and Functions (attribute usage).</summary>
+public class ApimSubscriptionNamesTests
+{
+    [Fact]
+    public void ForUser_is_the_prefix_plus_the_invariant_user_id()
+    {
+        Assert.Equal("foundrygate-42", ApimSubscriptionNames.ForUser(42));
+        Assert.Equal("foundrygate-1", ApimSubscriptionNames.ForUser(1));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-7)]
+    public void ForUser_refuses_an_unsaved_or_invalid_id(int userId) =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => ApimSubscriptionNames.ForUser(userId));
+
+    [Fact]
+    public void TryGetUserId_round_trips_a_minted_name()
+    {
+        Assert.True(ApimSubscriptionNames.TryGetUserId(ApimSubscriptionNames.ForUser(4711), out var userId));
+        Assert.Equal(4711, userId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("master")]
+    [InlineData("foundrygate-")]
+    [InlineData("foundrygate-abc")]
+    [InlineData("foundrygate--1")]
+    [InlineData("foundrygate-0")]
+    [InlineData("FoundryGate-42")]
+    [InlineData("foundrygate-42-extra")]
+    public void TryGetUserId_rejects_names_FoundryGate_did_not_mint(string? name)
+    {
+        Assert.False(ApimSubscriptionNames.TryGetUserId(name, out var userId));
+        Assert.Equal(0, userId);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/CapturingLoggerProvider.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/CapturingLoggerProvider.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// <see cref="ILoggerProvider"/> that records every log call — the formatted message <em>and</em> the
+/// raw structured state (each <c>{Placeholder}</c> value), because a secret that never appears in a
+/// message template could still be shipped as a property. Used to prove the key service never logs
+/// key material. Create loggers with <see cref="CreateLogger{T}"/>.
+/// </summary>
+public sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly Lock _gate = new();
+    private readonly List<string> _entries = [];
+
+    /// <summary>Every recorded message and state value, in order.</summary>
+    public IReadOnlyList<string> Entries
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return [.. _entries];
+            }
+        }
+    }
+
+    /// <summary>A typed logger that records into this provider at every level.</summary>
+    public ILogger<T> CreateLogger<T>() =>
+        LoggerFactory.Create(builder => builder.AddProvider(this).SetMinimumLevel(LogLevel.Trace)).CreateLogger<T>();
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+    private void Record(string entry)
+    {
+        lock (_gate)
+        {
+            _entries.Add(entry);
+        }
+    }
+
+    private sealed class CapturingLogger(CapturingLoggerProvider provider) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            provider.Record(formatter(state, exception));
+
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> properties)
+            {
+                foreach (var property in properties)
+                {
+                    provider.Record(property.Value?.ToString() ?? string.Empty);
+                }
+            }
+
+            if (exception is not null)
+            {
+                provider.Record(exception.ToString());
+            }
+        }
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
@@ -35,6 +35,21 @@ public sealed class FakeApimManagementClient : IApimManagementClient
     /// <summary>When set, <see cref="CreateOrUpdateSubscriptionAsync"/> throws it instead of creating — simulates an ARM failure.</summary>
     public Exception? ThrowOnCreate { get; set; }
 
+    /// <summary>When set, <see cref="ListSecretsAsync"/> throws it — simulates ARM failing between "keys regenerated" and "new key read".</summary>
+    public Exception? ThrowOnListSecrets { get; set; }
+
+    /// <summary>Changes a subscription's state behind the key service's back (e.g. <c>"suspended"</c> for a hand-made orphan).</summary>
+    public void SetState(string subscriptionName, string state)
+    {
+        lock (_gate)
+        {
+            _subscriptions[subscriptionName].State = state;
+        }
+    }
+
+    /// <inheritdoc />
+    public string GetSubscriptionResourceId(string subscriptionName) => $"{ServiceId}/subscriptions/{subscriptionName}";
+
     /// <summary>Pre-creates a subscription (an "orphan" from the key service's point of view) and returns its current keys.</summary>
     public ApimSubscriptionKeys Seed(string subscriptionName, string productId, string displayName = "orphan")
     {
@@ -125,6 +140,11 @@ public sealed class FakeApimManagementClient : IApimManagementClient
         lock (_gate)
         {
             _calls.Add($"ListSecrets:{subscriptionName}");
+            if (ThrowOnListSecrets is { } exception)
+            {
+                throw exception;
+            }
+
             var entry = Require(subscriptionName);
             return Task.FromResult(new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey));
         }
@@ -185,7 +205,7 @@ public sealed class FakeApimManagementClient : IApimManagementClient
             entry.DisplayName,
             $"{ServiceId}/products/{entry.ProductId}",
             entry.ProductId,
-            "active");
+            entry.State);
 
     /// <summary>APIM keys are 32 characters; 16 random bytes as lower-case hex has the same shape.</summary>
     private static string NewKey() => Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
@@ -199,5 +219,7 @@ public sealed class FakeApimManagementClient : IApimManagementClient
         public string PrimaryKey { get; set; } = primaryKey;
 
         public string SecondaryKey { get; set; } = secondaryKey;
+
+        public string State { get; set; } = "active";
     }
 }

--- a/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
@@ -1,0 +1,203 @@
+using System.Security.Cryptography;
+using FoundryGate.Api.Services.Keys;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// In-memory <see cref="IApimManagementClient"/>: a dictionary of subscriptions with random 32-hex
+/// keys, the same not-found contract as the ARM implementation (null / false /
+/// <see cref="ApimSubscriptionNotFoundException"/>), and a call log for assertions. Registered by
+/// <c>ApiTestFactory</c> in place of the ARM client so no test reaches Azure. Hand-rolled per
+/// CONVENTIONS.md (no mocking library).
+/// </summary>
+public sealed class FakeApimManagementClient : IApimManagementClient
+{
+    /// <summary>The fake APIM instance's ARM id; resource ids and scopes are built under it exactly as ARM would.</summary>
+    public const string ServiceId =
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-foundrygate-test/providers/Microsoft.ApiManagement/service/apim-foundrygate-test";
+
+    private readonly Lock _gate = new();
+    private readonly Dictionary<string, Entry> _subscriptions = new(StringComparer.Ordinal);
+    private readonly List<string> _calls = [];
+
+    /// <summary>Every call, as <c>"{Method}:{subscriptionName}"</c> (plus <c>:{productId}</c> where relevant), in order.</summary>
+    public IReadOnlyList<string> Calls
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return [.. _calls];
+            }
+        }
+    }
+
+    /// <summary>When set, <see cref="CreateOrUpdateSubscriptionAsync"/> throws it instead of creating — simulates an ARM failure.</summary>
+    public Exception? ThrowOnCreate { get; set; }
+
+    /// <summary>Pre-creates a subscription (an "orphan" from the key service's point of view) and returns its current keys.</summary>
+    public ApimSubscriptionKeys Seed(string subscriptionName, string productId, string displayName = "orphan")
+    {
+        lock (_gate)
+        {
+            var entry = new Entry(displayName, productId, NewKey(), NewKey());
+            _subscriptions[subscriptionName] = entry;
+            return new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey);
+        }
+    }
+
+    /// <summary>Removes a subscription behind the key service's back — simulates a portal deletion.</summary>
+    public bool Remove(string subscriptionName)
+    {
+        lock (_gate)
+        {
+            return _subscriptions.Remove(subscriptionName);
+        }
+    }
+
+    public bool Contains(string subscriptionName)
+    {
+        lock (_gate)
+        {
+            return _subscriptions.ContainsKey(subscriptionName);
+        }
+    }
+
+    /// <summary>The current keys without going through the interface (no call is logged).</summary>
+    public ApimSubscriptionKeys KeysOf(string subscriptionName)
+    {
+        lock (_gate)
+        {
+            var entry = _subscriptions[subscriptionName];
+            return new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey);
+        }
+    }
+
+    /// <summary>The current product id without going through the interface (no call is logged).</summary>
+    public string ProductOf(string subscriptionName)
+    {
+        lock (_gate)
+        {
+            return _subscriptions[subscriptionName].ProductId;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"CreateOrUpdate:{subscriptionName}:{productId}");
+
+            if (ThrowOnCreate is { } exception)
+            {
+                throw exception;
+            }
+
+            if (!_subscriptions.TryGetValue(subscriptionName, out var entry))
+            {
+                entry = new Entry(displayName, productId, NewKey(), NewKey());
+                _subscriptions[subscriptionName] = entry;
+            }
+            else
+            {
+                entry.DisplayName = displayName;
+                entry.ProductId = productId;
+            }
+
+            return Task.FromResult(new ApimSubscriptionWithKeys(Map(subscriptionName, entry), new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey)));
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<ApimSubscription?> GetSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"Get:{subscriptionName}");
+            return Task.FromResult(_subscriptions.TryGetValue(subscriptionName, out var entry) ? Map(subscriptionName, entry) : null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<ApimSubscriptionKeys> ListSecretsAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"ListSecrets:{subscriptionName}");
+            var entry = Require(subscriptionName);
+            return Task.FromResult(new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey));
+        }
+    }
+
+    /// <inheritdoc />
+    public Task RegeneratePrimaryKeyAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"RegeneratePrimary:{subscriptionName}");
+            Require(subscriptionName).PrimaryKey = NewKey();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task RegenerateSecondaryKeyAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"RegenerateSecondary:{subscriptionName}");
+            Require(subscriptionName).SecondaryKey = NewKey();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task UpdateScopeAsync(string subscriptionName, string productId, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"UpdateScope:{subscriptionName}:{productId}");
+            Require(subscriptionName).ProductId = productId;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"Delete:{subscriptionName}");
+            return Task.FromResult(_subscriptions.Remove(subscriptionName));
+        }
+    }
+
+    private Entry Require(string subscriptionName) =>
+        _subscriptions.TryGetValue(subscriptionName, out var entry)
+            ? entry
+            : throw new ApimSubscriptionNotFoundException(subscriptionName);
+
+    private static ApimSubscription Map(string subscriptionName, Entry entry) =>
+        new(
+            subscriptionName,
+            $"{ServiceId}/subscriptions/{subscriptionName}",
+            entry.DisplayName,
+            $"{ServiceId}/products/{entry.ProductId}",
+            entry.ProductId,
+            "active");
+
+    /// <summary>APIM keys are 32 characters; 16 random bytes as lower-case hex has the same shape.</summary>
+    private static string NewKey() => Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+
+    private sealed class Entry(string displayName, string productId, string primaryKey, string secondaryKey)
+    {
+        public string DisplayName { get; set; } = displayName;
+
+        public string ProductId { get; set; } = productId;
+
+        public string PrimaryKey { get; set; } = primaryKey;
+
+        public string SecondaryKey { get; set; } = secondaryKey;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/FakeCryptographyClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FakeCryptographyClient.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// A <see cref="CryptographyClient"/> that performs real RSA-OAEP-256 wrap/unwrap with a local
+/// <see cref="RSA"/> key instead of calling Key Vault, reporting <paramref name="versionedKeyId"/> as
+/// the key that did the work — exactly what Key Vault reports when asked to wrap under a versionless
+/// key URI. Real RSA (not a byte-reversing stub) so ciphertext sizes, and therefore the
+/// <c>User.ApimSubscriptionKey</c> length budget, are measured for real. Uses the SDK's protected
+/// mocking constructor and <see cref="CryptographyModelFactory"/>.
+/// </summary>
+public sealed class FakeCryptographyClient(string versionedKeyId, RSA rsa) : CryptographyClient
+{
+    /// <summary>The versioned key id this fake reports on every result.</summary>
+    public string VersionedKeyId { get; } = versionedKeyId;
+
+    public int WrapCalls { get; private set; }
+
+    public int UnwrapCalls { get; private set; }
+
+    /// <inheritdoc />
+    public override Task<WrapResult> WrapKeyAsync(KeyWrapAlgorithm algorithm, byte[] key, CancellationToken cancellationToken = default)
+    {
+        RequireRsaOaep256(algorithm);
+        WrapCalls++;
+
+        return Task.FromResult(CryptographyModelFactory.WrapResult(VersionedKeyId, rsa.Encrypt(key, RSAEncryptionPadding.OaepSHA256), algorithm));
+    }
+
+    /// <inheritdoc />
+    public override Task<UnwrapResult> UnwrapKeyAsync(KeyWrapAlgorithm algorithm, byte[] encryptedKey, CancellationToken cancellationToken = default)
+    {
+        RequireRsaOaep256(algorithm);
+        UnwrapCalls++;
+
+        return Task.FromResult(CryptographyModelFactory.UnwrapResult(VersionedKeyId, rsa.Decrypt(encryptedKey, RSAEncryptionPadding.OaepSHA256), algorithm));
+    }
+
+    private static void RequireRsaOaep256(KeyWrapAlgorithm algorithm)
+    {
+        if (algorithm != KeyWrapAlgorithm.RsaOaep256)
+        {
+            throw new ArgumentException($"Expected RSA-OAEP-256 but the protector asked for {algorithm}.", nameof(algorithm));
+        }
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/FakeKeyClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FakeKeyClient.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using Azure;
+using Azure.Security.KeyVault.Keys;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// A <see cref="KeyClient"/> whose <see cref="GetKeyAsync"/> answers "the current version of the key
+/// is <see cref="CurrentVersionId"/>" without touching Azure — the one call the Key Vault protector
+/// makes to follow a key rotation. Flip <see cref="CurrentVersionId"/> to simulate a rotation and
+/// <see cref="CurrentEnabled"/> to simulate a disabled version. Uses the SDK's protected mocking
+/// constructor and <see cref="KeyModelFactory"/>.
+/// </summary>
+public sealed class FakeKeyClient(Uri vaultUri, string keyName, RSA publicKeySource) : KeyClient
+{
+    /// <summary>The versioned key id the next <see cref="GetKeyAsync"/> reports.</summary>
+    public required Uri CurrentVersionId { get; set; }
+
+    public bool CurrentEnabled { get; set; } = true;
+
+    public int Calls { get; private set; }
+
+    /// <inheritdoc />
+    public override Task<Response<KeyVaultKey>> GetKeyAsync(string name, string? version = null, CancellationToken cancellationToken = default)
+    {
+        Calls++;
+
+        if (!string.Equals(name, keyName, StringComparison.Ordinal))
+        {
+            throw new RequestFailedException(404, $"Key '{name}' not found in fake vault.");
+        }
+
+        var id = CurrentVersionId;
+        var properties = KeyModelFactory.KeyProperties(
+            id,
+            vaultUri,
+            keyName,
+            id.AbsolutePath.Trim('/').Split('/')[^1],
+            managed: false,
+            createdOn: null,
+            updatedOn: null,
+            recoveryLevel: null);
+        properties.Enabled = CurrentEnabled;
+
+        var key = KeyModelFactory.KeyVaultKey(properties, new JsonWebKey(publicKeySource, includePrivateParameters: false));
+        return Task.FromResult<Response<KeyVaultKey>>(new ValueResponse<KeyVaultKey>(key));
+    }
+
+    private sealed class ValueResponse<T>(T value) : Response<T>
+    {
+        public override T Value => value;
+
+        public override Response GetRawResponse() => throw new NotSupportedException("The fake carries no HTTP response.");
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/StaticTokenCredential.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/StaticTokenCredential.cs
@@ -1,0 +1,15 @@
+using Azure.Core;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>A <see cref="TokenCredential"/> that hands out a fixed token and never talks to Entra — for constructing Azure clients that must not be exercised.</summary>
+public sealed class StaticTokenCredential : TokenCredential
+{
+    private static readonly AccessToken Token = new("test-token", DateTimeOffset.MaxValue);
+
+    /// <inheritdoc />
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) => Token;
+
+    /// <inheritdoc />
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) => new(Token);
+}


### PR DESCRIPTION
## Summary

Wires FoundryGate to the APIM management plane for developer subscription keys and encrypts the stored key at rest, per plans/09 and the lifecycle contract in plans/21.

- **`Services/Security`** — `IKeyProtector` with two implementations selected by `KeyProtection:Provider`: `KeyVaultKeyProtector` (RSA-OAEP-256 wrap of the key bytes under `Gateway:KeyEncryptionKeyUri` via `CryptographyClient`, stored as the versioned envelope `kv1:{versionedKeyId}:{base64}`) and `DataProtectionKeyProtector` (`dp1:{token}`, **local only**). `KeyProtectorFactory` fail-fasts at host start through a small `AddResolveOnStartup<T>()` helper: `KeyVault` without a key URI → `ConfigurationValidationException`; `DataProtection` in `qa`/`prod` → refused.
- **`Services/Keys`** — `IApimManagementClient` (thin seam over `Azure.ResourceManager.ApiManagement`, 7 operations; `ArmApimManagementClient` + `UnconfiguredApimManagementClient` for local dev without APIM, itself refused outside `local`) and `IApimKeyService`/`ApimKeyService`: provision (under the tier product, orphan reuse with both keys regenerated), rotate (**both** keys, #117), key-only revoke (#116), move-to-product (tier change, for #118), masked read from a stored hint, audited reveal. Every mutation adds its audit row through `IAuditService` and saves once.
- **`Controllers/KeysController`** — `GET /keys/me`, `POST /keys/me/reveal`, `POST /keys/me/rotate`; admin `POST /keys/{userId}/provision?tier=`, `POST /keys/{userId}/rotate`, `DELETE /keys/{userId}` (204, idempotent, user stays active).
- **Data** — `User.ApimSubscriptionKey` widened to `nvarchar(1000)`; new `ApimSubscriptionKeyHint nvarchar(4)` and `ApimKeyIssuedDate datetimeoffset null`; `Users.sql` mirrored (SchemaParity green). `Domain/Keys/ApimSubscriptionNames` (`foundrygate-{UserId}` ↔ `UserId`) shared with the future Functions reconciliation job (#84). `AuditActions.KeyTierChanged` added.
- **Config** — `GatewayOptions` (`SubscriptionId`, `ResourceGroup`, `ApimName`, `KeyEncryptionKeyUri`; all-or-none validation) and `KeyProtectionOptions` on `AppSettings`, bound from the `Gateway` / `KeyProtection` sections — names match the `Gateway__*` env vars `control-plane.bicep` sets (#108, PR #111). `appsettings.json` defaults to `KeyVault`; `appsettings.local.json` opts into `DataProtection`.
- **Docs** — `reference/api.md` Keys table rewritten to the implemented semantics; `reference/configuration.mdx` env vars updated to `Gateway__*`/`KeyProtection__Provider`; `architecture/overview.mdx` Rotate paragraph (prose only); spec §4.5/§5.1–5.3; plans/09 (verification ticked) and plans/21 (no suspend surface, `RevokeAsync` step).

Closes #36
Closes #37
Closes #95
Closes #116
Closes #117

## Design decisions (please scrutinize)

1. **Key-only revocation, no suspend anywhere** (#116 ruling): `DELETE /keys/{userId}` deletes the subscription and clears the four key fields; `IsActive` is untouched. `SuspendAsync`/`ReenableAsync` and a `SetStateAsync` on the management client were deliberately **not** built — nothing in plan 21 calls them any more and a dead suspend path invites the wrong mental model. `RevokeAsync(User)` is the building block `POST /users/{id}/deactivate` (#65) calls first; it is a no-op (`false`) for a user with no key so the Entra-departure path can call it unconditionally.
2. **Rotation regenerates both APIM keys** (#117): the secondary is never issued, stored, or returned, and rotating it alongside the primary means no credential on the subscription outlives a rotation. Orphan reuse regenerates both too, so a reused subscription never keeps keys FoundryGate did not mint.
3. **Masked view from a stored hint, not a decrypt.** `ApimSubscriptionKeyHint` (last 4) makes `GET /keys/me` — and the `/users/me` profile that embeds it — a plain row read instead of a Key Vault unwrap per page load (Key Vault RSA-3072 ops are rate-limited per vault). Four characters is exactly what the masked display discloses by design. `GetMasked(User)` is therefore synchronous.
4. **`ApimKeyIssuedDate`** added so `ApiKeyRevealResponse.IssuedDate` on reveal reports when the key was minted/rotated (plan 09's "updates RotatedAt"), not when it was revealed.
5. **Envelope records the Key Vault key *version*.** Wrap targets the versionless URI (Key Vault picks current), the result's `KeyId` is stored; unwrap targets the stored version. A Key Vault key rotation therefore needs no re-encryption sweep, and rows still on an old version are findable with `LIKE 'kv1:%/{version}:%'`. Column budget checked with a real RSA-4096 wrap + long vault name in tests (< 1000).
6. **Direct RSA wrap of the key bytes** (no DEK indirection): APIM keys are 32 chars; RSA-3072 OAEP-256 wraps up to 318 bytes.
7. **`ApimSubscriptionId` stays plaintext** (#95 asked to confirm): it is an ARM resource id — an address, not a credential.
8. **Options live under `Gateway`, not a separate `Apim` section**, to match what infra already sets (`Gateway__SubscriptionId/ResourceGroup/ApimName/KeyEncryptionKeyUri`). #108's remaining fields (`ApimGatewayUrl`, `LogAnalyticsWorkspaceId`, `FoundryAccountNames`) are for the Foundry/reconciliation waves to add to the same `GatewayOptions` class. PR #111 stays the source of truth for the names.
9. **Fail-fast via eager resolution.** Both singletons are factory-registered (they need `AppSettings` + the `AppEnvironment.Types` singleton, which `AddFoundryGateApiServices()` cannot see); `AddResolveOnStartup<T>()` resolves them in an `IHostedService.StartAsync` so a misconfiguration aborts startup rather than surfacing as a 500 on the first key call — the same mechanism `OptionsBuilder.ValidateOnStart()` uses.
10. **Actor resolved before any APIM side effect.** An admin without a `User` row hitting `POST /keys/{id}/provision` gets the 403 *before* a subscription is created (otherwise the refused request would leave an orphan). Covered by `Admin_without_a_User_row_returns_403_on_provision_…`.
11. **Subscription name is `foundrygate-{UserId}`** per plan 21/#66/the orchestrator brief. `User.UserUnique`'s doc comment suggests the Guid for external naming; I followed the plan (an int identity is not secret and the Functions job needs the inverse mapping to be trivial) — flagging in case the reviewer prefers the Guid.
12. **Not-found contract of the management client**: `Get` → null, `Delete` → false, everything else → `ApimSubscriptionNotFoundException`, which the key service maps to a **409** with "revoke and re-provision" guidance (a subscription deleted in the portal is a state conflict, not a missing resource).
13. **`ProvisionForUserAsync` refuses a deactivated user (409)** — provisioning alone would leave an inactive user holding a working key; `POST /users/{id}/activate` (plan 21 Trigger C) is the path. The building block `ProvisionAsync(User, …)` does not check `IsActive` because the re-activation pipeline provisions before flipping the flag.

## Public interface shapes

```csharp
// Services/Security
public interface IKeyProtector
{
    Task<string> ProtectAsync(string plaintext, CancellationToken cancellationToken);
    Task<string> UnprotectAsync(string ciphertext, CancellationToken cancellationToken);
}
public sealed record KeyEnvelope(string Scheme, string? KeyId, string Payload); // "kv1" | "dp1"
public static IKeyProtector KeyProtectorFactory.Create(KeyProtectionOptions, GatewayOptions, AppEnvironment.Types, TokenCredential, IDataProtectionProvider);

// Services/Keys
public interface IApimManagementClient
{
    Task<ApimSubscriptionWithKeys> CreateOrUpdateSubscriptionAsync(string subscriptionName, string displayName, string productId, CancellationToken ct);
    Task<ApimSubscription?> GetSubscriptionAsync(string subscriptionName, CancellationToken ct);           // null = absent (orphan probe)
    Task<ApimSubscriptionKeys> ListSecretsAsync(string subscriptionName, CancellationToken ct);
    Task RegeneratePrimaryKeyAsync(string subscriptionName, CancellationToken ct);
    Task RegenerateSecondaryKeyAsync(string subscriptionName, CancellationToken ct);
    Task UpdateScopeAsync(string subscriptionName, string productId, CancellationToken ct);
    Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken ct);                   // false = already gone
}
public sealed record ApimSubscription(string Name, string ResourceId, string DisplayName, string Scope, string? ProductId, string State);
public sealed record ApimSubscriptionKeys(string PrimaryKey, string SecondaryKey);
public sealed record ApimSubscriptionWithKeys(ApimSubscription Subscription, ApimSubscriptionKeys Keys);
public sealed class ApimSubscriptionNotFoundException(string subscriptionName) : Exception;

public interface IApimKeyService
{
    // building blocks (plan 21 orchestrator): tracked User in, APIM call, mutate, audit, SaveChanges
    Task<ApiKeyRevealResponse> ProvisionAsync(User user, string tierProductId, CancellationToken ct);   // 409 if key exists, 400 bad tier, orphan reuse
    Task<ApiKeyRevealResponse> RotateAsync(User user, CancellationToken ct);                            // both keys; 404 no key; 409 subscription vanished
    Task<bool> RevokeAsync(User user, CancellationToken ct);                                            // key-only; false = nothing to revoke
    Task MoveToProductAsync(User user, string tierProductId, CancellationToken ct);                     // tier change (#118)
    ApiKeyResponse GetMasked(User user);
    Task<ApiKeyRevealResponse> RevealAsync(User user, CancellationToken ct);
    // endpoint entry points
    Task<ApiKeyResponse> GetMineAsync(CancellationToken ct);
    Task<ApiKeyRevealResponse> RevealMineAsync(CancellationToken ct);
    Task<ApiKeyRevealResponse> RotateMineAsync(CancellationToken ct);
    Task<ApiKeyRevealResponse> ProvisionForUserAsync(int userId, string tierProductId, CancellationToken ct);
    Task<ApiKeyRevealResponse> RotateForUserAsync(int userId, CancellationToken ct);
    Task<bool> RevokeForUserAsync(int userId, CancellationToken ct);
}

// Configuration (AppSettings)
public GatewayOptions Gateway { get; set; }            // SubscriptionId, ResourceGroup, ApimName, KeyEncryptionKeyUri; IsApimConfigured
public KeyProtectionOptions KeyProtection { get; set; } // Provider: KeyVault (default) | DataProtection

// Domain
public static class ApimSubscriptionNames { const string Prefix = "foundrygate-"; string ForUser(int userId); bool TryGetUserId(string? name, out int userId); }
```

## Verification

- `dotnet build FoundryGate.sln -c Release`: succeeded, **zero warnings**.
- `dotnet test src/FoundryGate.Tests.Predeployment -c Release --no-build`: **229 passed, 0 failed** (126 on main + 103 new).
  - Protectors: round trip under both providers, `kv1`/`dp1` envelope grammar, version pinning across a simulated Key Vault rotation (real RSA-3072 fake), one client per key id, RSA-4096 length budget, foreign-envelope and tamper refusal, factory rules (`DataProtection` refused in `qa`/`prod`; `KeyVault` needs a URI).
  - `ApimKeyServiceTests` (real SQLite + real audit path + fake APIM): provision/conflict/bad tier/orphan reuse/ARM failure leaves row untouched; rotate both keys; revoke clears fields + keeps `IsActive` + idempotent + tolerates already-gone; masked ≤ 4 chars (no 5-char window survives); reveal audited without APIM; move-to-product before/after; `/me` operations and deactivated-caller refusal; **plaintext never reaches the logger (formatted messages *and* structured state) or any audit `Details`**.
  - `KeysEndpointTests` (`ApiTestFactory` + fake APIM + ephemeral Data Protection): 401 anonymous; 403 no `User` row (`/me` and admin-without-row); 403 non-admin on admin routes; 200 masked; 404 reveal/rotate with no key; 200 provision (default and `?tier=power`), 400 bad tier, 409 second provision / inactive user, 404 unknown user; reveal = minted key; rotate replaces primary **and** secondary; 204 revoke keeps user active, idempotent, re-provisionable.
  - Existing suites untouched and green (SchemaParity picks up the three column changes; DomainArchitecture allowlist unchanged).
- `dotnet format FoundryGate.sln --verify-no-changes`: clean.
- `cd docs-site && npm ci && npm run build`: Complete.
- `plans/09-apim-keys.md` Verification: all code items ticked; the live item points at #132.
- No live Azure was touched. Nothing under `.github/` or `infra/`.

## Follow-ups filed

- #132 — live-validate the key lifecycle + Key Vault wrapping against real APIM/Key Vault (exact manual checklist).

## Shared-file footprint (for the parallel quota/Entra/Foundry PRs)

`Services/ApiServiceCollectionExtensions.cs` (+2 lines), `Configuration/AppSettings.cs` (+2 properties, +3 classes appended), `appsettings*.json` (own sections), `Directory.Packages.props` + `FoundryGate.Api.csproj` (2 packages), `Domain/Constants/AuditActions.cs` (+1 constant), `Tests/Api/ApiTestFactory.cs` (config key + fake APIM/ephemeral Data Protection registration + `Apim` property). No files owned by the quota, Entra or Foundry waves were created or edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
