### PR TITLE
fix(api): request DTOs validate as 400 instead of 500, and generated URLs are lowercase

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -173,6 +173,9 @@ Landed with #42 (the first `/api/v1` controller); every endpoint wave builds on 
   `DomainArchitectureTests` fails the build for either broken placement;
   `Api/Endpoints/RequestDtoBindingTests` posts each request record through the real pipeline
   (via a test-only controller the factory registers) and asserts 400, never 500.
+- **Generated URLs are lowercase** (`RouteOptions.LowercaseUrls`, #129): `CreatedAtRoute`'s
+  `Location` reads `/api/v1/foundry/...`, route values included — so anything a route value
+  identifies must resolve case-insensitively (Foundry account and deployment names do).
 
 ## Schema pipeline (no EF migrations)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -161,6 +161,18 @@ Landed with #42 (the first `/api/v1` controller); every endpoint wave builds on 
   `Program.cs`'s first line, which is also how `UseEnvironment` gets through. External
   systems (ARM, APIM, Graph) are fakes owned by the factory (`FoundryClient` is the
   precedent) — never a live client.
+- **Request DTOs are init-property records; response DTOs are positional records.** A
+  `*Request` body is `public record X { [Required, StringLength(n)] public string Name
+  { get; init; } = string.Empty; … }` — attributes on the properties, `= string.Empty` on
+  every non-nullable string so a missing JSON field is a field-level `[Required]` 400 rather
+  than a `$`-level deserialization error. Never a positional record with `[property: …]`
+  (MVC throws at bind time → 500 on every body of that type, #128) and never attributes on
+  the constructor parameters (MVC is happy, but `Validator` and Blazor's
+  `DataAnnotationsValidator` read properties, so nothing validates). Responses are never
+  bound by MVC, so they stay positional (`public record Y(int Id, string Name);`).
+  `DomainArchitectureTests` fails the build for either broken placement;
+  `Api/Endpoints/RequestDtoBindingTests` posts each request record through the real pipeline
+  (via a test-only controller the factory registers) and asserts 400, never 500.
 
 ## Schema pipeline (no EF migrations)
 

--- a/src/FoundryGate.Api/Program.cs
+++ b/src/FoundryGate.Api/Program.cs
@@ -83,6 +83,18 @@ builder.Services.AddFoundryGateHealthChecks();
 // authenticated by default; opt out per-action with [AllowAnonymous].
 builder.Services.AddControllers(options => options.Filters.Add(new AuthorizeFilter()));
 
+// URL generation (CreatedAtRoute → Location headers) renders the whole path lowercase, so a 201
+// points at /api/v1/foundry/... exactly as reference/api.md documents it rather than the
+// [controller] token's class-name casing (/api/v1/Foundry/...) (#129). Matching was always
+// case-insensitive, and so are the lookups behind every route value today (Foundry account and
+// deployment names resolve case-insensitively in the service and in ARM). Query strings keep their
+// casing: their values can be case-sensitive identifiers.
+builder.Services.Configure<RouteOptions>(options =>
+{
+    options.LowercaseUrls = true;
+    options.LowercaseQueryStrings = false;
+});
+
 // Global error handling (CONVENTIONS.md: "one IExceptionHandler + ProblemDetails, not
 // per-controller try/catch"). AddProblemDetails also shapes the framework's own
 // non-exception error responses (e.g. the 404 catch-all wired up via UseStatusCodePages below).

--- a/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
+++ b/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
@@ -17,10 +17,14 @@ public record SystemConfigEntryResponse(
     DateTimeOffset UpdatedDate,
     int? UpdatedByUserId);
 
-/// <summary>PUT /config/{key} body.</summary>
-public record UpdateSystemConfigRequest(
-    [property: Required, StringLength(ValidationConstants.ConfigValueMaxLength)]
-    string Value);
+/// <summary>PUT /config/{key} body. Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).</summary>
+public record UpdateSystemConfigRequest
+{
+    /// <summary>The new value for the key. Required: a missing JSON field binds to <c>""</c> and fails as a field-level 400.</summary>
+    [Required]
+    [StringLength(ValidationConstants.ConfigValueMaxLength)]
+    public string Value { get; init; } = string.Empty;
+}
 
 /// <summary>
 /// Gateway connection details a developer needs to point Claude Code, Codex CLI, or

--- a/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
+++ b/src/FoundryGate.Domain/Groups/Contracts/GroupContracts.cs
@@ -54,41 +54,63 @@ public record GroupMemberResponse(
     DateTimeOffset AddedDate,
     int? AddedByUserId);
 
-/// <summary>POST /groups body.</summary>
-/// <param name="Name">Group display name.</param>
-/// <param name="Description">Optional free-text description.</param>
-/// <param name="EntraGroupId">
-/// Optional Entra group object id to link for &#167;7.3 group sync. Validated as
-/// GUID-shaped (Entra object ids are always GUIDs) rather than typed as <see cref="Guid"/>
-/// directly, to stay consistent with <c>User.EntraObjectId</c> — also a GUID-shaped
-/// <see cref="string"/> elsewhere in this domain (see <see cref="ValidationConstants.EntraObjectIdMaxLength"/>).
-/// </param>
-/// <param name="IsUnlimited">When true, members get unlimited quota unless overridden individually.</param>
-/// <param name="MonthlyTokenQuota">Group-level quota override for members; null falls through the resolution chain (spec &#167;3.2).</param>
-public record CreateGroupRequest(
-    [property: Required, StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
-    string Name,
-    [property: StringLength(ValidationConstants.DescriptionMaxLength)]
-    string? Description,
-    [property: StringLength(ValidationConstants.EntraObjectIdMaxLength)]
-    [property: RegularExpression(ValidationConstants.GuidPattern, ErrorMessage = "EntraGroupId must be a GUID (Entra object id).")]
-    string? EntraGroupId,
-    bool IsUnlimited,
-    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
-    long? MonthlyTokenQuota);
+/// <summary>POST /groups body. Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).</summary>
+public record CreateGroupRequest
+{
+    /// <summary>Group display name.</summary>
+    [Required]
+    [StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Optional free-text description.</summary>
+    [StringLength(ValidationConstants.DescriptionMaxLength)]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Optional Entra group object id to link for &#167;7.3 group sync. Validated as
+    /// GUID-shaped (Entra object ids are always GUIDs) rather than typed as <see cref="Guid"/>
+    /// directly, to stay consistent with <c>User.EntraObjectId</c> — also a GUID-shaped
+    /// <see cref="string"/> elsewhere in this domain (see <see cref="ValidationConstants.EntraObjectIdMaxLength"/>).
+    /// </summary>
+    [StringLength(ValidationConstants.EntraObjectIdMaxLength)]
+    [RegularExpression(ValidationConstants.GuidPattern, ErrorMessage = "EntraGroupId must be a GUID (Entra object id).")]
+    public string? EntraGroupId { get; init; }
+
+    /// <summary>When true, members get unlimited quota unless overridden individually.</summary>
+    public bool IsUnlimited { get; init; }
+
+    /// <summary>Group-level quota override for members; null falls through the resolution chain (spec &#167;3.2).</summary>
+    [Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    public long? MonthlyTokenQuota { get; init; }
+}
 
 /// <summary>PUT /groups/{id} body — admin updates name/description/quota (spec &#167;4.2).</summary>
-public record UpdateGroupRequest(
-    [property: Required, StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
-    string Name,
-    [property: StringLength(ValidationConstants.DescriptionMaxLength)]
-    string? Description,
-    bool IsUnlimited,
-    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
-    long? MonthlyTokenQuota);
+public record UpdateGroupRequest
+{
+    /// <summary>Group display name.</summary>
+    [Required]
+    [StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Optional free-text description.</summary>
+    [StringLength(ValidationConstants.DescriptionMaxLength)]
+    public string? Description { get; init; }
+
+    /// <summary>When true, members get unlimited quota unless overridden individually.</summary>
+    public bool IsUnlimited { get; init; }
+
+    /// <summary>Group-level quota override for members; null falls through the resolution chain (spec &#167;3.2).</summary>
+    [Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    public long? MonthlyTokenQuota { get; init; }
+}
 
 /// <summary>POST /groups/{id}/members body.</summary>
-public record AddGroupMemberRequest([property: Range(1, int.MaxValue, ErrorMessage = "UserId must be a valid user id.")] int UserId);
+public record AddGroupMemberRequest
+{
+    /// <summary>The user to add. An empty body binds to <c>0</c>, which <c>[Range]</c> rejects as a field-level 400.</summary>
+    [Range(1, int.MaxValue, ErrorMessage = "UserId must be a valid user id.")]
+    public int UserId { get; init; }
+}
 
 /// <summary>Result of POST /groups/sync-entra for one group (spec &#167;7.3).</summary>
 public record GroupSyncResult(int GroupId, int AddedCount, int RemovedCount);

--- a/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
+++ b/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
@@ -22,16 +22,26 @@ public record QuotaIncreaseRequestResponse(
     string? ReviewNotes,
     DateTimeOffset CreatedDate);
 
-/// <summary>POST /requests body — a developer (or admin on their behalf) submits a quota increase request.</summary>
-/// <param name="RequestedQuota">Null means requesting unlimited (spec &#167;3.1).</param>
-/// <param name="Justification">Free-text reason for the request; required so reviewers have something to evaluate.</param>
-public record SubmitQuotaIncreaseRequest(
-    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
-    long? RequestedQuota,
-    [property: Required, StringLength(ValidationConstants.JustificationMaxLength, MinimumLength = ValidationConstants.JustificationMinLength)]
-    string Justification);
+/// <summary>
+/// POST /requests body — a developer (or admin on their behalf) submits a quota increase request.
+/// Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).
+/// </summary>
+public record SubmitQuotaIncreaseRequest
+{
+    /// <summary>Null means requesting unlimited (spec &#167;3.1).</summary>
+    [Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    public long? RequestedQuota { get; init; }
+
+    /// <summary>Free-text reason for the request; required so reviewers have something to evaluate.</summary>
+    [Required]
+    [StringLength(ValidationConstants.JustificationMaxLength, MinimumLength = ValidationConstants.JustificationMinLength)]
+    public string Justification { get; init; } = string.Empty;
+}
 
 /// <summary>PUT /requests/{id}/approve or PUT /requests/{id}/reject body — same shape for both (spec &#167;4.4).</summary>
-public record ReviewQuotaIncreaseRequest(
-    [property: StringLength(ValidationConstants.ReviewNotesMaxLength)]
-    string? ReviewNotes);
+public record ReviewQuotaIncreaseRequest
+{
+    /// <summary>Optional reviewer notes, shown to the requester.</summary>
+    [StringLength(ValidationConstants.ReviewNotesMaxLength)]
+    public string? ReviewNotes { get; init; }
+}

--- a/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
+++ b/src/FoundryGate.Domain/Users/Contracts/UserContracts.cs
@@ -51,13 +51,19 @@ public record UserProfileResponse(
     ApiKeyResponse ApiKey,
     GatewayConnectionInfo CliConfig);
 
-/// <summary>PUT /users/{id}/quota body — admin sets a user's quota or unlimited flag.</summary>
-/// <param name="IsUnlimited">When true, <paramref name="MonthlyTokenQuota"/> is ignored (spec &#167;3.2 step 1).</param>
-/// <param name="MonthlyTokenQuota">Null means "use the system/group default" (spec &#167;3.2 steps 2-5); ignored when <paramref name="IsUnlimited"/> is true.</param>
-public record UpdateUserQuotaRequest(
-    bool IsUnlimited,
-    [property: Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
-    long? MonthlyTokenQuota);
+/// <summary>
+/// PUT /users/{id}/quota body — admin sets a user's quota or unlimited flag.
+/// Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).
+/// </summary>
+public record UpdateUserQuotaRequest
+{
+    /// <summary>When true, <see cref="MonthlyTokenQuota"/> is ignored (spec &#167;3.2 step 1).</summary>
+    public bool IsUnlimited { get; init; }
+
+    /// <summary>Null means "use the system/group default" (spec &#167;3.2 steps 2-5); ignored when <see cref="IsUnlimited"/> is true.</summary>
+    [Range(0, ValidationConstants.MaxMonthlyTokenQuota)]
+    public long? MonthlyTokenQuota { get; init; }
+}
 
 /// <summary>Result of POST /users/sync (spec &#167;7.2 bulk Entra sync).</summary>
 /// <param name="AddedCount">Users assigned in Entra that had no row and were inserted (no API key).</param>

--- a/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
@@ -205,6 +205,11 @@ public sealed class ApiTestFactory : WebApplicationFactory<Program>
                 options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
                 options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
             }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+
+            // Test-only controllers (Support/RequestDtoBindingController): this assembly is not in
+            // Api's application-part graph, so add it explicitly. AddControllers() is idempotent —
+            // Program.cs's options (the global AuthorizeFilter) are untouched.
+            services.AddControllers().AddApplicationPart(typeof(ApiTestFactory).Assembly);
         });
     }
 

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/FoundryEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/FoundryEndpointTests.cs
@@ -127,20 +127,21 @@ public class FoundryEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
     {
         var admin = await factory.SeedUserAsync(displayName: "Admin Ada");
         using var client = factory.CreateClientAs(admin.EntraObjectId, isAdmin: true);
-        var name = Marker();
+        var name = "Dep-" + Marker(); // mixed case on purpose, see the Location assertions
 
         var response = await client.PostAsJsonAsync(new Uri(DeploymentsPath, UriKind.Relative), ValidRequest(name));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        // Case-insensitive: URL generation keeps the [controller] token's class-name casing ("Foundry")
-        // until RouteOptions.LowercaseUrls is set host-wide; routing itself is case-insensitive.
-        Assert.EndsWith($"{DeploymentsPath}/{ApiTestFactory.PrimaryFoundryAccount}/{name}", response.Headers.Location?.ToString(), StringComparison.OrdinalIgnoreCase);
+        // Exact-case: RouteOptions.LowercaseUrls (#129) makes URL generation render the whole path
+        // lowercase — the [controller] token ("foundry", as reference/api.md documents it) and the
+        // route values alike, so the deployment name comes back lowercased too.
+        Assert.EndsWith($"{DeploymentsPath}/{ApiTestFactory.PrimaryFoundryAccount}/{name.ToLowerInvariant()}", response.Headers.Location?.ToString(), StringComparison.Ordinal);
         var created = await response.Content.ReadFromJsonAsync<FoundryDeploymentResponse>(JsonOptions);
         Assert.NotNull(created);
         Assert.Equal(name, created.DeploymentName);
         Assert.Equal("Creating", created.ProvisioningState);
 
-        // The Location resolves.
+        // The lowercased Location still resolves: deployment lookups are case-insensitive.
         var follow = await client.GetAsync(response.Headers.Location);
         Assert.Equal(HttpStatusCode.OK, follow.StatusCode);
 

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FoundryGate.Domain.Common;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Groups.Contracts;
+using FoundryGate.Domain.Requests.Contracts;
+using FoundryGate.Domain.Users.Contracts;
+using FoundryGate.Tests.Predeployment.Support;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// The regression guard for #128 through the real pipeline: every request record without a
+/// production controller yet is posted to <see cref="RequestDtoBindingController"/> (registered by
+/// <see cref="ApiTestFactory"/>) with an invalid body and must come back as a 400 validation
+/// ProblemDetails naming the offending member — not the 500 MVC threw for positional records with
+/// <c>[property: …]</c> attributes. <see cref="A_valid_body_binds_and_echoes_back"/> is the other
+/// half: the init-property shape also binds.
+/// </summary>
+public class RequestDtoBindingTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private const string BasePath = "/api/v1/requestdtobinding";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static TheoryData<string, string, string> InvalidBodies => new()
+    {
+        { "groups", """{"name":""}""", nameof(CreateGroupRequest.Name) },
+        { "groups", """{"name":"Platform Team","entraGroupId":"not-a-guid"}""", nameof(CreateGroupRequest.EntraGroupId) },
+        { "groups/update", """{"name":"Platform Team","monthlyTokenQuota":-1}""", nameof(UpdateGroupRequest.MonthlyTokenQuota) },
+        { "groups/members", """{}""", nameof(AddGroupMemberRequest.UserId) },
+        { "users/quota", """{"isUnlimited":false,"monthlyTokenQuota":-1}""", nameof(UpdateUserQuotaRequest.MonthlyTokenQuota) },
+        { "requests", """{"requestedQuota":2000000,"justification":"short"}""", nameof(SubmitQuotaIncreaseRequest.Justification) },
+        { "requests/review", $$"""{"reviewNotes":"{{new string('x', ValidationConstants.ReviewNotesMaxLength + 1)}}"}""", nameof(ReviewQuotaIncreaseRequest.ReviewNotes) },
+        { "config", """{}""", nameof(UpdateSystemConfigRequest.Value) },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidBodies))]
+    public async Task An_invalid_body_returns_400_validation_problem_details_not_500(string path, string json, string expectedMember)
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString());
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(new Uri($"{BasePath}/{path}", UriKind.Relative), content);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ApiError>(JsonOptions);
+        Assert.NotNull(problem?.Errors);
+        Assert.Contains(expectedMember, problem.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task A_valid_body_binds_and_echoes_back()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString());
+        var request = new CreateGroupRequest
+        {
+            Name = "Platform Team",
+            Description = "Core platform developers",
+            EntraGroupId = "11111111-2222-3333-4444-555555555555",
+            IsUnlimited = false,
+            MonthlyTokenQuota = 5_000_000,
+        };
+
+        var response = await client.PostAsJsonAsync(new Uri($"{BasePath}/groups", UriKind.Relative), request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var echoed = await response.Content.ReadFromJsonAsync<CreateGroupRequest>(JsonOptions);
+        Assert.Equal(request, echoed); // record value equality — every property round-tripped
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/DomainArchitectureTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using FoundryGate.Domain.Common;
 
@@ -85,4 +86,47 @@ public class DomainArchitectureTests
             foundryGateReferences.Count == 0,
             $"FoundryGate.Domain references other FoundryGate projects: {string.Join(", ", foundryGateReferences)}");
     }
+
+    [Fact]
+    public void Domain_records_never_carry_validation_attributes_on_positional_parameters_or_their_properties()
+    {
+        // #128: ASP.NET Core MVC throws at bind time — a 500 on every POST/PUT — for a positional
+        // record whose validation attributes sit on the generated properties ([property: ...]);
+        // moving them onto the constructor parameters satisfies MVC but hides them from
+        // DataAnnotations.Validator and Blazor's DataAnnotationsValidator, which read properties.
+        // Request DTOs are therefore init-property records with the attributes on plain properties
+        // (CONVENTIONS.md "API service/controller conventions"); either broken placement fails here.
+        List<Type> records = DomainAssembly.GetTypes().Where(IsRecord).ToList();
+        Assert.Contains(records, record => record.Name.EndsWith("Request", StringComparison.Ordinal)); // the scan is not vacuous
+
+        List<string> violations = [];
+        foreach (var record in records)
+        {
+            List<ParameterInfo> positionalParameters = record
+                .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                .SelectMany(constructor => constructor.GetParameters())
+                .ToList();
+
+            violations.AddRange(positionalParameters
+                .Where(parameter => parameter.GetCustomAttributes<ValidationAttribute>(inherit: true).Any())
+                .Select(parameter => $"{record.Name}({parameter.Name}): validation attribute on a constructor parameter — invisible to Validator and Blazor forms"));
+
+            var parameterNames = positionalParameters.Select(parameter => parameter.Name).ToHashSet(StringComparer.Ordinal);
+            violations.AddRange(record
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => parameterNames.Contains(property.Name)
+                    && property.GetCustomAttributes<ValidationAttribute>(inherit: true).Any())
+                .Select(property => $"{record.Name}.{property.Name}: validation attribute on a positional record's property — MVC returns 500 for every body of this type"));
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Domain records mix a primary constructor with validation attributes (#128). Make the "
+                + "record non-positional (`public string Name { get; init; } = string.Empty;`) with the "
+                + "attributes on the properties:\n - " + string.Join("\n - ", violations));
+    }
+
+    /// <summary>A C# record: the compiler emits a public <c>&lt;Clone&gt;$</c> method on every record class (record structs are not used in Domain).</summary>
+    private static bool IsRecord(Type type) =>
+        type.IsClass && type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) is not null;
 }

--- a/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/RequestDtoValidationTests.cs
@@ -10,8 +10,10 @@ namespace FoundryGate.Tests.Predeployment.Domain;
 /// Smoke-checks that request DTOs' <c>DataAnnotations</c> attributes actually fire
 /// (plans/03-shared-dtos.md verification: "All request DTOs have at least one
 /// validation attribute"). Not exhaustive over every DTO — enough to prove the
-/// pattern (<c>[Required]</c>/<c>[StringLength]</c>/<c>[Range]</c> composed on a
-/// positional record via <c>[property: ...]</c>) actually validates.
+/// pattern (<c>[Required]</c>/<c>[StringLength]</c>/<c>[Range]</c> on the init
+/// properties of a non-positional record, #128) actually validates through
+/// <see cref="Validator"/>, which is what Blazor's <c>DataAnnotationsValidator</c> uses.
+/// The MVC side of the same records is <c>Api/Endpoints/RequestDtoBindingTests</c>.
 /// </summary>
 public class RequestDtoValidationTests
 {
@@ -25,12 +27,7 @@ public class RequestDtoValidationTests
     [Fact]
     public void CreateGroupRequest_with_empty_name_fails_validation()
     {
-        var request = new CreateGroupRequest(
-            Name: string.Empty,
-            Description: null,
-            EntraGroupId: null,
-            IsUnlimited: false,
-            MonthlyTokenQuota: null);
+        var request = new CreateGroupRequest { Name = string.Empty };
 
         IList<ValidationResult> results = Validate(request);
 
@@ -40,12 +37,12 @@ public class RequestDtoValidationTests
     [Fact]
     public void CreateGroupRequest_with_a_valid_name_passes_validation()
     {
-        var request = new CreateGroupRequest(
-            Name: "Platform Team",
-            Description: "Core platform developers",
-            EntraGroupId: null,
-            IsUnlimited: false,
-            MonthlyTokenQuota: 5_000_000);
+        var request = new CreateGroupRequest
+        {
+            Name = "Platform Team",
+            Description = "Core platform developers",
+            MonthlyTokenQuota = 5_000_000,
+        };
 
         Assert.Empty(Validate(request));
     }
@@ -56,12 +53,7 @@ public class RequestDtoValidationTests
     [InlineData("11111111-2222-3333-4444-55555555555")] // one hex digit short
     public void CreateGroupRequest_with_a_non_guid_entraGroupId_fails_validation(string entraGroupId)
     {
-        var request = new CreateGroupRequest(
-            Name: "Platform Team",
-            Description: null,
-            EntraGroupId: entraGroupId,
-            IsUnlimited: false,
-            MonthlyTokenQuota: null);
+        var request = new CreateGroupRequest { Name = "Platform Team", EntraGroupId = entraGroupId };
 
         IList<ValidationResult> results = Validate(request);
 
@@ -71,20 +63,26 @@ public class RequestDtoValidationTests
     [Fact]
     public void CreateGroupRequest_with_a_guid_shaped_entraGroupId_passes_validation()
     {
-        var request = new CreateGroupRequest(
-            Name: "Platform Team",
-            Description: null,
-            EntraGroupId: "11111111-2222-3333-4444-555555555555",
-            IsUnlimited: false,
-            MonthlyTokenQuota: null);
+        var request = new CreateGroupRequest { Name = "Platform Team", EntraGroupId = "11111111-2222-3333-4444-555555555555" };
 
         Assert.Empty(Validate(request));
     }
 
     [Fact]
+    public void CreateGroupRequest_default_instance_fails_on_Name_only()
+    {
+        // What an empty JSON body binds to: Name is "" (not null), so [Required] reports a
+        // field-level error rather than the deserializer failing the whole body.
+        IList<ValidationResult> results = Validate(new CreateGroupRequest());
+
+        var single = Assert.Single(results);
+        Assert.Equal([nameof(CreateGroupRequest.Name)], single.MemberNames);
+    }
+
+    [Fact]
     public void SubmitQuotaIncreaseRequest_with_too_short_justification_fails_validation()
     {
-        var request = new SubmitQuotaIncreaseRequest(RequestedQuota: 2_000_000, Justification: "need more");
+        var request = new SubmitQuotaIncreaseRequest { RequestedQuota = 2_000_000, Justification = "need more" };
 
         IList<ValidationResult> results = Validate(request);
 
@@ -94,9 +92,11 @@ public class RequestDtoValidationTests
     [Fact]
     public void SubmitQuotaIncreaseRequest_with_negative_requestedQuota_fails_validation()
     {
-        var request = new SubmitQuotaIncreaseRequest(
-            RequestedQuota: -1,
-            Justification: "Running large batch evals against the shared model this sprint.");
+        var request = new SubmitQuotaIncreaseRequest
+        {
+            RequestedQuota = -1,
+            Justification = "Running large batch evals against the shared model this sprint.",
+        };
 
         IList<ValidationResult> results = Validate(request);
 

--- a/src/FoundryGate.Tests.Predeployment/Support/RequestDtoBindingController.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/RequestDtoBindingController.cs
@@ -1,0 +1,41 @@
+using FoundryGate.Api.Controllers;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Groups.Contracts;
+using FoundryGate.Domain.Requests.Contracts;
+using FoundryGate.Domain.Users.Contracts;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Tests.Predeployment.Support;
+
+/// <summary>
+/// Test-only controller — this assembly is registered as an application part by
+/// <see cref="Api.ApiTestFactory"/> — that binds every request record Domain defines ahead of
+/// its production controller (the users/groups/requests/config waves). Each action echoes the
+/// bound body; what matters is what happens <em>before</em> the action runs: an invalid body must
+/// be a 400 ProblemDetails, never the 500 a positional record with <c>[property: …]</c> attributes
+/// produced (#128). Once a production controller binds one of these records, its own endpoint
+/// tests take over and the matching action here can go.
+/// </summary>
+public sealed class RequestDtoBindingController : ApiControllerBase
+{
+    [HttpPost("groups")]
+    public CreateGroupRequest CreateGroup([FromBody] CreateGroupRequest request) => request;
+
+    [HttpPost("groups/update")]
+    public UpdateGroupRequest UpdateGroup([FromBody] UpdateGroupRequest request) => request;
+
+    [HttpPost("groups/members")]
+    public AddGroupMemberRequest AddGroupMember([FromBody] AddGroupMemberRequest request) => request;
+
+    [HttpPost("users/quota")]
+    public UpdateUserQuotaRequest UpdateUserQuota([FromBody] UpdateUserQuotaRequest request) => request;
+
+    [HttpPost("requests")]
+    public SubmitQuotaIncreaseRequest SubmitQuotaIncrease([FromBody] SubmitQuotaIncreaseRequest request) => request;
+
+    [HttpPost("requests/review")]
+    public ReviewQuotaIncreaseRequest ReviewQuotaIncrease([FromBody] ReviewQuotaIncreaseRequest request) => request;
+
+    [HttpPost("config")]
+    public UpdateSystemConfigRequest UpdateSystemConfig([FromBody] UpdateSystemConfigRequest request) => request;
+}


### PR DESCRIPTION
## Summary

Two host-wide fixes found while landing #61's first `POST` body, done before the users/groups/requests/config waves land theirs.

**#128 — request DTOs were 500s.** Every positional `*Request` record with `[property: Required/StringLength/Range/...]` made MVC throw at bind time (`Record type ... has validation metadata defined on property ... that will be ignored`) — a 500 on every POST/PUT of that type, before the action ran. Attributes on the constructor parameters would satisfy MVC but hide them from `DataAnnotations.Validator` and Blazor's `DataAnnotationsValidator`. The one placement all three agree on is the **init-property record** `CreateFoundryDeploymentRequest` already used:

```csharp
public record CreateGroupRequest
{
    [Required]
    [StringLength(ValidationConstants.GroupNameMaxLength, MinimumLength = 1)]
    public string Name { get; init; } = string.Empty;
    ...
}
```

- Converted `UpdateUserQuotaRequest`, `CreateGroupRequest`, `UpdateGroupRequest`, `AddGroupMemberRequest`, `SubmitQuotaIncreaseRequest`, `ReviewQuotaIncreaseRequest`, `UpdateSystemConfigRequest` — every attribute, default and XML doc preserved (`<param>` → property `<summary>`). Response records stay positional (MVC never binds them). `FoundryGate.Web` compiles unchanged (it only passes these records through; no page constructs one yet).
- `RequestDtoValidationTests` → object-initializer construction, plus an "empty body binds to an instance whose only error is `[Required] Name`" case.
- **`DomainArchitectureTests`** gains a reflection guard over every Domain record: a validation attribute on a positional parameter, *or* on the property a positional parameter generates, fails the build naming the record/member.
- **`RequestDtoBindingTests`** proves the bug is gone through the real pipeline: the test assembly is registered as an application part of the `ApiTestFactory` host and a test-only `Support/RequestDtoBindingController` binds each of the seven records; a Theory posts an invalid body per record and asserts **400 ValidationProblemDetails naming the member, never 500**, and a Fact round-trips a valid body (record equality).
- `CONVENTIONS.md` → "API service/controller conventions": request DTOs are init-property records with attributes on the properties; response DTOs are positional records.

**#129 — `Location: .../api/v1/Foundry/...`.** `RouteOptions.LowercaseUrls = true` (`LowercaseQueryStrings = false`) in `Program.cs`; the `FoundryEndpointTests` create test now asserts the `Location` **ordinally** — using a mixed-case deployment name, so it also pins that `LowercaseUrls` lowercases route values and that the lowercased `Location` still resolves (200 on follow). CONVENTIONS bullet records the consequence: anything a route value identifies must resolve case-insensitively (Foundry account and deployment names do — service, ARM client and fake are all `OrdinalIgnoreCase`).

## Verification

- `dotnet build FoundryGate.sln -c Release` → **0 Warning(s), 0 Error(s)**
- `dotnet test src/FoundryGate.Tests.Predeployment -c Release --no-build` → **Passed: 249, Failed: 0** (+11 new: 8 Theory rows + 1 Fact in `RequestDtoBindingTests`, 1 default-instance test, 1 architecture guard)
- `dotnet format FoundryGate.sln --verify-no-changes` → clean
- **Mutation check:** temporarily reverting `ReviewQuotaIncreaseRequest` to the positional `[property: …]` shape failed exactly the two guards — `DomainArchitectureTests` ("`ReviewQuotaIncreaseRequest.ReviewNotes`: validation attribute on a positional record's property — MVC returns 500…") and `RequestDtoBindingTests` (`Expected: BadRequest, Actual: InternalServerError`) — and nothing else. Restored before commit.

## Decisions for the reviewer

- **Test-only controller lives in the test project** (`Support/RequestDtoBindingController`, wired via `services.AddControllers().AddApplicationPart(typeof(ApiTestFactory).Assembly)` at the end of `ConfigureTestServices`). No production surface is touched; the second `AddControllers()` is idempotent and leaves Program.cs's global `AuthorizeFilter` in place (the binding tests use an authenticated client). Each production wave retires its action here when its own endpoint tests bind the record — tracked in #145.
- **The architecture guard scans every Domain record, not just `*Request`** — there is no legitimate reason for any positional record to carry validation attributes, and the failure message says how to fix it. It also flags attributes on constructor *parameters* (the MVC-only placement that silently disables Blazor forms).
- **`LowercaseUrls` lowercases route values too**, not just the `[controller]` token. Today that's safe (all lookups behind route values are case-insensitive) and the create test pins it; the CONVENTIONS bullet makes it a rule for future routes.
- **Concurrency with #127/#133**: only the request records changed, no reordering of surrounding files; the CONVENTIONS bullets are appended at the *end* of the section (PR #127's bullet lands mid-section) and the `ApiTestFactory` line is at the end of `ConfigureTestServices` (PR #133 adds mid-block), so both merges stay trivial.

Closes #128
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtuGhG69SaSuVfx92RwwNk
