### PR TITLE
feat(api): add the /config and /dashboard admin endpoints

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -47,7 +47,13 @@
 - Temporal: `DateTimeOffset`, names end in `Date` (`CreatedDate`, `ReviewedDate`).
   **[improvement]** All `CreatedDate`/`ModifiedDate` set by ONE
   `SaveChangesInterceptor` using injected `TimeProvider` — never inline
-  `DateTimeOffset.UtcNow` in services.
+  `DateTimeOffset.UtcNow` in services. **One exception**: a service may assign a
+  `ModifiedDate`-style field itself, from the injected `TimeProvider`, when the row must
+  record a re-save that changed no other column — EF never hands an unmodified entity to
+  the interceptor, so "who touched this and when" would otherwise be lost on a same-value
+  save (precedent: `ConfigService.UpdateAsync`). Both read the same `TimeProvider`, so the
+  explicit assignment and the interceptor cannot disagree; `DateTimeOffset.UtcNow` stays
+  banned either way.
 - **[improvement]** `TimeProvider` injected everywhere time is read. No naked
   `UtcNow` outside the interceptor's TimeProvider.
 - Strings: non-nullable, `[Required]` + `[StringLength(n)]`, default

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -127,7 +127,61 @@ Rules the mutation paths enforce (CLAUDE.md "Anthropic deployments are create-on
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET` | `/config` | Admin | All SystemConfiguration keys |
-| `PUT` | `/config/{key}` | Admin | Update a configuration value |
+| `GET` | `/config` | Admin | Every `SystemConfiguration` key, ordered by key: `{ key, value, updatedDate, updatedByUserId, updatedByDisplayName }`. The last two are `null` for a seeded key no admin has edited |
+| `PUT` | `/config/{key}` | Admin | Set one key's value. Returns the row as it now stands |
 | `GET` | `/audit` | Admin | Audit log, paged. Filter: `?actor=&action=&from=&to=` |
-| `GET` | `/dashboard` | Admin | Summary stats for the dashboard |
+| `GET` | `/dashboard` | Admin | Summary stats for the dashboard. `?fresh=true` bypasses the 30-second cache |
+
+### `PUT /config/{key}`
+
+Body: `{ "value": "..." }`. The key is matched case-insensitively; an unknown one is `404`. The
+value is validated **per key** before it is stored — a configuration editor that accepts a value
+the system cannot use only moves the failure somewhere harder to find — and stored **normalized**
+(trimmed, booleans lower-cased, URLs and resource ids without a trailing slash), so two admins
+typing `True` and `true` leave the same row behind.
+
+| Key | Rule |
+|---|---|
+| `DefaultMonthlyTokenQuota` | A non-negative whole number that is exactly one of the configured tier caps (`Gateway:Tiers`; `GET /quota/tiers` lists them). Same D-013 rule as every other quota write path — the gateway enforces a tier, not a number. Unlimited is not expressible fork-wide: it is set per user or per group |
+| `ResetDayOfMonth` | A whole number from 1 to 28 (28 is the last day every month has) |
+| `EntraGroupSyncEnabled` | `true` or `false` |
+| `ApimGatewayUrl` | An absolute `https` URL, or empty |
+| `ApimResourceId`, `FoundryResourceId` | An ARM resource id (`/subscriptions/{id}/resourceGroups/{group}/providers/{namespace}/{type}/{name}`), or empty. Shape only — whether the resource exists is Azure's answer, reported as `503` by the endpoints that use it |
+| Any other row a fork operator added | Free text, up to 4000 characters |
+
+Two seeded keys are **read-only (`409`)**, because editing them would be a silent no-op. They stay
+in the table only so re-seeding is idempotent, and the refusal names the replacement:
+
+- `ApimProductId` — quota tiers are APIM *products* now, so a developer's subscription is issued
+  against the product for their tier (`Gateway:Tiers` in the API, `quotaTiers` in `infra/main.bicep`),
+  not against one fork-wide product id.
+- `EntraTenantId` — Graph access is configured by the `Entra` options section over the host's
+  `AzureAd:TenantId` ([#123](https://github.com/kolatts/foundry-gate/issues/123)).
+
+Every accepted edit stamps `updatedByUserId` (the calling admin) and `updatedDate`, and writes one
+`config.updated` audit row with `{ key, before, after }` — in the same transaction as the change, so
+a value can never move without a trail. The calling admin must already have a FoundryGate user row
+(`GET /users/me` provisions one) or the write is `403`; reading `/config` needs no such row.
+
+**A deploy never reverts an edit.** `SystemConfiguration`'s value, timestamp and editor columns are
+`[DoNotUpdate]`, so the reference-data seeder that runs after every database deploy only *inserts*
+keys that are missing.
+
+### `GET /dashboard`
+
+Returns `{ totalUserCount, activeUserCount, unlimitedUserCount, pendingQuotaIncreaseRequestCount,
+totalTokensUsedThisPeriod, topConsumers }` for the current UTC calendar month.
+
+- `unlimitedUserCount` counts **active** unlimited users — a deactivated account consumes nothing.
+- `totalTokensUsedThisPeriod` sums every allocation in the period, deactivated users included: the
+  tokens they spent before offboarding are still tokens this month spent.
+- `topConsumers` is the ten busiest **active** users this period, each with `userId`, `userUnique`,
+  `displayName`, `tokensUsed`, `allocatedTokens` and `percentUsed` — `null` for an unlimited user,
+  `100` for a zero quota with any usage.
+
+Every usage figure here is a reconciliation number from the Log Analytics sync, refreshed on that
+job's cadence — not a live view of gateway enforcement.
+
+The summary is computed once and served to every admin for **30 seconds**, keyed by billing period
+(so the first read after a month boundary can never show last month's figures). The admin page
+refreshes itself every 60 s; pass `?fresh=true` to recompute immediately after a change.

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -206,6 +206,10 @@ the system cannot use only moves the failure somewhere harder to find — and st
 (trimmed, booleans lower-cased, URLs and resource ids without a trailing slash), so two admins
 typing `True` and `true` leave the same row behind.
 
+Emptiness is one of those per-key decisions, not a blanket rule: `{ "value": "" }` **clears** a key
+whose rule allows empty (the URL and resource-id keys — how you unwire a resource) and is a `400`
+for one that does not (a quota, a reset day and a feature flag have no empty form).
+
 | Key | Rule |
 |---|---|
 | `DefaultMonthlyTokenQuota` | A non-negative whole number that is exactly one of the configured tier caps (`Gateway:Tiers`; `GET /quota/tiers` lists them). Same D-013 rule as every other quota write path — the gateway enforces a tier, not a number. Unlimited is not expressible fork-wide: it is set per user or per group |

--- a/src/FoundryGate.Api/Controllers/ConfigController.cs
+++ b/src/FoundryGate.Api/Controllers/ConfigController.cs
@@ -1,0 +1,44 @@
+using FoundryGate.Api.Services.Config;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// <c>/api/v1/config</c> (spec &#167;4.6; issue #161) — the fork-wide <c>SystemConfiguration</c>
+/// editor behind the admin <c>/config</c> page (#55). Admin-only for the whole controller: these
+/// values steer quota resolution and the gateway addressing.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+public sealed class ConfigController(IConfigService configService) : ApiControllerBase
+{
+    /// <summary>Every configuration key with its value, when it last changed, and which admin changed it.</summary>
+    /// <response code="200">The rows, ordered by key.</response>
+    [HttpGet]
+    [ProducesResponseType<IReadOnlyList<SystemConfigEntryResponse>>(StatusCodes.Status200OK)]
+    public Task<IReadOnlyList<SystemConfigEntryResponse>> ListAsync(CancellationToken cancellationToken) =>
+        configService.ListAsync(cancellationToken);
+
+    /// <summary>
+    /// Sets one key's value. Validated per key (<see cref="SystemConfigValidator"/>), stamped with the
+    /// calling admin and the current time, and audited (<c>config.updated</c>) in the same save.
+    /// </summary>
+    /// <response code="200">The row as it now stands.</response>
+    /// <response code="400">The value breaks the key's rule; the <c>detail</c> states the rule.</response>
+    /// <response code="403">The caller is not an admin, or has no <c>User</c> row yet (call <c>GET /users/me</c> first).</response>
+    /// <response code="404">No such configuration key.</response>
+    /// <response code="409">The key is retired and read-only; the <c>detail</c> names its replacement.</response>
+    [HttpPut("{key}")]
+    [ProducesResponseType<SystemConfigEntryResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status409Conflict)]
+    public Task<SystemConfigEntryResponse> UpdateAsync(
+        string key,
+        [FromBody] UpdateSystemConfigRequest request,
+        CancellationToken cancellationToken) =>
+        configService.UpdateAsync(key, request, cancellationToken);
+}

--- a/src/FoundryGate.Api/Controllers/DashboardController.cs
+++ b/src/FoundryGate.Api/Controllers/DashboardController.cs
@@ -1,0 +1,29 @@
+using FoundryGate.Api.Services.Dashboard;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Dashboard.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// <c>/api/v1/dashboard</c> (spec &#167;4.6; issue #162) — the admin landing page's summary stats
+/// (#54). Admin-only: it aggregates every user's usage.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+public sealed class DashboardController(IDashboardService dashboardService) : ApiControllerBase
+{
+    /// <summary>
+    /// Counts, this period's total token usage, and the top ten consumers — all for the current UTC
+    /// calendar month. Served from a <see cref="DashboardService.CacheDuration"/> in-memory cache
+    /// shared by every admin; pass <c>?fresh=true</c> to recompute (the page does this after a
+    /// mutation, and tests after seeding).
+    /// </summary>
+    /// <response code="200">The summary.</response>
+    [HttpGet]
+    [ProducesResponseType<DashboardSummaryResponse>(StatusCodes.Status200OK)]
+    public Task<DashboardSummaryResponse> GetAsync(
+        [FromQuery] bool fresh,
+        CancellationToken cancellationToken) =>
+        dashboardService.GetSummaryAsync(fresh, cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Config;
+using FoundryGate.Api.Services.Dashboard;
 using FoundryGate.Api.Services.Entra;
 using FoundryGate.Api.Services.Foundry;
 using FoundryGate.Api.Services.Identity;
@@ -30,6 +32,8 @@ public static class ApiServiceCollectionExtensions
         services.AddEntraServices();
         services.AddSecurityServices();
         services.AddKeysServices();
+        services.AddConfigServices();
+        services.AddDashboardServices();
 
         return services;
     }

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -13,6 +13,11 @@ namespace FoundryGate.Api.Services.Config;
 /// one <c>SaveChangesAsync</c> — a configuration edit without its audit trail is exactly the kind of
 /// change an operator later needs to explain.
 /// </summary>
+/// <remarks>
+/// No concurrency token: two admins editing the same key are last-write-wins today. Deliberately
+/// deferred to #170, which adds an optional <c>ExpectedUpdatedDate</c> to the request when the admin
+/// config page (#55) exists to send it.
+/// </remarks>
 public sealed class ConfigService(
     AppDbContext dbContext,
     SystemConfigValidator validator,

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -1,0 +1,88 @@
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Data;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Api.Services.Config;
+
+/// <summary>
+/// Default <see cref="IConfigService"/>. Scoped: it shares the request's <see cref="AppDbContext"/>
+/// with <see cref="IAuditService"/>, so the value change and its <c>config.updated</c> row commit in
+/// one <c>SaveChangesAsync</c> — a configuration edit without its audit trail is exactly the kind of
+/// change an operator later needs to explain.
+/// </summary>
+public sealed class ConfigService(
+    AppDbContext dbContext,
+    SystemConfigValidator validator,
+    ICurrentUserAccessor currentUser,
+    IAuditService audit,
+    TimeProvider timeProvider) : IConfigService
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SystemConfigEntryResponse>> ListAsync(CancellationToken cancellationToken) =>
+        await dbContext.SystemConfigurations
+            .AsNoTracking()
+            .OrderBy(c => c.Key)
+            .Select(c => new SystemConfigEntryResponse(
+                c.Key,
+                c.Value,
+                c.UpdatedDate,
+                c.UpdatedByUserId,
+                c.UpdatedByUser != null ? c.UpdatedByUser.DisplayName : null))
+            .ToListAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<SystemConfigEntryResponse> UpdateAsync(
+        string key,
+        UpdateSystemConfigRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Materialize the whole table (nine rows on a shipped fork) and match in memory rather than
+        // translating the comparison: `Key == key` is case-insensitive under SQL Server's default
+        // collation but case-sensitive under the SQLite the tests run on, and an endpoint that 404s
+        // on one provider and succeeds on the other is a contract nobody can document. Tracked (no
+        // AsNoTracking) — the matched row is mutated below.
+        var entries = await dbContext.SystemConfigurations.ToListAsync(cancellationToken);
+        var entry = entries.FirstOrDefault(c => string.Equals(c.Key, key, StringComparison.OrdinalIgnoreCase))
+            ?? throw new KeyNotFoundException(
+                $"There is no system configuration key '{key}'. GET /api/v1/config lists the keys this fork has.");
+
+        SystemConfigValidator.EnsureEditable(entry.Key);
+        var newValue = validator.Normalize(entry.Key, request.Value);
+
+        // Resolve the actor before mutating anything: "no User row for this caller" is a 403, and it
+        // should leave the change tracker as clean as it found it.
+        var actor = await currentUser.GetRequiredUserAsync(cancellationToken);
+
+        var before = entry.Value;
+        entry.Value = newValue;
+        entry.UpdatedByUserId = actor.UserId;
+
+        // Set explicitly rather than leaning on TimestampInterceptor alone: re-saving an unchanged
+        // value must still record who touched it and when, and an entity EF sees as unmodified is
+        // never handed to the interceptor. The interceptor then stamps the same instant (one
+        // TimeProvider), so the two never disagree.
+        entry.UpdatedDate = timeProvider.GetUtcNow();
+
+        await audit.LogAsync(
+            AuditActions.ConfigUpdated,
+            AuditTargetTypes.SystemConfiguration,
+            entry.Key,
+            new { key = entry.Key, before, after = newValue },
+            cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new SystemConfigEntryResponse(
+            entry.Key,
+            entry.Value,
+            entry.UpdatedDate,
+            entry.UpdatedByUserId,
+            actor.DisplayName);
+    }
+}

--- a/src/FoundryGate.Api/Services/Config/ConfigServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+namespace FoundryGate.Api.Services.Config;
+
+/// <summary>DI registration for the <c>Services/Config</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class ConfigServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the per-key validation table (<see cref="SystemConfigValidator"/> — singleton, pure
+    /// over the tier table <c>AddQuotaServices</c> registers) and <see cref="IConfigService"/>
+    /// (scoped — it shares the request's <c>AppDbContext</c> so the value change and its audit row
+    /// commit together).
+    /// </summary>
+    public static IServiceCollection AddConfigServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<SystemConfigValidator>();
+        services.AddScoped<IConfigService, ConfigService>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Config/IConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/IConfigService.cs
@@ -1,0 +1,35 @@
+using FoundryGate.Domain.Config.Contracts;
+
+namespace FoundryGate.Api.Services.Config;
+
+/// <summary>
+/// The fork-wide <c>SystemConfiguration</c> key/value editor behind <c>/api/v1/config</c>
+/// (spec &#167;4.6; issue #161). Admin-only at the controller; the service itself owns the read
+/// projection, the per-key validation table (<see cref="SystemConfigValidator"/>), the audit row and
+/// the single save.
+/// </summary>
+/// <remarks>
+/// Seeding and editing share the table without fighting over it: <c>SystemConfiguration.Value</c>,
+/// <c>UpdatedDate</c> and <c>UpdatedByUserId</c> all carry <c>[DoNotUpdate]</c>, so the reference-data
+/// seeder only ever <em>inserts</em> a missing key — re-running a deploy can never revert what an
+/// admin set here.
+/// </remarks>
+public interface IConfigService
+{
+    /// <summary>Every configuration row, ordered by key, with the editing admin's display name joined in. Read-only projection — nothing is tracked.</summary>
+    Task<IReadOnlyList<SystemConfigEntryResponse>> ListAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets one key's value, stamping the calling admin and the current time, and writes one
+    /// <c>config.updated</c> audit row (details <c>{ key, before, after }</c>) in the same save.
+    /// </summary>
+    /// <param name="key">The configuration key; matched case-insensitively, as SQL Server's default collation would.</param>
+    /// <param name="request">The new value. Validated and normalized per key before it is stored.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The row as it now stands.</returns>
+    /// <exception cref="KeyNotFoundException">No such configuration key (→ 404).</exception>
+    /// <exception cref="Domain.Exceptions.ConflictException">The key is retired and read-only (→ 409); the message names its replacement.</exception>
+    /// <exception cref="ArgumentException">The value breaks the key's rule (→ 400); the message states the rule.</exception>
+    /// <exception cref="UnauthorizedAccessException">The calling admin has no <c>User</c> row yet (→ 403; call <c>GET /users/me</c> first).</exception>
+    Task<SystemConfigEntryResponse> UpdateAsync(string key, UpdateSystemConfigRequest request, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/Config/SystemConfigValidator.cs
+++ b/src/FoundryGate.Api/Services/Config/SystemConfigValidator.cs
@@ -1,0 +1,185 @@
+using System.Globalization;
+using FoundryGate.Api.Services.Quota;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
+
+namespace FoundryGate.Api.Services.Config;
+
+/// <summary>
+/// The one place that says what a <c>SystemConfiguration</c> value is allowed to be (#161). Every
+/// key the seeder ships has a rule; <c>PUT /config/{key}</c> runs it before persisting, so a value
+/// that would break quota resolution, the monthly reset, or the gateway addressing is a <c>400</c>
+/// at the edit rather than a runtime failure days later. Pure and singleton — the only state is the
+/// tier table behind <see cref="GatewayTierMapper"/>.
+/// </summary>
+/// <remarks>
+/// Three outcomes:
+/// <list type="bullet">
+/// <item><b>Read-only key</b> → <see cref="ConflictException"/> (409). Two seeded keys are no longer
+/// wired to anything (<see cref="SystemConfigurationKeys.ApimProductId"/>, superseded by the per-tier
+/// APIM products; <see cref="SystemConfigurationKeys.EntraTenantId"/>, unused since #123). They stay in
+/// the table because the seed data references them, but editing one would be a silent no-op — so the
+/// refusal names what to change instead.</item>
+/// <item><b>Known key, bad value</b> → <see cref="ArgumentException"/> (400) whose message states the
+/// rule.</item>
+/// <item><b>Known key, good value</b> → the <em>normalized</em> string to store (trimmed; booleans
+/// lower-cased) so two admins typing <c>True</c> and <c>true</c> leave the same row behind.</item>
+/// </list>
+/// A key that is present in the table but not in <see cref="SystemConfigurationKeys.All"/> — a fork
+/// operator's own row, which the reference-data seeder deliberately preserves — has no rule and is
+/// accepted as free text (length is <c>UpdateSystemConfigRequest</c>'s <c>[StringLength]</c> job).
+/// </remarks>
+public sealed class SystemConfigValidator(GatewayTierMapper tierMapper)
+{
+    /// <summary>Highest day-of-month a monthly reset may be scheduled on: 28 is the last day every month has.</summary>
+    public const int MaxResetDayOfMonth = 28;
+
+    /// <summary>
+    /// Throws when <paramref name="key"/> is one of the retired keys, with a message naming its
+    /// replacement. Called before any value validation so a read-only key answers <c>409</c>
+    /// regardless of what was posted.
+    /// </summary>
+    /// <exception cref="ConflictException">The key is retired and cannot be edited.</exception>
+    public static void EnsureEditable(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var replacement = key switch
+        {
+            SystemConfigurationKeys.ApimProductId =>
+                "quota tiers are APIM products now: a developer's subscription is issued against the product for "
+                + "their tier (`Gateway:Tiers` in the API configuration, `quotaTiers` in infra/main.bicep; "
+                + "`GET /quota/tiers` lists them), so this single product id is no longer read",
+            SystemConfigurationKeys.EntraTenantId =>
+                "Microsoft Graph access is configured by the `Entra` options section (`Entra:Enabled`, "
+                + "`Entra:GraphBaseUrl`, `Entra:ServicePrincipalObjectId`) over the host's `AzureAd:TenantId`, "
+                + "so this key is no longer read",
+            _ => null,
+        };
+
+        if (replacement is not null)
+        {
+            throw new ConflictException(
+                $"System configuration key '{key}' is read-only: {replacement}. The row is kept so re-seeding stays idempotent.");
+        }
+    }
+
+    /// <summary>
+    /// Validates <paramref name="value"/> against <paramref name="key"/>'s rule and returns the
+    /// normalized form to store.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value breaks the key's rule (→ 400).</exception>
+    public string Normalize(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        var trimmed = value.Trim();
+
+        return key switch
+        {
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota => NormalizeDefaultQuota(trimmed),
+            SystemConfigurationKeys.ResetDayOfMonth => NormalizeResetDayOfMonth(trimmed),
+            SystemConfigurationKeys.EntraGroupSyncEnabled => NormalizeBoolean(key, trimmed),
+            SystemConfigurationKeys.ApimGatewayUrl => NormalizeHttpsUrl(key, trimmed),
+            SystemConfigurationKeys.ApimResourceId or SystemConfigurationKeys.FoundryResourceId =>
+                NormalizeArmResourceId(key, trimmed),
+            _ => trimmed,
+        };
+    }
+
+    /// <summary>
+    /// The system-wide fallback budget (quota resolution's last precedence level). Must be a
+    /// non-negative integer — <c>QuotaResolutionService</c> parses it as one — and, per D-013, must
+    /// equal a configured tier cap: the gateway can only enforce a tier, so a default that is not one
+    /// would be silently rounded up for every user who falls through to it.
+    /// </summary>
+    private string NormalizeDefaultQuota(string value)
+    {
+        if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var quota))
+        {
+            throw new ArgumentException(
+                $"'{value}' is not a non-negative whole number of tokens. {tierMapper.Describe()}",
+                nameof(value));
+        }
+
+        // Unlimited is not expressible here: the system default is the fallback for users with no
+        // override at all, and quota resolution reads this row as a number. An unlimited default is
+        // set per user (IsUnlimited) or per group, never fork-wide by accident.
+        tierMapper.EnsureValidQuota(quota, nameof(value));
+
+        return quota.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>1–28: the reset must land on a day every calendar month actually has (spec §6 ships "1").</summary>
+    private static string NormalizeResetDayOfMonth(string value)
+    {
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var day)
+            || day < 1
+            || day > MaxResetDayOfMonth)
+        {
+            throw new ArgumentException(
+                $"'{value}' is not a valid day of month for the monthly reset. Use a whole number from 1 to {MaxResetDayOfMonth} "
+                + "(28 is the last day every month has).",
+                nameof(value));
+        }
+
+        return day.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Stored lower-cased so <c>bool.Parse</c> on the read side never sees a casing it dislikes.</summary>
+    private static string NormalizeBoolean(string key, string value)
+    {
+        if (!bool.TryParse(value, out var parsed))
+        {
+            throw new ArgumentException(
+                $"System configuration key '{key}' is a boolean: use 'true' or 'false', not '{value}'.",
+                nameof(value));
+        }
+
+        return parsed ? "true" : "false";
+    }
+
+    /// <summary>Empty (feature not addressed yet) or an absolute https origin — the gateway is never plain http.</summary>
+    private static string NormalizeHttpsUrl(string key, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ArgumentException(
+                $"System configuration key '{key}' must be an absolute https URL (e.g. https://ai.contoso.com) or empty, not '{value}'.",
+                nameof(value));
+        }
+
+        return uri.ToString().TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Empty or an ARM resource id. Shape only (<c>/subscriptions/{id}/.../providers/{namespace}/...</c>)
+    /// — whether the resource exists is Azure's answer, not a config editor's, and the endpoints that
+    /// use it report a missing resource as <c>503 feature not configured</c>.
+    /// </summary>
+    private static string NormalizeArmResourceId(string key, string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        if (!value.StartsWith("/subscriptions/", StringComparison.OrdinalIgnoreCase)
+            || !value.Contains("/providers/", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"System configuration key '{key}' must be an ARM resource id "
+                + "(/subscriptions/{subscriptionId}/resourceGroups/{group}/providers/{namespace}/{type}/{name}) or empty, "
+                + $"not '{value}'.",
+                nameof(value));
+        }
+
+        return value.TrimEnd('/');
+    }
+}

--- a/src/FoundryGate.Api/Services/Config/SystemConfigValidator.cs
+++ b/src/FoundryGate.Api/Services/Config/SystemConfigValidator.cs
@@ -19,7 +19,8 @@ namespace FoundryGate.Api.Services.Config;
 /// wired to anything (<see cref="SystemConfigurationKeys.ApimProductId"/>, superseded by the per-tier
 /// APIM products; <see cref="SystemConfigurationKeys.EntraTenantId"/>, unused since #123). They stay in
 /// the table because the seed data references them, but editing one would be a silent no-op — so the
-/// refusal names what to change instead.</item>
+/// refusal names what to change instead. #164 removes the rows themselves, which is a data change
+/// rather than an API one.</item>
 /// <item><b>Known key, bad value</b> → <see cref="ArgumentException"/> (400) whose message states the
 /// rule.</item>
 /// <item><b>Known key, good value</b> → the <em>normalized</em> string to store (trimmed; booleans
@@ -111,7 +112,10 @@ public sealed class SystemConfigValidator(GatewayTierMapper tierMapper)
         return quota.ToString(CultureInfo.InvariantCulture);
     }
 
-    /// <summary>1–28: the reset must land on a day every calendar month actually has (spec §6 ships "1").</summary>
+    /// <summary>
+    /// 1–28: the reset must land on a day every calendar month actually has (spec §6 ships "1"). The
+    /// rule is enforced ahead of a reader — nothing consumes this key yet (#165).
+    /// </summary>
     private static string NormalizeResetDayOfMonth(string value)
     {
         if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var day)

--- a/src/FoundryGate.Api/Services/Dashboard/DashboardService.cs
+++ b/src/FoundryGate.Api/Services/Dashboard/DashboardService.cs
@@ -1,0 +1,138 @@
+using FoundryGate.Data;
+using FoundryGate.Domain.Dashboard.Contracts;
+using FoundryGate.Domain.Quota;
+using FoundryGate.Domain.Requests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FoundryGate.Api.Services.Dashboard;
+
+/// <summary>
+/// Default <see cref="IDashboardService"/>: six set-based, <c>AsNoTracking</c> queries over the
+/// current <see cref="BillingPeriod"/>, behind a short shared cache.
+/// </summary>
+/// <remarks>
+/// <b>Why a cache.</b> The dashboard is the admin landing page and refreshes itself every 60 s
+/// (plans/18), so N admins with the tab open are N × 6 aggregate queries a minute against tables the
+/// enforcement path also uses. Holding the answer for <see cref="CacheDuration"/> collapses that to
+/// roughly two query bursts a minute for the whole fork. It is a summary of numbers that are
+/// themselves reconciled on the sync job's cadence — 30 seconds of staleness is invisible next to
+/// that — and <c>?fresh=true</c> is the escape hatch when it is not.
+/// <para>
+/// The key carries the period, so the first read after a month boundary can never serve last month's
+/// figures no matter how recently the entry was written.
+/// </para>
+/// </remarks>
+public sealed class DashboardService(
+    AppDbContext dbContext,
+    IMemoryCache cache,
+    TimeProvider timeProvider) : IDashboardService
+{
+    /// <summary>Prefix of the <see cref="IMemoryCache"/> key; the current <see cref="BillingPeriod"/> is appended.</summary>
+    public const string CacheKeyPrefix = "FoundryGate.Dashboard.Summary";
+
+    /// <summary>How long a computed summary is served to every admin before it is recomputed.</summary>
+    public static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>How many consumers the summary lists (spec &#167;4.6's "top consumers").</summary>
+    public const int TopConsumerCount = 10;
+
+    /// <summary>The cache key for <paramref name="period"/>.</summary>
+    public static string CacheKey(BillingPeriod period) => $"{CacheKeyPrefix}:{period}";
+
+    /// <inheritdoc />
+    public async Task<DashboardSummaryResponse> GetSummaryAsync(bool fresh, CancellationToken cancellationToken)
+    {
+        var period = BillingPeriod.Current(timeProvider);
+        var cacheKey = CacheKey(period);
+
+        if (!fresh && cache.TryGetValue(cacheKey, out DashboardSummaryResponse? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var summary = await QueryAsync(period, cancellationToken);
+        _ = cache.Set(cacheKey, summary, CacheDuration);
+        return summary;
+    }
+
+    /// <summary>
+    /// The six queries, run in sequence — one <see cref="AppDbContext"/> permits one active operation
+    /// at a time, so "concurrently" is not on the table; each is a single aggregate the indexes
+    /// already cover (<c>QuotaAllocation</c> has a <c>(PeriodYear, PeriodMonth)</c> index).
+    /// </summary>
+    private async Task<DashboardSummaryResponse> QueryAsync(BillingPeriod period, CancellationToken cancellationToken)
+    {
+        var totalUserCount = await dbContext.Users.AsNoTracking()
+            .CountAsync(cancellationToken);
+
+        var activeUserCount = await dbContext.Users.AsNoTracking()
+            .CountAsync(u => u.IsActive, cancellationToken);
+
+        // "Unlimited" is a property of an active user: a deactivated account consumes nothing, so
+        // counting it here would inflate the number an admin reads as "how many people are uncapped".
+        var unlimitedUserCount = await dbContext.Users.AsNoTracking()
+            .CountAsync(u => u.IsActive && u.IsUnlimited, cancellationToken);
+
+        var pendingQuotaIncreaseRequestCount = await dbContext.QuotaIncreaseRequests.AsNoTracking()
+            .CountAsync(r => r.StatusType == QuotaRequestStatusType.Pending, cancellationToken);
+
+        // Cast to long? so an empty period sums to null rather than depending on the provider to
+        // COALESCE it; every user's allocation counts, including deactivated ones, because the
+        // tokens they burned before offboarding are still tokens this month spent.
+        var totalTokensUsedThisPeriod = await CurrentPeriod(period)
+            .Select(a => (long?)a.TokensUsed)
+            .SumAsync(cancellationToken) ?? 0L;
+
+        var topConsumers = await CurrentPeriod(period)
+            .Where(a => a.User.IsActive)
+            .OrderByDescending(a => a.TokensUsed)
+            .ThenBy(a => a.UserId)
+            .Take(TopConsumerCount)
+            .Select(a => new ConsumerRow(
+                a.UserId,
+                a.User.UserUnique,
+                a.User.DisplayName,
+                a.TokensUsed,
+                a.AllocatedTokens))
+            .ToListAsync(cancellationToken);
+
+        return new DashboardSummaryResponse(
+            totalUserCount,
+            activeUserCount,
+            unlimitedUserCount,
+            pendingQuotaIncreaseRequestCount,
+            totalTokensUsedThisPeriod,
+            [.. topConsumers.Select(c => new TopConsumerResponse(
+                c.UserId,
+                c.UserUnique,
+                c.DisplayName,
+                c.TokensUsed,
+                c.AllocatedTokens,
+                PercentUsed(c.AllocatedTokens, c.TokensUsed)))]);
+    }
+
+    private IQueryable<Data.Entities.QuotaAllocation> CurrentPeriod(BillingPeriod period) =>
+        dbContext.QuotaAllocations.AsNoTracking()
+            .Where(a => a.PeriodYear == period.Year && a.PeriodMonth == period.Month);
+
+    /// <summary>
+    /// Null when unlimited; a zero quota reads as 100% the moment anything is used (never a division
+    /// by zero). Same rule as <c>QuotaAllocationService</c>, so the dashboard and the quota pages
+    /// never show one user two different percentages.
+    /// </summary>
+    private static double? PercentUsed(long? allocated, long used) => allocated switch
+    {
+        null => null,
+        <= 0 => used > 0 ? 100d : 0d,
+        _ => used * 100d / allocated.Value,
+    };
+
+    /// <summary>Query-side shape: <c>PercentUsed</c> has a zero-quota branch better expressed in C# than in translated SQL.</summary>
+    private sealed record ConsumerRow(
+        int UserId,
+        Guid UserUnique,
+        string DisplayName,
+        long TokensUsed,
+        long? AllocatedTokens);
+}

--- a/src/FoundryGate.Api/Services/Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Dashboard/DashboardServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+namespace FoundryGate.Api.Services.Dashboard;
+
+/// <summary>DI registration for the <c>Services/Dashboard</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class DashboardServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <c>IMemoryCache</c> the summary is held in (<c>AddMemoryCache</c> is
+    /// <c>TryAdd</c>-based, so calling it here as well as in <c>AddFoundryServices</c> is a no-op the
+    /// second time) and <see cref="IDashboardService"/> (scoped — it reads through the request's
+    /// <c>AppDbContext</c>).
+    /// </summary>
+    public static IServiceCollection AddDashboardServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddMemoryCache();
+        services.AddScoped<IDashboardService, DashboardService>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Dashboard/IDashboardService.cs
+++ b/src/FoundryGate.Api/Services/Dashboard/IDashboardService.cs
@@ -1,0 +1,27 @@
+using FoundryGate.Domain.Dashboard.Contracts;
+
+namespace FoundryGate.Api.Services.Dashboard;
+
+/// <summary>
+/// The admin dashboard's one read (spec &#167;4.6; issue #162): the counts and top-consumer list
+/// behind <c>GET /api/v1/dashboard</c>, all for the current UTC billing period.
+/// </summary>
+/// <remarks>
+/// Every usage figure is a reconciliation number from the Log Analytics sync (spec &#167;5.4), not a
+/// live view of gateway enforcement — see <see cref="DashboardSummaryResponse"/>.
+/// </remarks>
+public interface IDashboardService
+{
+    /// <summary>
+    /// The current period's summary.
+    /// </summary>
+    /// <param name="fresh">
+    /// <see langword="true"/> bypasses the short in-memory cache and re-queries. The page
+    /// auto-refreshes every 60 s (plans/18) against a cache that holds for
+    /// <see cref="DashboardService.CacheDuration"/>, so an admin who just changed something —
+    /// approved a request, deactivated a user — would otherwise watch a stale number for up to half a
+    /// refresh cycle. Tests use it for the same reason.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DashboardSummaryResponse> GetSummaryAsync(bool fresh, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
+++ b/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
@@ -11,11 +11,17 @@ namespace FoundryGate.Domain.Config.Contracts;
 /// Null for a seeded row an admin has never edited (the data-layer entity is nullable for the
 /// same reason — reconciled in #92, see the row's <c>[DoNotUpdate]</c> seeding semantics).
 /// </param>
+/// <param name="UpdatedByDisplayName">
+/// The editing admin's display name, joined from <c>SystemConfiguration.UpdatedByUser</c> so the
+/// config editor (#55) can render "last changed by" without a second round trip per row. Null
+/// exactly when <paramref name="UpdatedByUserId"/> is.
+/// </param>
 public record SystemConfigEntryResponse(
     string Key,
     string Value,
     DateTimeOffset UpdatedDate,
-    int? UpdatedByUserId);
+    int? UpdatedByUserId,
+    string? UpdatedByDisplayName);
 
 /// <summary>PUT /config/{key} body. Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).</summary>
 public record UpdateSystemConfigRequest

--- a/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
+++ b/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
@@ -26,8 +26,21 @@ public record SystemConfigEntryResponse(
 /// <summary>PUT /config/{key} body. Init-property record, not positional — see <see cref="Foundry.Contracts.CreateFoundryDeploymentRequest"/>'s remarks (#128).</summary>
 public record UpdateSystemConfigRequest
 {
-    /// <summary>The new value for the key. Required: a missing JSON field binds to <c>""</c> and fails as a field-level 400.</summary>
-    [Required]
+    /// <summary>
+    /// The new value for the key.
+    /// </summary>
+    /// <remarks>
+    /// <c>AllowEmptyStrings</c> deliberately: <b>empty is a legitimate value for several keys</b> —
+    /// clearing <c>ApimGatewayUrl</c>, <c>ApimResourceId</c> or <c>FoundryResourceId</c> back to
+    /// "not addressed yet" is exactly how a fork operator unwires a resource. The default
+    /// <c>[Required]</c> (which rejects <c>""</c>) would have MVC answer 400 before the action ran,
+    /// so the per-key rule could never be consulted and the documented "or empty" capability was
+    /// unreachable over HTTP. Emptiness is the API's decision to make per key
+    /// (<c>SystemConfigValidator</c>), not model binding's to make for all of them; the attribute
+    /// stays on so a <see langword="null"/> <c>value</c> is still a field-level 400 rather than a
+    /// null-reference deeper in.
+    /// </remarks>
+    [Required(AllowEmptyStrings = true)]
     [StringLength(ValidationConstants.ConfigValueMaxLength)]
     public string Value { get; init; } = string.Empty;
 }

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
@@ -1,0 +1,274 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FoundryGate.Data.Seeding;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// End-to-end coverage of <c>/api/v1/config</c> (#161) through the real pipeline: the auth matrix,
+/// the per-key validation table's HTTP mapping (400/404/409), the stamped actor/timestamp, the audit
+/// row, and the guarantee that a later deploy's reference-data seed never reverts an edit.
+/// </summary>
+/// <remarks>
+/// The factory's <c>SystemConfiguration</c> rows are shared by this class's tests, so each test
+/// asserts only on the key it just wrote — never on another key's value.
+/// </remarks>
+public class ConfigEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string ConfigPath = "/api/v1/config";
+
+    [Fact]
+    public async Task Anonymous_request_returns_401()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri(ConfigPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Anonymous_update_returns_401()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await PutAsync(client, SystemConfigurationKeys.ResetDayOfMonth, "1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Authenticated_non_admin_returns_403_on_both_actions()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: false);
+
+        var list = await client.GetAsync(new Uri(ConfigPath, UriKind.Relative));
+        var update = await PutAsync(client, SystemConfigurationKeys.ResetDayOfMonth, "1");
+
+        Assert.Equal(HttpStatusCode.Forbidden, list.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, update.StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_with_no_user_row_cannot_update()
+    {
+        // Reading is fine — nothing is attributed. Writing needs an actor for the audit row, and
+        // "authenticated principal with no User row" is 403 everywhere (CONVENTIONS.md).
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var list = await client.GetAsync(new Uri(ConfigPath, UriKind.Relative));
+        var update = await PutAsync(client, SystemConfigurationKeys.ResetDayOfMonth, "1");
+
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, update.StatusCode);
+        var problem = await update.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        Assert.Contains("GET /users/me", problem!.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Admin_lists_every_seeded_key_ordered_by_key()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await client.GetAsync(new Uri(ConfigPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        var entries = await response.Content.ReadFromJsonAsync<IReadOnlyList<SystemConfigEntryResponse>>(JsonOptions);
+        Assert.NotNull(entries);
+
+        var keys = entries.Select(e => e.Key).ToList();
+        Assert.Equal([.. SystemConfigurationKeys.All.Order(StringComparer.Ordinal)], keys);
+    }
+
+    [Fact]
+    public async Task Update_stores_the_value_stamps_the_admin_and_audits_before_and_after()
+    {
+        const string Key = SystemConfigurationKeys.ApimResourceId;
+        const string NewValue =
+            "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-foundrygate/providers/Microsoft.ApiManagement/service/apim-foundrygate";
+
+        var oid = Guid.NewGuid().ToString();
+        var admin = await factory.SeedUserAsync(oid, displayName: "Ada Lovelace");
+        var before = await ValueOfAsync(Key);
+        factory.TimeProvider.Advance(TimeSpan.FromMinutes(7));
+        var now = factory.TimeProvider.GetUtcNow();
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, Key, NewValue);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await response.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+        Assert.NotNull(entry);
+        Assert.Equal(Key, entry.Key);
+        Assert.Equal(NewValue, entry.Value);
+        Assert.Equal(admin.UserId, entry.UpdatedByUserId);
+        Assert.Equal("Ada Lovelace", entry.UpdatedByDisplayName);
+        Assert.Equal(now, entry.UpdatedDate);
+
+        await using var dbContext = factory.CreateDbContext();
+        var row = await dbContext.SystemConfigurations.SingleAsync(c => c.Key == Key);
+        Assert.Equal(NewValue, row.Value);
+        Assert.Equal(admin.UserId, row.UpdatedByUserId);
+        Assert.Equal(now, row.UpdatedDate);
+
+        var audit = await dbContext.AuditLogs
+            .Where(a => a.Action == AuditActions.ConfigUpdated && a.TargetId == Key)
+            .OrderByDescending(a => a.AuditLogId)
+            .FirstAsync();
+        Assert.Equal(admin.UserId, audit.ActorUserId);
+        Assert.Equal(AuditTargetTypes.SystemConfiguration, audit.TargetType);
+        using var details = JsonDocument.Parse(audit.Details);
+        Assert.Equal(Key, details.RootElement.GetProperty("key").GetString());
+        Assert.Equal(before, details.RootElement.GetProperty("before").GetString());
+        Assert.Equal(NewValue, details.RootElement.GetProperty("after").GetString());
+    }
+
+    [Fact]
+    public async Task Update_normalizes_the_stored_value()
+    {
+        const string Key = SystemConfigurationKeys.EntraGroupSyncEnabled;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, Key, "  TRUE ");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await response.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+        Assert.Equal("true", entry!.Value);
+        Assert.Equal("true", await ValueOfAsync(Key));
+    }
+
+    [Fact]
+    public async Task Update_matches_the_key_case_insensitively()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, "resetdayofmonth", "1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await response.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+        // The canonical key comes back, not the casing the caller typed.
+        Assert.Equal(SystemConfigurationKeys.ResetDayOfMonth, entry!.Key);
+    }
+
+    [Fact]
+    public async Task Update_of_an_unknown_key_returns_404()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, "NoSuchKey", "whatever");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        Assert.Contains("NoSuchKey", problem!.Detail, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.ApimProductId, "Gateway:Tiers")]
+    [InlineData(SystemConfigurationKeys.EntraTenantId, "Entra:Enabled")]
+    public async Task Update_of_a_retired_key_returns_409_naming_its_replacement(string key, string replacementHint)
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        var before = await ValueOfAsync(key);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, key, "something-new");
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        Assert.Contains(replacementHint, problem!.Detail, StringComparison.Ordinal);
+        Assert.Equal(before, await ValueOfAsync(key));
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.DefaultMonthlyTokenQuota, "1234567")]
+    [InlineData(SystemConfigurationKeys.ResetDayOfMonth, "31")]
+    [InlineData(SystemConfigurationKeys.EntraGroupSyncEnabled, "yes")]
+    [InlineData(SystemConfigurationKeys.ApimGatewayUrl, "http://ai.contoso.com")]
+    [InlineData(SystemConfigurationKeys.FoundryResourceId, "not-an-arm-id")]
+    public async Task Update_with_a_value_the_key_does_not_allow_returns_400_and_changes_nothing(string key, string value)
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        var before = await ValueOfAsync(key);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, key, value);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(before, await ValueOfAsync(key));
+    }
+
+    [Fact]
+    public async Task Update_accepts_a_configured_tier_cap_for_the_system_default_quota()
+    {
+        const string Key = SystemConfigurationKeys.DefaultMonthlyTokenQuota;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, Key, "20000000");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("20000000", await ValueOfAsync(Key));
+    }
+
+    [Fact]
+    public async Task A_later_reference_data_seed_never_reverts_an_edited_value()
+    {
+        // SystemConfiguration.Value/UpdatedDate/UpdatedByUserId are [DoNotUpdate], so the seeder only
+        // inserts missing keys. Pinned here because the whole config editor is worthless if the next
+        // deploy silently undoes it.
+        const string Key = SystemConfigurationKeys.ApimGatewayUrl;
+        const string EditedValue = "https://ai.contoso.example";
+
+        var oid = Guid.NewGuid().ToString();
+        var admin = await factory.SeedUserAsync(oid, displayName: "Grace Hopper");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, Key, EditedValue);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var edited = await response.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+
+        await using (var seedContext = factory.CreateDbContext())
+        {
+            _ = await ReferenceDataSeeder.SeedAsync(seedContext);
+            _ = await ReferenceDataSeeder.SeedAsync(seedContext);
+        }
+
+        await using var dbContext = factory.CreateDbContext();
+        var row = await dbContext.SystemConfigurations.SingleAsync(c => c.Key == Key);
+        Assert.Equal(EditedValue, row.Value);
+        Assert.Equal(admin.UserId, row.UpdatedByUserId);
+        Assert.Equal(edited!.UpdatedDate, row.UpdatedDate);
+        Assert.Equal(SystemConfigurationKeys.All.Count, await dbContext.SystemConfigurations.CountAsync());
+    }
+
+    private static Task<HttpResponseMessage> PutAsync(HttpClient client, string key, string value) =>
+        client.PutAsJsonAsync(
+            new Uri($"{ConfigPath}/{Uri.EscapeDataString(key)}", UriKind.Relative),
+            new UpdateSystemConfigRequest { Value = value });
+
+    private async Task<string> ValueOfAsync(string key)
+    {
+        await using var dbContext = factory.CreateDbContext();
+        return await dbContext.SystemConfigurations
+            .Where(c => c.Key == key)
+            .Select(c => c.Value)
+            .SingleAsync();
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FoundryGate.Data.Seeding;
+using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Constants;
 using Microsoft.AspNetCore.Mvc;
@@ -225,6 +226,66 @@ public class ConfigEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTest
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("20000000", await ValueOfAsync(Key));
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.ApimGatewayUrl)]
+    [InlineData(SystemConfigurationKeys.FoundryResourceId)]
+    public async Task An_empty_value_clears_a_key_whose_rule_allows_it(string key)
+    {
+        // The regression this pins: `[Required]` defaults to AllowEmptyStrings = false, so MVC's
+        // automatic model validation used to 400 an empty body before the per-key rule — which
+        // explicitly accepts "" — was ever consulted. Unwiring a resource is a real operation.
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, key, string.Empty);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await response.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+        Assert.Equal(string.Empty, entry!.Value);
+        Assert.Equal(string.Empty, await ValueOfAsync(key));
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.DefaultMonthlyTokenQuota)]
+    [InlineData(SystemConfigurationKeys.ResetDayOfMonth)]
+    [InlineData(SystemConfigurationKeys.EntraGroupSyncEnabled)]
+    public async Task An_empty_value_is_still_refused_where_the_keys_rule_forbids_it(string key)
+    {
+        // Emptiness is the per-key rule's decision, not model binding's: a quota, a reset day and a
+        // feature flag have no empty form, and quota resolution reads all three.
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        var before = await ValueOfAsync(key);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(client, key, string.Empty);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(before, await ValueOfAsync(key));
+    }
+
+    [Fact]
+    public async Task An_over_long_value_is_a_field_level_400_not_a_500()
+    {
+        // Takes over from RequestDtoBindingController's `config` action now that a production
+        // controller binds this record (#128's guard: an invalid body is a 400 ProblemDetails naming
+        // the member, never the 500 a positional record with [property: …] attributes produced).
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var response = await PutAsync(
+            client,
+            SystemConfigurationKeys.ApimGatewayUrl,
+            new string('x', ValidationConstants.ConfigValueMaxLength + 1));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ApiError>(JsonOptions);
+        Assert.NotNull(problem?.Errors);
+        Assert.Contains(nameof(UpdateSystemConfigRequest.Value), problem.Errors.Keys);
     }
 
     [Fact]

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/DashboardEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/DashboardEndpointTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Dashboard.Contracts;
+using FoundryGate.Domain.Quota;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// End-to-end coverage of <c>GET /api/v1/dashboard</c> (#162): the auth matrix, the wire shape, and
+/// the cache contract (<c>?fresh=true</c>). The exact arithmetic behind each number is pinned in
+/// <c>Api/Services/Dashboard/DashboardServiceTests</c>, against a database only that class touches —
+/// this factory's database is shared by the tests below, so they assert on <em>deltas</em> and on
+/// rows they seeded themselves.
+/// </summary>
+public class DashboardEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string DashboardPath = "/api/v1/dashboard";
+
+    [Fact]
+    public async Task Anonymous_request_returns_401()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri(DashboardPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Authenticated_non_admin_returns_403()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: false);
+
+        var response = await client.GetAsync(new Uri(DashboardPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_returns_200_and_the_summary_shape()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await client.GetAsync(new Uri(DashboardPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        var summary = await response.Content.ReadFromJsonAsync<DashboardSummaryResponse>(JsonOptions);
+        Assert.NotNull(summary);
+        Assert.NotNull(summary.TopConsumers);
+        Assert.True(summary.TopConsumers.Count <= 10);
+    }
+
+    [Fact]
+    public async Task Admin_with_no_user_row_can_still_read_the_dashboard()
+    {
+        // Nothing is attributed and nothing is written, so — unlike every mutation — the caller does
+        // not have to have loaded the app once. An admin's first stop is this page.
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+
+        var response = await client.GetAsync(new Uri(DashboardPath, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Seeded_usage_shows_up_in_the_counts_and_at_the_top_of_the_consumer_list()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+        var before = await GetAsync(client, fresh: true);
+
+        var user = await factory.SeedUserAsync(displayName: "Katherine Johnson", configure: u => u.IsUnlimited = true);
+        // Far more than any other row this class seeds, so "top of the list" is not a coincidence.
+        await SeedAllocationAsync(user, tokensUsed: 987_654_321, allocatedTokens: null);
+
+        var after = await GetAsync(client, fresh: true);
+
+        Assert.Equal(before.TotalUserCount + 1, after.TotalUserCount);
+        Assert.Equal(before.ActiveUserCount + 1, after.ActiveUserCount);
+        Assert.Equal(before.UnlimitedUserCount + 1, after.UnlimitedUserCount);
+        Assert.Equal(before.TotalTokensUsedThisPeriod + 987_654_321, after.TotalTokensUsedThisPeriod);
+
+        var top = after.TopConsumers[0];
+        Assert.Equal(user.UserId, top.UserId);
+        Assert.Equal(user.UserUnique, top.UserUnique);
+        Assert.Equal("Katherine Johnson", top.DisplayName);
+        Assert.Equal(987_654_321, top.TokensUsed);
+        Assert.Null(top.AllocatedTokens);
+        Assert.Null(top.PercentUsed);
+    }
+
+    [Fact]
+    public async Task A_plain_read_is_served_from_cache_and_fresh_true_bypasses_it()
+    {
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: true);
+        var primed = await GetAsync(client, fresh: true);
+
+        _ = await factory.SeedUserAsync(displayName: "Arrived after the cache was written");
+
+        var cached = await GetAsync(client, fresh: false);
+        var fresh = await GetAsync(client, fresh: true);
+
+        Assert.Equal(primed.TotalUserCount, cached.TotalUserCount);
+        Assert.Equal(primed.TotalUserCount + 1, fresh.TotalUserCount);
+    }
+
+    private static async Task<DashboardSummaryResponse> GetAsync(HttpClient client, bool fresh)
+    {
+        var path = fresh ? $"{DashboardPath}?fresh=true" : DashboardPath;
+
+        var response = await client.GetAsync(new Uri(path, UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var summary = await response.Content.ReadFromJsonAsync<DashboardSummaryResponse>(JsonOptions);
+        Assert.NotNull(summary);
+        return summary;
+    }
+
+    private async Task SeedAllocationAsync(User user, long tokensUsed, long? allocatedTokens)
+    {
+        var period = BillingPeriod.Current(factory.TimeProvider);
+
+        await using var dbContext = factory.CreateDbContext();
+        dbContext.QuotaAllocations.Add(new QuotaAllocation
+        {
+            UserId = user.UserId,
+            PeriodYear = period.Year,
+            PeriodMonth = period.Month,
+            AllocatedTokens = allocatedTokens,
+            TokensUsed = tokensUsed,
+            ResolvedLevelType = QuotaLevelType.UserUnlimited,
+            TierProductId = GatewayTiers.Unlimited,
+        });
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using FoundryGate.Domain.Common;
-using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Groups.Contracts;
 using FoundryGate.Domain.Requests.Contracts;
@@ -34,7 +33,6 @@ public class RequestDtoBindingTests(ApiTestFactory factory) : IClassFixture<ApiT
         { "users/quota", """{"isUnlimited":false,"monthlyTokenQuota":-1}""", nameof(UpdateUserQuotaRequest.MonthlyTokenQuota) },
         { "requests", """{"requestedQuota":2000000,"justification":"short"}""", nameof(SubmitQuotaIncreaseRequest.Justification) },
         { "requests/review", $$"""{"reviewNotes":"{{new string('x', ValidationConstants.ReviewNotesMaxLength + 1)}}"}""", nameof(ReviewQuotaIncreaseRequest.ReviewNotes) },
-        { "config", """{}""", nameof(UpdateSystemConfigRequest.Value) },
     };
 
     [Theory]

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Config/SystemConfigValidatorTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Config/SystemConfigValidatorTests.cs
@@ -1,0 +1,153 @@
+using FoundryGate.Api.Services.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
+using FoundryGate.Tests.Predeployment.Support;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Config;
+
+/// <summary>
+/// The per-key validation table (#161). Every rule is pinned here so <c>ConfigService</c>'s tests can
+/// stay about persistence, auditing and HTTP mapping.
+/// </summary>
+public class SystemConfigValidatorTests
+{
+    private readonly SystemConfigValidator _validator = new(TestGatewayTiers.Mapper());
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.ApimProductId, "Gateway:Tiers")]
+    [InlineData(SystemConfigurationKeys.EntraTenantId, "Entra:Enabled")]
+    public void EnsureEditable_refuses_a_retired_key_and_names_its_replacement(string key, string replacementHint)
+    {
+        var exception = Assert.Throws<ConflictException>(() => SystemConfigValidator.EnsureEditable(key));
+
+        Assert.Contains(key, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("read-only", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(replacementHint, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.DefaultMonthlyTokenQuota)]
+    [InlineData(SystemConfigurationKeys.ApimResourceId)]
+    [InlineData(SystemConfigurationKeys.ApimGatewayUrl)]
+    [InlineData(SystemConfigurationKeys.FoundryResourceId)]
+    [InlineData(SystemConfigurationKeys.EntraGroupSyncEnabled)]
+    [InlineData(SystemConfigurationKeys.ResetDayOfMonth)]
+    public void EnsureEditable_allows_every_other_seeded_key(string key) =>
+        SystemConfigValidator.EnsureEditable(key);
+
+    [Theory]
+    [InlineData("5000000", "5000000")]
+    [InlineData("  20000000  ", "20000000")]
+    public void DefaultMonthlyTokenQuota_accepts_a_configured_tier_cap(string value, string expected) =>
+        Assert.Equal(expected, _validator.Normalize(SystemConfigurationKeys.DefaultMonthlyTokenQuota, value));
+
+    [Theory]
+    [InlineData("5000001")] // between Standard and Power — a real number, but not a tier
+    [InlineData("0")]       // the unlimited tier's sentinel cap, not a finite budget
+    public void DefaultMonthlyTokenQuota_rejects_a_value_that_is_not_a_tier_cap(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => _validator.Normalize(SystemConfigurationKeys.DefaultMonthlyTokenQuota, value));
+
+        Assert.Contains("tier", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("5,000,000", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("unlimited")]
+    [InlineData("5_000_000")]
+    [InlineData("-5000000")]
+    [InlineData("5000000.0")]
+    public void DefaultMonthlyTokenQuota_rejects_anything_that_is_not_a_non_negative_whole_number(string value) =>
+        Assert.Throws<ArgumentException>(
+            () => _validator.Normalize(SystemConfigurationKeys.DefaultMonthlyTokenQuota, value));
+
+    [Theory]
+    [InlineData("1", "1")]
+    [InlineData(" 28 ", "28")]
+    [InlineData("07", "7")]
+    public void ResetDayOfMonth_accepts_1_through_28(string value, string expected) =>
+        Assert.Equal(expected, _validator.Normalize(SystemConfigurationKeys.ResetDayOfMonth, value));
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("29")]
+    [InlineData("31")]
+    [InlineData("-1")]
+    [InlineData("first")]
+    [InlineData("")]
+    public void ResetDayOfMonth_rejects_a_day_no_month_is_guaranteed_to_have(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => _validator.Normalize(SystemConfigurationKeys.ResetDayOfMonth, value));
+
+        Assert.Contains("1 to 28", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("true", "true")]
+    [InlineData("True", "true")]
+    [InlineData(" FALSE ", "false")]
+    public void EntraGroupSyncEnabled_normalizes_a_boolean_to_lower_case(string value, string expected) =>
+        Assert.Equal(expected, _validator.Normalize(SystemConfigurationKeys.EntraGroupSyncEnabled, value));
+
+    [Theory]
+    [InlineData("yes")]
+    [InlineData("1")]
+    [InlineData("")]
+    public void EntraGroupSyncEnabled_rejects_a_non_boolean(string value) =>
+        Assert.Throws<ArgumentException>(
+            () => _validator.Normalize(SystemConfigurationKeys.EntraGroupSyncEnabled, value));
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("https://ai.contoso.com", "https://ai.contoso.com")]
+    [InlineData("https://ai.contoso.com/", "https://ai.contoso.com")]
+    public void ApimGatewayUrl_accepts_an_absolute_https_url_or_empty(string value, string expected) =>
+        Assert.Equal(expected, _validator.Normalize(SystemConfigurationKeys.ApimGatewayUrl, value));
+
+    [Theory]
+    [InlineData("http://ai.contoso.com")]
+    [InlineData("ai.contoso.com")]
+    [InlineData("/anthropic")]
+    public void ApimGatewayUrl_rejects_anything_that_is_not_absolute_https(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => _validator.Normalize(SystemConfigurationKeys.ApimGatewayUrl, value));
+
+        Assert.Contains("absolute https URL", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.ApimResourceId)]
+    [InlineData(SystemConfigurationKeys.FoundryResourceId)]
+    public void Resource_id_keys_accept_an_arm_resource_id_or_empty(string key)
+    {
+        const string ResourceId =
+            "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-foundrygate/providers/Microsoft.ApiManagement/service/apim-foundrygate";
+
+        Assert.Equal(string.Empty, _validator.Normalize(key, "  "));
+        Assert.Equal(ResourceId, _validator.Normalize(key, ResourceId));
+        Assert.Equal(ResourceId, _validator.Normalize(key, ResourceId + "/"));
+    }
+
+    [Theory]
+    [InlineData(SystemConfigurationKeys.ApimResourceId, "apim-foundrygate")]
+    [InlineData(SystemConfigurationKeys.FoundryResourceId, "/subscriptions/abc/resourceGroups/rg")]
+    public void Resource_id_keys_reject_anything_that_is_not_shaped_like_one(string key, string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => _validator.Normalize(key, value));
+
+        Assert.Contains("ARM resource id", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_operator_added_key_has_no_rule_and_is_stored_trimmed()
+    {
+        // The reference-data seeder's deleteFilter deliberately preserves rows a fork operator added
+        // themselves; the editor must not refuse to edit what the seeder refuses to delete.
+        Assert.Equal("anything at all", _validator.Normalize("Contoso:SupportEmail", "  anything at all  "));
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Dashboard/DashboardServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Dashboard/DashboardServiceTests.cs
@@ -1,0 +1,230 @@
+using FoundryGate.Api.Services.Dashboard;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Quota;
+using FoundryGate.Domain.Requests;
+using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Dashboard;
+
+/// <summary>
+/// <see cref="DashboardService"/> against a private database, where every number can be pinned
+/// exactly (#162). The endpoint tests cover the auth matrix and the wire shape.
+/// </summary>
+public class DashboardServiceTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 15, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly MutableTimeProvider _timeProvider = new(Now);
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+
+    [Fact]
+    public async Task Empty_system_reports_zeroes_and_no_consumers()
+    {
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(0, summary.TotalUserCount);
+        Assert.Equal(0, summary.ActiveUserCount);
+        Assert.Equal(0, summary.UnlimitedUserCount);
+        Assert.Equal(0, summary.PendingQuotaIncreaseRequestCount);
+        Assert.Equal(0, summary.TotalTokensUsedThisPeriod);
+        Assert.Empty(summary.TopConsumers);
+    }
+
+    [Fact]
+    public async Task Counts_separate_total_active_and_unlimited_users()
+    {
+        _ = await SeedUserAsync("Active one");
+        _ = await SeedUserAsync("Active two");
+        _ = await SeedUserAsync("Unlimited", isUnlimited: true);
+        _ = await SeedUserAsync("Departed", isActive: false);
+        // An inactive account that still carries the unlimited flag must not inflate the "how many
+        // people are uncapped" number: it consumes nothing.
+        _ = await SeedUserAsync("Departed unlimited", isActive: false, isUnlimited: true);
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(5, summary.TotalUserCount);
+        Assert.Equal(3, summary.ActiveUserCount);
+        Assert.Equal(1, summary.UnlimitedUserCount);
+    }
+
+    [Fact]
+    public async Task Pending_request_count_ignores_reviewed_requests()
+    {
+        var user = await SeedUserAsync("Requester");
+        await SeedRequestAsync(user, QuotaRequestStatusType.Pending);
+        await SeedRequestAsync(user, QuotaRequestStatusType.Pending);
+        await SeedRequestAsync(user, QuotaRequestStatusType.Approved);
+        await SeedRequestAsync(user, QuotaRequestStatusType.Rejected);
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(2, summary.PendingQuotaIncreaseRequestCount);
+    }
+
+    [Fact]
+    public async Task Token_total_covers_this_period_only_and_includes_deactivated_users()
+    {
+        var alice = await SeedUserAsync("Alice");
+        var departed = await SeedUserAsync("Departed", isActive: false);
+        await SeedAllocationAsync(alice, tokensUsed: 1_000, allocatedTokens: 5_000_000);
+        await SeedAllocationAsync(departed, tokensUsed: 500, allocatedTokens: 5_000_000);
+        // Last month's row must not be counted.
+        await SeedAllocationAsync(alice, tokensUsed: 9_999_999, allocatedTokens: 5_000_000, period: new BillingPeriod(2026, 8));
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(1_500, summary.TotalTokensUsedThisPeriod);
+    }
+
+    [Fact]
+    public async Task Top_consumers_are_the_ten_busiest_active_users_this_period()
+    {
+        for (var i = 1; i <= 12; i++)
+        {
+            var user = await SeedUserAsync($"User {i:D2}");
+            await SeedAllocationAsync(user, tokensUsed: i * 1_000, allocatedTokens: 5_000_000);
+        }
+
+        // Busiest of all, but deactivated — the list is about who to talk to, and there is nobody
+        // to talk to here.
+        var departed = await SeedUserAsync("Departed", isActive: false);
+        await SeedAllocationAsync(departed, tokensUsed: 999_999, allocatedTokens: 5_000_000);
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(DashboardService.TopConsumerCount, summary.TopConsumers.Count);
+        Assert.Equal(
+            ["User 12", "User 11", "User 10", "User 09", "User 08", "User 07", "User 06", "User 05", "User 04", "User 03"],
+            summary.TopConsumers.Select(c => c.DisplayName));
+        Assert.Equal(12_000, summary.TopConsumers[0].TokensUsed);
+        Assert.DoesNotContain(summary.TopConsumers, c => c.DisplayName == "Departed");
+    }
+
+    [Fact]
+    public async Task Consumer_percentage_is_null_when_unlimited_and_computed_otherwise()
+    {
+        var capped = await SeedUserAsync("Capped");
+        var unlimited = await SeedUserAsync("Unlimited", isUnlimited: true);
+        var zeroQuota = await SeedUserAsync("Zero quota");
+        await SeedAllocationAsync(capped, tokensUsed: 1_000_000, allocatedTokens: 5_000_000);
+        await SeedAllocationAsync(unlimited, tokensUsed: 900_000, allocatedTokens: null, tier: GatewayTiers.Unlimited);
+        await SeedAllocationAsync(zeroQuota, tokensUsed: 1, allocatedTokens: 0);
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+        var byName = summary.TopConsumers.ToDictionary(c => c.DisplayName);
+
+        Assert.Equal(20d, byName["Capped"].PercentUsed);
+        Assert.Equal(5_000_000, byName["Capped"].AllocatedTokens);
+        Assert.Null(byName["Unlimited"].PercentUsed);
+        Assert.Null(byName["Unlimited"].AllocatedTokens);
+        // A zero quota reads as fully used the moment anything is spent — never a division by zero.
+        Assert.Equal(100d, byName["Zero quota"].PercentUsed);
+    }
+
+    [Fact]
+    public async Task Consumers_carry_the_stable_user_identifiers_the_ui_links_on()
+    {
+        var user = await SeedUserAsync("Linkable");
+        await SeedAllocationAsync(user, tokensUsed: 42, allocatedTokens: 5_000_000);
+
+        var summary = await CreateService().GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        var consumer = Assert.Single(summary.TopConsumers);
+        Assert.Equal(user.UserId, consumer.UserId);
+        Assert.Equal(user.UserUnique, consumer.UserUnique);
+    }
+
+    [Fact]
+    public async Task A_second_call_is_served_from_cache_until_fresh_is_asked_for()
+    {
+        var service = CreateService();
+        _ = await SeedUserAsync("First");
+        var first = await service.GetSummaryAsync(fresh: false, CancellationToken.None);
+
+        _ = await SeedUserAsync("Second");
+        var cached = await service.GetSummaryAsync(fresh: false, CancellationToken.None);
+        var fresh = await service.GetSummaryAsync(fresh: true, CancellationToken.None);
+
+        Assert.Equal(1, first.TotalUserCount);
+        Assert.Same(first, cached);
+        Assert.Equal(2, fresh.TotalUserCount);
+
+        // ...and the fresh read replaces what the cache serves next.
+        Assert.Equal(2, (await service.GetSummaryAsync(fresh: false, CancellationToken.None)).TotalUserCount);
+    }
+
+    [Fact]
+    public async Task A_new_billing_period_never_serves_the_previous_periods_cached_summary()
+    {
+        var user = await SeedUserAsync("Alice");
+        await SeedAllocationAsync(user, tokensUsed: 7_000, allocatedTokens: 5_000_000);
+        var service = CreateService();
+
+        var september = await service.GetSummaryAsync(fresh: false, CancellationToken.None);
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 10, 1, 0, 0, 0, TimeSpan.Zero));
+        var october = await service.GetSummaryAsync(fresh: false, CancellationToken.None);
+
+        Assert.Equal(7_000, september.TotalTokensUsedThisPeriod);
+        Assert.Equal(0, october.TotalTokensUsedThisPeriod);
+        Assert.Empty(october.TopConsumers);
+    }
+
+    private DashboardService CreateService() => new(Context, _cache, _timeProvider);
+
+    private async Task<User> SeedUserAsync(string displayName, bool isActive = true, bool isUnlimited = false)
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = displayName,
+            Email = $"{Guid.NewGuid():N}@contoso.test",
+            IsActive = isActive,
+            IsUnlimited = isUnlimited,
+        };
+
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync(CancellationToken.None);
+        return user;
+    }
+
+    private async Task SeedAllocationAsync(
+        User user,
+        long tokensUsed,
+        long? allocatedTokens,
+        BillingPeriod? period = null,
+        string tier = GatewayTiers.Standard)
+    {
+        var target = period ?? BillingPeriod.FromInstant(Now);
+
+        Context.QuotaAllocations.Add(new QuotaAllocation
+        {
+            UserId = user.UserId,
+            PeriodYear = target.Year,
+            PeriodMonth = target.Month,
+            AllocatedTokens = allocatedTokens,
+            TokensUsed = tokensUsed,
+            ResolvedLevelType = QuotaLevelType.SystemDefault,
+            TierProductId = tier,
+        });
+        await Context.SaveChangesAsync(CancellationToken.None);
+    }
+
+    private async Task SeedRequestAsync(User user, QuotaRequestStatusType status)
+    {
+        Context.QuotaIncreaseRequests.Add(new QuotaIncreaseRequest
+        {
+            UserId = user.UserId,
+            RequestedByUserId = user.UserId,
+            PeriodYear = Now.Year,
+            PeriodMonth = Now.Month,
+            RequestedQuota = 20_000_000,
+            Justification = "Because the agents are hungry.",
+            StatusType = status,
+        });
+        await Context.SaveChangesAsync(CancellationToken.None);
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/RequestDtoBindingController.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/RequestDtoBindingController.cs
@@ -1,5 +1,4 @@
 using FoundryGate.Api.Controllers;
-using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Groups.Contracts;
 using FoundryGate.Domain.Requests.Contracts;
 using FoundryGate.Domain.Users.Contracts;
@@ -10,7 +9,7 @@ namespace FoundryGate.Tests.Predeployment.Support;
 /// <summary>
 /// Test-only controller — this assembly is registered as an application part by
 /// <see cref="Api.ApiTestFactory"/> — that binds every request record Domain defines ahead of
-/// its production controller (the users/groups/requests/config waves). Each action echoes the
+/// its production controller (the users/groups/requests waves). Each action echoes the
 /// bound body; what matters is what happens <em>before</em> the action runs: an invalid body must
 /// be a 400 ProblemDetails, never the 500 a positional record with <c>[property: …]</c> attributes
 /// produced (#128). Once a production controller binds one of these records, its own endpoint
@@ -35,7 +34,4 @@ public sealed class RequestDtoBindingController : ApiControllerBase
 
     [HttpPost("requests/review")]
     public ReviewQuotaIncreaseRequest ReviewQuotaIncrease([FromBody] ReviewQuotaIncreaseRequest request) => request;
-
-    [HttpPost("config")]
-    public UpdateSystemConfigRequest UpdateSystemConfig([FromBody] UpdateSystemConfigRequest request) => request;
 }


### PR DESCRIPTION
Implements the two remaining spec §4.6 admin endpoints — the `SystemConfiguration` editor API and the dashboard summary — so the wave-3 frontend (#54, #55) has a backend to call.

Closes #161
Closes #162

## What landed

**`/api/v1/config` (#161)** — `ConfigController` + `Services/Config/{IConfigService, ConfigService, SystemConfigValidator}`.

- `GET /config` → every row ordered by key, `AsNoTracking` projection, with the editing admin's name joined in.
- `PUT /config/{key}` → `404` unknown key, `409` retired key, `400` invalid value, `200` with the updated row. Stamps `UpdatedByUserId` + `UpdatedDate` (TimeProvider), writes one `config.updated` audit row with `{ key, before, after }`, one `SaveChangesAsync`.
- `SystemConfigEntryResponse` gains a nullable `UpdatedByDisplayName` (last positional member) for the #55 editor. `FoundryGate.Web` compiles unchanged — it only deserializes the record.

**`/api/v1/dashboard` (#162)** — `DashboardController` + `Services/Dashboard/{IDashboardService, DashboardService}`.

- Six set-based `AsNoTracking` queries over `BillingPeriod.Current(TimeProvider)`, behind a 30 s `IMemoryCache` keyed by period; `?fresh=true` bypasses it.

## Decisions worth a reviewer's attention

1. **One validation table, in the API, not Domain.** `SystemConfigValidator` is a singleton over `GatewayTierMapper` because `DefaultMonthlyTokenQuota` must satisfy the same D-013 tier rule as every other quota write path, and the tier table lives in `GatewayOptions`. Rules: tier-cap quota; reset day 1–28; boolean; absolute-https-or-empty URL; ARM-resource-id-or-empty for the two resource id keys; free text for a row a fork operator added themselves (the seeder's `deleteFilter` deliberately preserves those, so the editor must not refuse to edit what the seeder refuses to delete). Values are stored **normalized** — trimmed, booleans lower-cased, trailing slash removed.
2. **The two dead keys are `409`, not `400` or a silent no-op.** `ApimProductId` (superseded by per-tier APIM products) and `EntraTenantId` (unused since #123) still exist because the seed data references them; editing either would do nothing, so the refusal names the replacement. Removing the rows is a *data* change and got its own issue (#164).
3. **Key lookup is in memory, matched with `OrdinalIgnoreCase`.** `Key == key` is case-insensitive under SQL Server's default collation and case-sensitive under the SQLite the tests run on. Rather than ship an endpoint that 404s on one provider and succeeds on the other, `UpdateAsync` materializes the table (nine rows) and matches in C#. The canonical key comes back in the response, not the caller's casing.
4. **`UpdatedDate` is set explicitly as well as by the interceptor.** Re-saving an unchanged value must still record who touched it and when, and EF never hands an unmodified entity to `TimestampInterceptor`. Both read the same `TimeProvider`, so they cannot disagree.
5. **`unlimitedUserCount` counts active users only**; `totalTokensUsedThisPeriod` includes deactivated users' allocations (tokens spent before offboarding are still tokens this month spent); `topConsumers` lists active users only. Each choice is asserted in a test rather than left to the reader.
6. **`PUT` returns the updated row (`200`), not `204`.** The `Web` client's `SendActionAsync` accepts any 2xx, and the editor needs the new `updatedDate`/`updatedByDisplayName` without a re-list.
7. **`?fresh=true` rather than a cache-busting header.** Two callers need it — the page after a mutation, and the tests after seeding — and a query parameter is the one the Blazor client can express.

## Verification

- `dotnet build FoundryGate.sln -c Release` — **0 warnings, 0 errors**
- `FoundryGate.Tests.Predeployment` — **749 passed, 0 failed** (78 new)
- `dotnet format FoundryGate.sln --verify-no-changes` — clean
- `docs-site`: `npm ci && npm run build` — passes
- Merged `origin/main` (with #148's requests wave) before pushing; `ApiServiceCollectionExtensions` resolved to two added lines, `reference/api.md` sections do not overlap.

New tests: `SystemConfigValidatorTests` (the whole rule table, both `409` messages, the free-text fallback), `ConfigEndpointTests` (401/403 matrix on both actions, 400/404/409 mapping, actor/timestamp stamping, audit before/after, case-insensitive key, **and that a re-run of `ReferenceDataSeeder` never reverts an edit** — the `[DoNotUpdate]` guarantee the whole editor rests on), `DashboardServiceTests` (each number pinned against a private database, including period scoping, top-10 ordering, the percent-used branches and the per-period cache key), `DashboardEndpointTests` (auth matrix, wire shape, `?fresh=true`).

## Deferred, as issues

- **#164** — retire the `ApimProductId` / `EntraTenantId` rows from the seed set and drop the read-only branch.
- **#165** — `ResetDayOfMonth` is now validated on write but nothing reads it; either the monthly reset job honours it or it joins #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtuGhG69SaSuVfx92RwwNk
