### PR TITLE
feat: config concurrency + default-quota re-resolution, quota-request integrity, gateway config verification

### DIFF
--- a/docs-site/src/content/docs/architecture/overview.mdx
+++ b/docs-site/src/content/docs/architecture/overview.mdx
@@ -225,6 +225,10 @@ changing that setting takes effect the next day rather than at the next deployme
       detail: "Runs on or after SystemConfiguration[ResetDayOfMonth] (1–28) when this month has no reset in the audit log yet, so a tick lost to an outage is picked up by the next day rather than costing the month its reset. One replica then takes a short blob lease, renewed while held, so two instances waking together cannot both run — though the reset is idempotent either way.",
     },
     {
+      title: "Close quota requests the period left behind",
+      detail: "Any increase request still Pending from a month that has ended becomes Rejected, with a system note and no reviewer. Those requests can no longer be approved anyway — approval refuses a closed period — so leaving them would just mean the review queue starts every month with last month's dead entries in it. First, before anything can touch the gateway, so a failure here costs nothing.",
+    },
+    {
       title: "Resolve quota for the new period and upsert QuotaAllocation",
       detail: "For each active developer, run the five-level quota resolution for the new month and insert their row. A row that already exists is re-resolved but keeps its reconciled TokensUsed — zeroing it mid-period would only make the dashboard disagree with the gateway.",
     },
@@ -233,8 +237,8 @@ changing that setting takes effect the next day rather than at the next deployme
       detail: "Gateway token-quota counters reset themselves at the UTC month boundary — no APIM counter manipulation needed, and no subscription state is touched. The Function only clears the IsHardStopped mirror so dashboards start the month clean.",
     },
     {
-      title: "Write one audit log entry",
-      detail: "A single quota.monthly-reset row, committed in the same transaction as every allocation it describes. The same code runs behind an admin's manual POST /quota/reset, which audits as quota.reset and names the admin.",
+      title: "Write the audit log entries",
+      detail: "One quota.monthly-reset row carrying the counts, committed in the same transaction as every allocation it describes — plus a second quota.requests-expired row when the sweep above actually closed something (a sweep that finds nothing writes no row at all). The same code runs behind an admin's manual POST /quota/reset, which audits as quota.reset and names the admin.",
     },
   ]}
 />

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -291,8 +291,12 @@ appears on their first `GET /quota/allocations/me` of the month, as it always di
 
 **One open request per user per period.** A second submission while one is still `Pending` in the
 same UTC calendar month is `409`; a decided (approved or rejected) request frees the slot at once, so
-a rejected developer can re-ask with a better justification. The check is not yet backed by a database
-constraint, so two simultaneous submissions can both land ([#147](https://github.com/kolatts/foundry-gate/issues/147)).
+a rejected developer can re-ask with a better justification. The rule is backed by a **filtered unique
+index** on `(userId, periodYear, periodMonth) WHERE status = Pending`
+([#147](https://github.com/kolatts/foundry-gate/issues/147)), so two simultaneous submissions — a
+double-clicked button, a retrying client — get the same `409` as two sequential ones instead of both
+landing and showing the same person twice in the reviewer queue. The filter is what keeps a *decided*
+request from blocking the rest of the month.
 
 Every submission writes `quota.requested`; approval writes `quota.approved` with the before/after
 quota, the quota and level resolution reported at review time, the tier product and whether the gateway

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -250,8 +250,10 @@ exist are re-resolved (`allocatedTokens`, level, tier, capped flag) but **keep t
 `tokensUsed`** — the gateway's monthly window resets itself, so zeroing the mirror mid-month
 would only make dashboards lie. Every touched row gets `isHardStopped = false` and
 `resetDate = now`. Exactly one audit row (`quota.reset`, attributed to the calling admin, details
-`{ usersResetCount, periodYear, periodMonth, createdCount, tierSyncCount, expiredRequestCount }`)
-per run. Returns `{ usersResetCount, periodYear, periodMonth, resetDate }`. Running it twice in a
+`{ usersResetCount, periodYear, periodMonth, tierChangeCount, expiredRequestCount }`)
+per run. `tierChangeCount` is named for what it means to a human reading the trail — every one of those
+is a developer whose *enforced* budget moved this run — not for the seam it went through.
+Returns `{ usersResetCount, periodYear, periodMonth, resetDate, expiredRequestCount }`. Running it twice in a
 month produces the same row count.
 
 **The reset also sweeps the review queue.** In the same transaction, every quota increase request
@@ -273,6 +275,7 @@ nothing writes no row at all. The scheduled monthly job runs exactly the same co
 | `GET` | `/requests/{id}` | Owner or Admin | Request detail. `404` for anyone else — see below |
 | `POST` | `/requests/{id}/approve` | Admin | Approve. Applies the tier to the user and re-resolves the current period immediately |
 | `POST` | `/requests/{id}/reject` | Admin | Reject. Nothing about the user's quota changes |
+| `POST` | `/requests/expire-stale` | Admin | Close every request left `Pending` from a period that has ended. No body. Returns `{ expiredCount }` |
 
 **A request asks for a tier, not a number.** `requestedQuota` must be `null` (unlimited) or exactly
 one of the configured tier caps from `GET /quota/tiers` — anything else is `400` listing the allowed
@@ -446,10 +449,17 @@ transaction**, which moves their APIM subscription to the new tier product
 ([#193](https://github.com/kolatts/foundry-gate/issues/193)). Before this, the key changed and nobody
 moved: the allocation row said one thing, the gateway enforced another, and the first thing to notice
 was usually the scheduled monthly reset — which runs in the Functions host, has no APIM management
-client, and so could only log the divergence it was creating. A failed gateway move fails the whole
-edit, so the database never claims a default the gateway is not enforcing. Re-saving the key's existing
-value re-resolves nobody, and deactivated users are skipped (their key is revoked; there is nothing to
-move).
+client, and so could only log the divergence it was creating. Re-saving the key's existing value
+re-resolves nobody, and deactivated users are skipped (their key is revoked; there is nothing to move).
+
+A failed gateway move fails the whole edit, so **the database never claims a default the gateway is not
+enforcing**. The converse is not guaranteed, and on a large fork it is the likelier failure: the
+subscriptions are re-scoped one at a time, so if developer 200 of 400 throws, 199 have already been
+moved at the gateway and nothing commits — the gateway then enforces a default SQL never recorded. The
+next reset or config edit converges it, and the direction is the safe one (the record is behind the
+enforcement, not ahead of it), but it is a real partial state. It is the same shape the monthly reset
+has, and [#199](https://github.com/kolatts/foundry-gate/issues/199) — which is about not doing thousands
+of ARM calls inside one request at all — is where it gets solved.
 
 Every accepted edit stamps `updatedByUserId` (the calling admin) and `updatedDate`, and writes one
 `config.updated` audit row with `{ key, before, after, reresolvedUserCount, tierChangeCount }` — in the

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -376,13 +376,13 @@ Rules the mutation paths enforce (CLAUDE.md "Anthropic deployments are create-on
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | `GET` | `/config` | Admin | Every `SystemConfiguration` key, ordered by key: `{ key, value, updatedDate, updatedByUserId, updatedByDisplayName }`. The last two are `null` for a seeded key no admin has edited |
-| `PUT` | `/config/{key}` | Admin | Set one key's value. Returns the row as it now stands |
+| `PUT` | `/config/{key}` | Admin | Set one key's value. Returns the row as it now stands. Optional `expectedUpdatedDate` makes the write conditional (`409` if someone else got there first) |
 | `GET` | `/audit` | Admin | Audit log, paged. Filter: `?actor=&action=&from=&to=` |
 | `GET` | `/dashboard` | Admin | Summary stats for the dashboard. `?fresh=true` bypasses the 30-second cache |
 
 ### `PUT /config/{key}`
 
-Body: `{ "value": "..." }`. The key is matched case-insensitively; an unknown one is `404`. The
+Body: `{ "value": "...", "expectedUpdatedDate": "..." }` (the second field optional). The key is matched case-insensitively; an unknown one is `404`. The
 value is validated **per key** before it is stored — a configuration editor that accepts a value
 the system cannot use only moves the failure somewhere harder to find — and stored **normalized**
 (trimmed, booleans lower-cased, URLs and resource ids without a trailing slash), so two admins
@@ -406,6 +406,16 @@ Three keys that earlier versions seeded — `ApimGatewayUrl`, `ApimProductId`, `
 answered `409 read-only`; now the rows are gone entirely (the next `db seed-reference` deletes them),
 `GET /config` does not list them, and `PUT` on one is the ordinary `404`. What replaced each is in the
 [Configuration Reference](/foundry-gate/reference/configuration/#retired-keys).
+
+**Optimistic concurrency is opt-in per request.** Send back the `updatedDate` you read from
+`GET /config` as `expectedUpdatedDate` and the write is refused with `409` if anyone has changed the
+row since — the `detail` names the value it holds now, when it changed and, when the row has an
+editor, who they were, so a config page can say "Ada Lovelace changed this while you were editing"
+without another round trip. Omit the field and the write is last-write-wins, exactly as before
+([#170](https://github.com/kolatts/foundry-gate/issues/170)). The check runs *before* the per-key
+value rule, so a stale write with a bad value is the `409`, not the `400`: a caller whose view of the
+row is out of date has to re-read it whatever they were trying to write. The timestamp is compared as
+an instant, so a client that normalizes to UTC still matches.
 
 Every accepted edit stamps `updatedByUserId` (the calling admin) and `updatedDate`, and writes one
 `config.updated` audit row with `{ key, before, after }` — in the same transaction as the change, so

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -250,9 +250,18 @@ exist are re-resolved (`allocatedTokens`, level, tier, capped flag) but **keep t
 `tokensUsed`** — the gateway's monthly window resets itself, so zeroing the mirror mid-month
 would only make dashboards lie. Every touched row gets `isHardStopped = false` and
 `resetDate = now`. Exactly one audit row (`quota.reset`, attributed to the calling admin, details
-`{ usersResetCount, periodYear, periodMonth, createdCount, tierSyncCount }`) per run. Returns
-`{ usersResetCount, periodYear, periodMonth, resetDate }`. Running it twice in a month produces
-the same row count.
+`{ usersResetCount, periodYear, periodMonth, createdCount, tierSyncCount, expiredRequestCount }`)
+per run. Returns `{ usersResetCount, periodYear, periodMonth, resetDate }`. Running it twice in a
+month produces the same row count.
+
+**The reset also sweeps the review queue.** In the same transaction, every quota increase request
+still `Pending` from a *closed* period is set to `Rejected` with a system note and no reviewer — the
+same shape a departing user's requests get ([#159](https://github.com/kolatts/foundry-gate/issues/159)).
+Those requests can no longer be approved anyway (see below), so leaving them Pending would only mean
+an admin opens the queue each month with last month's dead entries still in it. When the sweep closes
+anything it writes one additional `quota.requests-expired` audit row (no actor, no target, details
+`{ expiredCount, currentPeriodYear, currentPeriodMonth, expiredRequestIds }`); a sweep that finds
+nothing writes no row at all. The scheduled monthly job runs exactly the same code.
 
 ## Quota Increase Requests
 
@@ -297,6 +306,14 @@ index** on `(userId, periodYear, periodMonth) WHERE status = Pending`
 double-clicked button, a retrying client — get the same `409` as two sequential ones instead of both
 landing and showing the same person twice in the reviewer queue. The filter is what keeps a *decided*
 request from blocking the rest of the month.
+
+**A request only applies to the period it was filed for.** Approval re-resolves the *current* period,
+so approving a July request in September would raise September's budget while the row and the response
+still said `periodYear: 2026, periodMonth: 7` — the number in the UI and the month actually affected
+disagreeing. Approving a request whose period has closed is therefore `409` naming both periods
+([#159](https://github.com/kolatts/foundry-gate/issues/159)). **Rejection is always allowed**, so an
+admin can clear an old queue by hand; and the monthly reset closes stale requests itself, so in
+practice this `409` only covers the window between a period ending and the next reset running.
 
 Every submission writes `quota.requested`; approval writes `quota.approved` with the before/after
 quota, the quota and level resolution reported at review time, the tier product and whether the gateway

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -438,9 +438,23 @@ value rule, so a stale write with a bad value is the `409`, not the `400`: a cal
 row is out of date has to re-read it whatever they were trying to write. The timestamp is compared as
 an instant, so a client that normalizes to UTC still matches.
 
+**Changing `DefaultMonthlyTokenQuota` re-resolves the developers it governs.** That key is level 5 of
+the quota precedence chain, so the moment it changes, every **active** user who falls through to it —
+no `isUnlimited`, no user quota, no group that would win at levels 3–4 — plus anyone whose current
+allocation already reads `SystemDefault`, is re-resolved for the current period **in the same
+transaction**, which moves their APIM subscription to the new tier product
+([#193](https://github.com/kolatts/foundry-gate/issues/193)). Before this, the key changed and nobody
+moved: the allocation row said one thing, the gateway enforced another, and the first thing to notice
+was usually the scheduled monthly reset — which runs in the Functions host, has no APIM management
+client, and so could only log the divergence it was creating. A failed gateway move fails the whole
+edit, so the database never claims a default the gateway is not enforcing. Re-saving the key's existing
+value re-resolves nobody, and deactivated users are skipped (their key is revoked; there is nothing to
+move).
+
 Every accepted edit stamps `updatedByUserId` (the calling admin) and `updatedDate`, and writes one
-`config.updated` audit row with `{ key, before, after }` — in the same transaction as the change, so
-a value can never move without a trail. The calling admin must already have a FoundryGate user row
+`config.updated` audit row with `{ key, before, after, reresolvedUserCount, tierChangeCount }` — in the
+same transaction as the change, so a value can never move without a trail, and an admin who changed one
+value and moved 200 developers between products has an entry that says so. The calling admin must already have a FoundryGate user row
 (`GET /users/me` provisions one) or the write is `403`; reading `/config` needs no such row.
 
 **A deploy never reverts an edit.** `SystemConfiguration`'s value, timestamp and editor columns are

--- a/docs-site/src/content/docs/reference/configuration.mdx
+++ b/docs-site/src/content/docs/reference/configuration.mdx
@@ -65,73 +65,90 @@ optional — the Api refuses to start without at least one tier.
 Validated at startup (fail-fast): at least one tier, product ids ⊆ `GatewayTiers.All`, no
 duplicates, every cap in range, exactly one unlimited tier, and at least one finite tier.
 
-**Adding or changing a tier** means changing two things together: `quotaTiers` in
+**Adding or changing a tier** means changing three things together: `quotaTiers` in
 `infra/main.bicep` (creates the APIM product and renders its `llm-token-limit` policy) and
-`Gateway:Tiers` here (what the Api validates quotas against and serves from `GET /quota/tiers`).
-A new product id must also be added to `GatewayTiers.All` in Domain. Until #108 has infra emit
-`Gateway__Tiers__*`, a fork that overrides `quotaTiers` at deploy time updates this section by
-hand. Existing quotas that no longer match any tier are not rejected on read — they are enforced
-at the next tier up and flagged `isGatewayCapped` until an admin corrects them.
+`Gateway:Tiers` in **both** hosts' `appsettings.json` (what the Api validates quotas against and
+serves from `GET /quota/tiers`, and what quota resolution in the Functions host maps onto). A new
+product id must also be added to `GatewayTiers.All` in Domain. Three predeployment tests keep the
+four in step, so getting this wrong fails the build rather than a deployment.
+
+`Gateway__Tiers__*` is the one part of the `Gateway` section infra does **not** set — every other
+value is an environment variable on both hosts (see below). A fork that overrides the `quotaTiers`
+parameter at deploy time therefore has to update both `appsettings.json` files by hand, or the gateway
+will enforce caps the control plane has never heard of;
+[#201](https://github.com/kolatts/foundry-gate/issues/201) tracks having infra emit them. Existing
+quotas that no longer match any tier are not rejected on read — they are enforced at the next tier up
+and flagged `isGatewayCapped` until an admin corrects them.
 
 ---
 
-## API environment variables / appsettings
+## Environment variables / appsettings
 
-Set as Container App environment variables by `infra/modules/control-plane.bicep` — the
-Bicep is the source of truth for names and values, and the
-[Infrastructure Reference](/foundry-gate/reference/infrastructure/) lists them per host.
-None of them is a secret: SQL uses Entra authentication, so even the connection string is
-plain configuration. Secrets, when one is ever needed, are set out of band in Key Vault
-and referenced from appsettings as `@KeyVault(SecretName)`.
+One table for both control-plane hosts. `infra/modules/control-plane.bicep` sets these as Container
+App environment variables and Function App application settings; the Bicep is the source of truth for
+the names, and the [Infrastructure Reference](/foundry-gate/reference/infrastructure/) covers the
+resources behind the values. None of them is a secret: SQL uses Entra authentication, so even the
+connection string is plain configuration. Secrets, when one is ever needed, are set out of band in Key
+Vault and referenced from appsettings as `@KeyVault(SecretName)`.
 
-| Key | Source | Description |
+The **Host** column is what each host *binds and can use* — ✅ set by infra, — not applicable to that
+host. Anything marked ✅ for both comes from the bicep's shared block, so the two can never be told
+about different gateways ([#108](https://github.com/kolatts/foundry-gate/issues/108); a predeployment
+test, `GatewayInfraBindingTests`, reads the bicep and fails if a `Gateway__*` name drifts from
+`GatewayOptions`, if infra sets one nothing binds, or if a new `Gateway` member arrives with no source).
+
+### Shared by both hosts
+
+| Key | API | Functions | Description |
+|---|:--:|:--:|---|
+| `AZURE_CLIENT_ID` | ✅ | ✅ | Client id of that host's user-assigned managed identity — selects it in the token credential chain |
+| `Azure__KeyVaultUrl` | ✅ | ✅ | Key Vault URI for `@KeyVault()` reference resolution; absent locally, which skips resolution |
+| `ConnectionStrings__FoundryGate` | ✅ | ✅ | Azure SQL connection string, `Authentication=Active Directory Default` (no password) |
+| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | ✅ | ✅ | OpenTelemetry → Azure Monitor; off in `appsettings.local.json` and for a local `func start` |
+
+### Gateway addressing (`Gateway__*`, shared by both hosts)
+
+Set on both hosts so nothing has to type an ARM resource id into `SystemConfiguration`. Both hosts
+bind the whole section rather than a per-host subset that would drift; the **Read by** column says who
+actually consumes each value.
+
+| Key | Read by | Description |
 |---|---|---|
-| `ASPNETCORE_ENVIRONMENT` | env var | `qa` or `prod` (lowercase; `local` is docker-only) |
-| `AZURE_CLIENT_ID` | env var | Client id of the API's user-assigned managed identity — selects it in the token credential chain |
-| `Azure__KeyVaultUrl` | env var | Key Vault URI for `@KeyVault()` reference resolution; absent locally, which skips resolution |
-| `ConnectionStrings__FoundryGate` | env var | Azure SQL connection string, `Authentication=Active Directory Default` (no password) |
-| `AzureAd__Instance` | env var | Entra cloud instance (`https://login.microsoftonline.com/` in the public cloud) |
-| `AzureAd__TenantId` | env var | Entra tenant ID for bearer token validation |
-| `AzureAd__ClientId` | env var | Entra App Registration client ID |
-| `AzureAd__Audience` | env var | Token audience (usually `api://{clientId}`) |
-| `Cors__AllowedOrigins__0` | env var | The Static Web App origin allowed to call `/api/v1` |
-| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | env var | OpenTelemetry → Azure Monitor; off in `appsettings.local.json` |
-| `Gateway__SubscriptionId`, `Gateway__ResourceGroup`, `Gateway__ApimName`, `Gateway__ApimGatewayUrl` | env var | Where the APIM instance lives — for subscription create/rotate/delete and alias named-value edits. `ApimName` without the subscription/resource group fails startup; with all three absent the `/keys/*` routes answer `503` locally (and a `qa`/`prod` host refuses to start) |
-| `Gateway__FoundryAccountNames__{i}` | env var | Foundry account names in pool order (index 0 = primary) — the API manages OpenAI model deployments in exactly these accounts. The whole `Gateway` section may be absent locally (no gateway to manage; `/foundry/*` then answers `503`); account names without a subscription/resource group fail startup |
-| `Gateway__LogAnalyticsWorkspaceId` / `Gateway__LogAnalyticsWorkspaceResourceId` | env var | Workspace GUID (what the Log Analytics query API calls the workspace id) / ARM resource id |
-| `Gateway__KeyEncryptionKeyUri` | env var | Versionless URI of the Key Vault RSA key (`fg-apim-key-encryption`) that wraps stored APIM subscription keys (RSA-OAEP-256). The API resolves the key's current version per wrap (5-minute cache) and pins each stored value to the version that wrapped it, so a Key Vault key rotation needs no redeploy or re-encryption. Required when `KeyProtection__Provider` is `KeyVault` |
-| `KeyProtection__Provider` | env var | `KeyVault` (default; cloud) or `DataProtection` (machine-local key ring — accepted in the `local` environment only; the API refuses to start with it anywhere else) |
-| `Entra__Enabled` | env var | `false` by default. Turns on Microsoft Graph-backed Entra sync (`POST /users/sync`). There is **no client secret**: Graph is called as the API's own identity — the user-assigned managed identity in Azure, your Azure CLI login locally — which must hold the Graph *application* roles `Application.Read.All`, `User.Read.All` and `GroupMember.ReadBasic.All` (see the [Infrastructure Reference](/foundry-gate/reference/infrastructure/#role-assignments)). While `false`, the sync endpoints return `400`. |
-| `Entra__ServicePrincipalObjectId` | env var | Optional. Object id of the enterprise application whose user assignments define who is a FoundryGate user. Defaults to the service principal of `AzureAd__ClientId`, resolved once at first use; set it only if developers are assigned to a different enterprise application. |
-| `Entra__GraphBaseUrl` | env var | Optional. Defaults to `https://graph.microsoft.com/v1.0`; sovereign-cloud forks override it (the token scope `{host}/.default` is derived from it). |
+| `Gateway__SubscriptionId` | API | Subscription the gateway resource group lives in — the ARM scope shared by APIM and Foundry |
+| `Gateway__ResourceGroup` | API | `rg-foundrygate-{env}` |
+| `Gateway__ApimName` | API | APIM service name (short name, not the ARM id) — subscription create/rotate/delete and alias named-value edits. `ApimName` without the subscription/resource group fails startup; with all three absent the `/keys/*` routes answer `503` locally (and a `qa`/`prod` host refuses to start) |
+| `Gateway__ApimGatewayUrl` | API | The gateway's public origin, handed to developers as `cliConfig.gatewayBaseUrl` on `GET /users/me`. Comes from the APIM module's own output, so it cannot drift from the gateway that was deployed |
+| `Gateway__FoundryAccountNames__{i}` | API | Foundry account names in pool order (index 0 = primary) — the API manages model deployments in exactly these accounts and no others. Account names without a subscription/resource group fail startup; the whole section may be absent locally, and `/foundry/*` then answers `503` |
+| `Gateway__KeyEncryptionKeyUri` | API | Versionless URI of the Key Vault RSA key (`fg-apim-key-encryption`) that wraps stored APIM subscription keys (RSA-OAEP-256). The API resolves the key's current version per wrap (5-minute cache) and pins each stored value to the version that wrapped it, so a Key Vault key rotation needs no redeploy or re-encryption. Required when `KeyProtection__Provider` is `KeyVault` |
+| `Gateway__LogAnalyticsWorkspaceId` | Functions | The workspace **GUID** — what the Log Analytics query API calls the "workspace id", not the ARM resource id. The only gateway value the usage reconciliation job needs; the host refuses to start if given anything that is not a GUID. Absent, the job logs a warning each pass and does nothing, which is right for a fork that has not enabled the gateway's GenAI diagnostic setting |
+| `Gateway__LogAnalyticsWorkspaceResourceId` | *(nothing yet)* | ARM resource id of the same workspace, for `QueryResourceAsync` and anything management-plane. Bound so nothing has to reconstruct it |
+| `Gateway__Tiers__{i}__*` | API + Functions | **Not set by infra** — see [Gateway quota tiers](#gateway-quota-tiers-gatewaytiers) above. Both hosts ship the table in their own `appsettings.json`, mirroring `infra/main.bicep`'s `quotaTiers`; a fork that overrides `quotaTiers` at deploy time must edit both by hand until [#201](https://github.com/kolatts/foundry-gate/issues/201) has infra emit them |
 
----
-
-## Function App settings
-
-Azure Functions (Flex Consumption) gets the same `Azure__*`, `ConnectionStrings__*`,
-`OpenTelemetry__*` and `Gateway__*` settings as the API, with its own identity in
-`AZURE_CLIENT_ID`, plus:
+### API only
 
 | Key | Description |
 |---|---|
-| `AZURE_FUNCTIONS_ENVIRONMENT` / `DOTNET_ENVIRONMENT` | `qa` or `prod` — the Functions host reads the first, the isolated worker's generic host the second |
-| `AzureWebJobsStorage__accountName` / `AzureWebJobsStorage__credential=managedidentity` / `AzureWebJobsStorage__clientId` | Identity-based host storage. There is no storage connection string: shared-key access is disabled on the account |
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Functions host telemetry |
+| `ASPNETCORE_ENVIRONMENT` | `qa` or `prod` (lowercase; `local` is docker-only) |
+| `AzureAd__Instance` | Entra cloud instance (`https://login.microsoftonline.com/` in the public cloud) |
+| `AzureAd__TenantId` | Entra tenant ID for bearer token validation |
+| `AzureAd__ClientId` | Entra App Registration client ID |
+| `AzureAd__Audience` | Token audience (usually `api://{clientId}`) |
+| `Cors__AllowedOrigins__0` | The Static Web App origin allowed to call `/api/v1` |
+| `KeyProtection__Provider` | `KeyVault` (default; cloud) or `DataProtection` (machine-local key ring — accepted in the `local` environment only; the API refuses to start with it anywhere else) |
+| `Entra__Enabled` | `false` by default. Turns on Microsoft Graph-backed Entra sync (`POST /users/sync`). There is **no client secret**: Graph is called as the API's own identity — the user-assigned managed identity in Azure, your Azure CLI login locally — which must hold the Graph *application* roles `Application.Read.All`, `User.Read.All` and `GroupMember.ReadBasic.All` (see the [Infrastructure Reference](/foundry-gate/reference/infrastructure/#role-assignments)). While `false`, the sync endpoints return `400` |
+| `Entra__ServicePrincipalObjectId` | Optional. Object id of the enterprise application whose user assignments define who is a FoundryGate user. Defaults to the service principal of `AzureAd__ClientId`, resolved once at first use; set it only if developers are assigned to a different enterprise application |
+| `Entra__GraphBaseUrl` | Optional. Defaults to `https://graph.microsoft.com/v1.0`; sovereign-cloud forks override it (the token scope `{host}/.default` is derived from it) |
 
-Of the shared `Gateway__*` values the Functions host actually reads two: `Gateway__Tiers__*`
-(quota resolution — shipped in the Functions project's own `appsettings.json`, which a
-predeployment test keeps byte-identical to the API's) and `Gateway__LogAnalyticsWorkspaceId`
-(usage reconciliation). That last one must be the workspace **GUID**, not the ARM resource id
-— it is what the Log Analytics query API calls the "workspace id" — and the host now refuses
-to start if it is given anything else. With it absent, the reconciliation job logs a warning
-each pass and does nothing, which is the correct behaviour for a fork that has not enabled
-the gateway's GenAI diagnostic setting.
+The Functions host has no `AzureAd`, `Cors` or `KeyProtection` section at all: nothing there serves a
+request, so there is no token to validate, and its jobs never read or write a developer's key.
 
-It also has four settings of its own, all optional; the two addressing ones are normally left unset:
+### Functions only
 
 | Key | Default | Description |
 |---|---|---|
+| `AZURE_FUNCTIONS_ENVIRONMENT` / `DOTNET_ENVIRONMENT` | — | `qa` or `prod` — the Functions host reads the first, the isolated worker's generic host the second |
+| `AzureWebJobsStorage__accountName` / `AzureWebJobsStorage__credential=managedidentity` / `AzureWebJobsStorage__clientId` | — | Identity-based host storage. There is no storage connection string: shared-key access is disabled on the account |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | — | Functions host telemetry |
 | `Storage__AccountName` | *(unset)* | Storage account for the monthly reset's distributed lock. Left empty, the host uses the account it already knows from `AzureWebJobsStorage__accountName`, so no extra configuration is needed in Azure |
 | `Storage__ConnectionString` | *(unset)* | Local Azurite only (`UseDevelopmentStorage=true`). A cloud connection string is refused at startup — the storage account does not accept shared keys |
 | `Storage__LockContainerName` | `foundrygate-locks` | Blob container holding the lock blob; created on demand |

--- a/docs-site/src/content/docs/reference/configuration.mdx
+++ b/docs-site/src/content/docs/reference/configuration.mdx
@@ -84,27 +84,29 @@ and flagged `isGatewayCapped` until an admin corrects them.
 
 ## Environment variables / appsettings
 
-One table for both control-plane hosts. `infra/modules/control-plane.bicep` sets these as Container
-App environment variables and Function App application settings; the Bicep is the source of truth for
-the names, and the [Infrastructure Reference](/foundry-gate/reference/infrastructure/) covers the
-resources behind the values. None of them is a secret: SQL uses Entra authentication, so even the
-connection string is plain configuration. Secrets, when one is ever needed, are set out of band in Key
-Vault and referenced from appsettings as `@KeyVault(SecretName)`.
+The complete set for both control-plane hosts, grouped by who gets what: shared, gateway addressing,
+API-only, Functions-only. `infra/modules/control-plane.bicep` sets them as Container App environment
+variables and Function App application settings; the Bicep is the source of truth for the names, and
+the [Infrastructure Reference](/foundry-gate/reference/infrastructure/) covers the resources behind
+the values. None of them is a secret: SQL uses Entra authentication, so even the connection string is
+plain configuration. Secrets, when one is ever needed, are set out of band in Key Vault and referenced
+from appsettings as `@KeyVault(SecretName)`.
 
-The **Host** column is what each host *binds and can use* — ✅ set by infra, — not applicable to that
-host. Anything marked ✅ for both comes from the bicep's shared block, so the two can never be told
-about different gateways ([#108](https://github.com/kolatts/foundry-gate/issues/108); a predeployment
-test, `GatewayInfraBindingTests`, reads the bicep and fails if a `Gateway__*` name drifts from
-`GatewayOptions`, if infra sets one nothing binds, or if a new `Gateway` member arrives with no source).
+Everything in the first two sections is set on **both** hosts from one shared block in the Bicep, so
+the API and the Functions host can never be told about different gateways
+([#108](https://github.com/kolatts/foundry-gate/issues/108)). A predeployment test,
+`GatewayInfraBindingTests`, reads that Bicep, binds a real `GatewayOptions` from the names it finds and
+checks by reflection that each one arrived — so it fails if a `Gateway__*` name drifts, if infra sets
+one nothing binds, or if a new `Gateway` member turns up with no declared source.
 
 ### Shared by both hosts
 
-| Key | API | Functions | Description |
-|---|:--:|:--:|---|
-| `AZURE_CLIENT_ID` | ✅ | ✅ | Client id of that host's user-assigned managed identity — selects it in the token credential chain |
-| `Azure__KeyVaultUrl` | ✅ | ✅ | Key Vault URI for `@KeyVault()` reference resolution; absent locally, which skips resolution |
-| `ConnectionStrings__FoundryGate` | ✅ | ✅ | Azure SQL connection string, `Authentication=Active Directory Default` (no password) |
-| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | ✅ | ✅ | OpenTelemetry → Azure Monitor; off in `appsettings.local.json` and for a local `func start` |
+| Key | Description |
+|---|---|
+| `AZURE_CLIENT_ID` | Client id of that host's user-assigned managed identity — selects it in the token credential chain |
+| `Azure__KeyVaultUrl` | Key Vault URI for `@KeyVault()` reference resolution; absent locally, which skips resolution |
+| `ConnectionStrings__FoundryGate` | Azure SQL connection string, `Authentication=Active Directory Default` (no password) |
+| `OpenTelemetry__Enabled` / `OpenTelemetry__ConnectionString` | OpenTelemetry → Azure Monitor; off in `appsettings.local.json` and for a local `func start` |
 
 ### Gateway addressing (`Gateway__*`, shared by both hosts)
 

--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -212,6 +212,45 @@ Verification runbook and a PowerShell grant snippet:
 [#120](https://github.com/kolatts/foundry-gate/issues/120). Locally the Azure CLI login is
 used instead, so the developer's own delegated Graph access applies.
 
+## Pre-deployment script
+
+`FoundryGate.Database/Scripts/PreDeployment.sql` is declared `<PreDeploy>` in the `.sqlproj`
+(and removed from the SDK's `**/*.sql` `Build` glob, which would otherwise try to parse DML as
+schema). DacFx embeds it in the dacpac as `predeploy.sql` and runs it **inside the deployment
+transaction, before any schema change** — which is what lets it clear data that a new constraint
+would otherwise reject. `db deploy` goes through `DacServices`, so it honours the script exactly as
+a `SqlPackage` publish would; nothing extra is wired in the CLI or the workflow.
+
+Two rules for anything added here:
+
+- **Idempotent, and safe at any earlier schema version.** The script runs on *every* deploy, not
+  only the one that first needs it — including against a brand-new empty database. Guard each block
+  on the objects it touches (`IF OBJECT_ID(...) IS NOT NULL`), and write the change so a second run
+  is a no-op.
+- **It is data repair, not schema.** Schema belongs in `dbo/Tables/*.sql`, which the EF model is the
+  source of truth for.
+
+The one block it currently carries closes duplicate **pending** quota increase requests per
+`(UserId, PeriodYear, PeriodMonth)`, keeping the newest, before
+`IX_QuotaIncreaseRequests_PendingPerUserPeriod` is created
+([#147](https://github.com/kolatts/foundry-gate/issues/147)). Until that filtered unique index
+existed the rule was enforced only by a read-then-write check that two concurrent submissions could
+both pass, so a fork that has been running may already hold exactly the rows the index forbids —
+and because the dacpac step is part of the automatic deploy chain, a failed `CREATE UNIQUE INDEX`
+would take the whole deployment down rather than just the index. The losers become `Rejected` with
+`ReviewNotes = 'Superseded by a later request (pre-deploy dedupe)'` and no reviewer, the same shape
+a lapsed request gets from the [#159](https://github.com/kolatts/foundry-gate/issues/159) sweep.
+
+Verified against SQL Server 2022 in docker: a database seeded with two pending rows for one user and
+period and the index dropped deploys cleanly, printing
+`Pre-deploy: closed 1 duplicate pending quota increase request(s) …` and then creating the index; a
+third deploy is silent, because there is nothing left to close.
+
+**One operational note about filtered indexes.** A filtered index makes `SET QUOTED_IDENTIFIER ON`
+mandatory for DML on that table. EF Core and SqlClient set it by default and DacFx sets it for its own
+scripts, so application code and deploys are unaffected — but a hand-run `sqlcmd -Q` against
+`QuotaIncreaseRequests` needs it stated explicitly or the write fails with `Msg 1934`.
+
 ## What the hosts are told
 
 Set as Container App environment variables and Function App settings; keys are ASP.NET

--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -217,6 +217,12 @@ used instead, so the developer's own delegated Graph access applies.
 Set as Container App environment variables and Function App settings; keys are ASP.NET
 Core configuration paths (`__` = section separator). None of them is a secret.
 
+This table is the **provenance** view: which Azure resource each value comes from. For what each
+setting *means*, which host reads it, and what happens when it is absent, the
+[Configuration Reference](/foundry-gate/reference/configuration/#environment-variables--appsettings)
+is the single per-host table. A predeployment test (`GatewayInfraBindingTests`) reads
+`control-plane.bicep` and fails if the `Gateway__*` names here drift from what the control plane binds.
+
 | Key | Value |
 |---|---|
 | `ASPNETCORE_ENVIRONMENT` (API) / `AZURE_FUNCTIONS_ENVIRONMENT` + `DOTNET_ENVIRONMENT` (Functions) | `qa` or `prod` |
@@ -230,6 +236,13 @@ Core configuration paths (`__` = section separator). None of them is a secret.
 | `Gateway__LogAnalyticsWorkspaceId` / `Gateway__LogAnalyticsWorkspaceResourceId` | the workspace **GUID** (`customerId` — what `LogsQueryClient.QueryWorkspaceAsync` and `/v1/workspaces/{id}/query` mean by "workspace id") / the ARM resource id (`QueryResourceAsync`, management plane) |
 | `AzureWebJobsStorage__accountName` / `__credential=managedidentity` / `__clientId` (Functions) | identity-based host storage — also where the monthly reset takes its lock lease, so the reset needed no setting of its own |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` (Functions) | host telemetry |
+
+Everything in the `Gateway` section is set on **both** hosts from one shared block in the Bicep, so
+the API and the Functions host can never be told about different gateways. The one exception is the
+quota tier table (`Gateway__Tiers__*`), which infra does not emit at all: both hosts ship it in their
+own `appsettings.json` mirroring the `quotaTiers` parameter, so a fork that overrides that parameter
+must update them by hand — [#201](https://github.com/kolatts/foundry-gate/issues/201) tracks closing
+that gap.
 
 ## Outputs contract
 

--- a/src/FoundryGate.Api/Controllers/ConfigController.cs
+++ b/src/FoundryGate.Api/Controllers/ConfigController.cs
@@ -29,11 +29,16 @@ public sealed class ConfigController(IConfigService configService) : ApiControll
     /// <response code="400">The value breaks the key's rule; the <c>detail</c> states the rule.</response>
     /// <response code="403">The caller is not an admin, or has no <c>User</c> row yet (call <c>GET /users/me</c> first).</response>
     /// <response code="404">No such configuration key — including one retired by #164/#123, whose row no longer exists.</response>
+    /// <response code="409">
+    /// The optional <c>expectedUpdatedDate</c> does not match the stored row: another admin wrote the key
+    /// first (#170). The <c>detail</c> carries the current value, when it changed and who changed it.
+    /// </response>
     [HttpPut("{key}")]
     [ProducesResponseType<SystemConfigEntryResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status403Forbidden)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status409Conflict)]
     public Task<SystemConfigEntryResponse> UpdateAsync(
         string key,
         [FromBody] UpdateSystemConfigRequest request,

--- a/src/FoundryGate.Api/Controllers/RequestsController.cs
+++ b/src/FoundryGate.Api/Controllers/RequestsController.cs
@@ -130,4 +130,24 @@ public sealed class RequestsController(IQuotaRequestService quotaRequests) : Api
         [FromBody] ReviewQuotaIncreaseRequest review,
         CancellationToken cancellationToken) =>
         quotaRequests.RejectAsync(id, review, cancellationToken);
+
+    /// <summary>
+    /// Admin: closes every request left <c>Pending</c> from a billing period that has ended, as
+    /// <c>Rejected</c> with a system note and no reviewer, and audits the sweep as one
+    /// <c>quota.requests-expired</c> row (#159).
+    /// </summary>
+    /// <remarks>
+    /// The monthly reset runs this same sweep, so an admin never normally needs it. It exists for the
+    /// window between a period ending and the next reset — where those requests are already unapprovable
+    /// (<c>409</c>) but still clutter the review queue — and it is the cheap way to clear them:
+    /// <c>POST /quota/reset</c> would also re-resolve every allocation and can move tiers at the gateway,
+    /// where this touches nothing but the stale rows.
+    /// </remarks>
+    /// <response code="200">How many requests were closed; <c>0</c> writes nothing at all.</response>
+    [HttpPost("expire-stale")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ProducesResponseType<ExpireStaleRequestsResult>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status403Forbidden)]
+    public async Task<ExpireStaleRequestsResult> ExpireStaleAsync(CancellationToken cancellationToken) =>
+        new(await quotaRequests.ExpireStaleAsync(cancellationToken));
 }

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -1,31 +1,46 @@
 using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
+using FoundryGate.Core.Quota;
 using FoundryGate.Data;
+using FoundryGate.Data.Concurrency;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Exceptions;
+using FoundryGate.Domain.Quota;
 using Microsoft.EntityFrameworkCore;
 
 namespace FoundryGate.Api.Services.Config;
 
 /// <summary>
 /// Default <see cref="IConfigService"/>. Scoped: it shares the request's <see cref="AppDbContext"/>
-/// with <see cref="IAuditService"/>, so the value change and its <c>config.updated</c> row commit in
-/// one <c>SaveChangesAsync</c> — a configuration edit without its audit trail is exactly the kind of
-/// change an operator later needs to explain.
+/// with <see cref="IAuditService"/> and <see cref="IQuotaResolutionService"/>, so the value change, the
+/// allocations it moves and its <c>config.updated</c> row commit in one <c>SaveChangesAsync</c> — a
+/// configuration edit without its audit trail is exactly the kind of change an operator later needs to
+/// explain.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Concurrency is opt-in per request (#170): a caller that echoes back the <c>updatedDate</c> it read
 /// gets a <c>409</c> when someone else has written the row since, and one that omits
 /// <c>ExpectedUpdatedDate</c> keeps the original last-write-wins behaviour. The check lives in the
 /// request rather than in a <c>rowversion</c> column because <c>SystemConfiguration</c> is reference
 /// data whose columns are all <c>[DoNotUpdate]</c> — a real EF concurrency token would make the seeder
 /// more delicate for a nine-row table, and the contention here is between two humans with a form open.
+/// </para>
+/// <para>
+/// <b>Commit-point discipline</b> (CONVENTIONS.md "external side effects have a commit point"): editing
+/// <c>DefaultMonthlyTokenQuota</c> re-resolves every developer who falls through to it (#193), which
+/// can reach <see cref="IGatewayTierSync"/> and move APIM subscriptions between tier products. Every
+/// refusal — 404, the 409, the per-key 400, the actor's 403 — therefore happens <em>before</em> that
+/// call, and when it actually moved the gateway the audit row and the save run on
+/// <see cref="CancellationToken.None"/> via <c>CommitToken.For</c>.
+/// </para>
 /// </remarks>
 public sealed class ConfigService(
     AppDbContext dbContext,
     SystemConfigValidator validator,
+    IQuotaResolutionService quotaResolution,
     ICurrentUserAccessor currentUser,
     IAuditService audit,
     TimeProvider timeProvider) : IConfigService
@@ -86,14 +101,40 @@ public sealed class ConfigService(
         // TimeProvider), so the two never disagree.
         entry.UpdatedDate = timeProvider.GetUtcNow();
 
+        // Level 5 of the precedence chain just moved for everyone who falls through to it (#193).
+        // Resolution reads the edited (still unsaved) row through the change tracker, so this sees the
+        // new default and the whole thing commits together — allocations, the config row and the audit
+        // row. Before this, an edit here changed nobody until something else happened to touch them, and
+        // the first thing to notice was usually the Functions host's monthly reset, which has no APIM
+        // client and so could only log the divergence it was creating.
+        var reresolvedUserIds = IsDefaultQuotaChange(entry.Key, before, newValue)
+            ? await SystemDefaultUserIdsAsync(cancellationToken)
+            : [];
+
+        var resolutions = reresolvedUserIds.Count == 0
+            ? []
+            : await quotaResolution.ResolveManyAsync(reresolvedUserIds, BillingPeriod.Current(timeProvider), cancellationToken);
+
+        var gatewayMoved = resolutions.Any(resolution => resolution.TierSyncRequested);
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
+
         await audit.LogAsync(
             AuditActions.ConfigUpdated,
             AuditTargetTypes.SystemConfiguration,
             entry.Key,
-            new { key = entry.Key, before, after = newValue },
-            cancellationToken);
+            new
+            {
+                key = entry.Key,
+                before,
+                after = newValue,
+                // An admin who changed one config value and moved 200 developers between APIM products
+                // deserves a trail entry that says so.
+                reresolvedUserCount = reresolvedUserIds.Count,
+                tierChangeCount = resolutions.Count(resolution => resolution.TierSyncRequested),
+            },
+            commitToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(commitToken);
 
         return new SystemConfigEntryResponse(
             entry.Key,
@@ -101,6 +142,59 @@ public sealed class ConfigService(
             entry.UpdatedDate,
             entry.UpdatedByUserId,
             actor.DisplayName);
+    }
+
+    /// <summary>
+    /// True only for an edit that actually changes <c>DefaultMonthlyTokenQuota</c>. Re-saving the same
+    /// value still stamps the editor (that is the point of the explicit <c>UpdatedDate</c>) but must not
+    /// walk the user table, let alone call ARM, for a no-op.
+    /// </summary>
+    private static bool IsDefaultQuotaChange(string key, string before, string after) =>
+        string.Equals(key, SystemConfigurationKeys.DefaultMonthlyTokenQuota, StringComparison.Ordinal)
+        && !string.Equals(before, after, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The users a change to the system default actually affects: every <b>active</b> user whose
+    /// resolution falls through to level 5 — no <c>IsUnlimited</c>, no <c>MonthlyTokenQuota</c>, and no
+    /// group membership that would win at levels 3-4 — plus any whose <em>current</em> allocation already
+    /// says <see cref="QuotaLevelType.SystemDefault"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two halves are not the same set and both are wanted. The first is who the new default applies
+    /// to; the second catches a row the chain has since moved off the default, whose stored allocation is
+    /// stale and would otherwise keep claiming a budget the gateway does not enforce — re-resolving it
+    /// costs one row and ends the disagreement.
+    /// </para>
+    /// <para>
+    /// Deactivated users are excluded, matching the monthly reset and <c>GroupService</c>: their key is
+    /// revoked, so there is no subscription to move and no budget to correct.
+    /// </para>
+    /// <para>
+    /// Deliberately a query rather than <c>IQuotaResolutionService.PreviewAsync</c> per user: the chain
+    /// is deterministic, so "which level would this user land on" is expressible as a predicate, and a
+    /// preview per user would be one round trip each on the one path that may already have hundreds.
+    /// </para>
+    /// </remarks>
+    private Task<List<int>> SystemDefaultUserIdsAsync(CancellationToken cancellationToken)
+    {
+        var period = BillingPeriod.Current(timeProvider);
+
+        return dbContext.Users.AsNoTracking()
+            .Where(user => user.IsActive
+                && ((!user.IsUnlimited
+                        && user.MonthlyTokenQuota == null
+                        && !dbContext.GroupMembers.Any(member =>
+                            member.UserId == user.UserId
+                            && (member.Group.IsUnlimited || member.Group.MonthlyTokenQuota != null)))
+                    || dbContext.QuotaAllocations.Any(allocation =>
+                        allocation.UserId == user.UserId
+                        && allocation.PeriodYear == period.Year
+                        && allocation.PeriodMonth == period.Month
+                        && allocation.ResolvedLevelType == QuotaLevelType.SystemDefault)))
+            .OrderBy(user => user.UserId)
+            .Select(user => user.UserId)
+            .ToListAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -200,6 +200,20 @@ public sealed class ConfigService(
 
         if (claimed > 0)
         {
+            // ExecuteUpdate runs outside the change tracker, so any instance of this row the request had
+            // already loaded is stale the moment it succeeds. Detach it, exactly as
+            // QuotaRequestService.ClaimAsync does — and here it is load-bearing, not tidiness: quota
+            // resolution reads the system default from the tracker first (pending state before database),
+            // and the reference-data seeder leaves these very rows tracked, so a stale copy left here
+            // would have the re-resolution below write the OLD default back onto every default-tier
+            // developer while still committing the new one.
+            foreach (var stale in dbContext.ChangeTracker.Entries<SystemConfiguration>()
+                .Where(tracked => string.Equals(tracked.Entity.Key, key, StringComparison.OrdinalIgnoreCase))
+                .ToList())
+            {
+                stale.State = EntityState.Detached;
+            }
+
             return;
         }
 

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -1,8 +1,10 @@
 using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Data;
+using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace FoundryGate.Api.Services.Config;
@@ -14,9 +16,12 @@ namespace FoundryGate.Api.Services.Config;
 /// change an operator later needs to explain.
 /// </summary>
 /// <remarks>
-/// No concurrency token: two admins editing the same key are last-write-wins today. Deliberately
-/// deferred to #170, which adds an optional <c>ExpectedUpdatedDate</c> to the request when the admin
-/// config page (#55) exists to send it.
+/// Concurrency is opt-in per request (#170): a caller that echoes back the <c>updatedDate</c> it read
+/// gets a <c>409</c> when someone else has written the row since, and one that omits
+/// <c>ExpectedUpdatedDate</c> keeps the original last-write-wins behaviour. The check lives in the
+/// request rather than in a <c>rowversion</c> column because <c>SystemConfiguration</c> is reference
+/// data whose columns are all <c>[DoNotUpdate]</c> — a real EF concurrency token would make the seeder
+/// more delicate for a nine-row table, and the contention here is between two humans with a form open.
 /// </remarks>
 public sealed class ConfigService(
     AppDbContext dbContext,
@@ -57,6 +62,14 @@ public sealed class ConfigService(
             ?? throw new KeyNotFoundException(
                 $"There is no system configuration key '{key}'. GET /api/v1/config lists the keys this fork has.");
 
+        // Before the value is even validated: a caller whose view of the row is stale must go and re-read
+        // it, whatever they were trying to write. Compared as instants (DateTimeOffset equality ignores
+        // the offset), so a UTC-normalizing client still matches a row stored with a local offset.
+        if (request.ExpectedUpdatedDate is { } expected && expected != entry.UpdatedDate)
+        {
+            throw new ConflictException(await ConcurrentEditMessageAsync(entry, expected, cancellationToken));
+        }
+
         var newValue = validator.Normalize(entry.Key, request.Value);
 
         // Resolve the actor before mutating anything: "no User row for this caller" is a 403, and it
@@ -88,5 +101,29 @@ public sealed class ConfigService(
             entry.UpdatedDate,
             entry.UpdatedByUserId,
             actor.DisplayName);
+    }
+
+    /// <summary>
+    /// The 409 body for a lost edit: what the row says now, when it changed, and — when the row has an
+    /// editor — who changed it, so the admin can decide whether to re-apply without another round trip.
+    /// The display-name lookup is a second query on purpose: it runs only on the conflict path, where a
+    /// stale write is being refused anyway, rather than joining <c>UpdatedByUser</c> into every update.
+    /// </summary>
+    private async Task<string> ConcurrentEditMessageAsync(
+        SystemConfiguration entry,
+        DateTimeOffset expected,
+        CancellationToken cancellationToken)
+    {
+        var editor = entry.UpdatedByUserId is { } editorUserId
+            ? await dbContext.Users.AsNoTracking()
+                .Where(u => u.UserId == editorUserId)
+                .Select(u => u.DisplayName)
+                .SingleOrDefaultAsync(cancellationToken)
+            : null;
+
+        var by = string.IsNullOrWhiteSpace(editor) ? string.Empty : $" by {editor}";
+
+        return $"System configuration key '{entry.Key}' was changed{by} at {entry.UpdatedDate:O} — you were editing the version from {expected:O}. " +
+            $"Its value is now '{entry.Value}'. Re-read GET /api/v1/config and re-apply your change if you still want it.";
     }
 }

--- a/src/FoundryGate.Api/Services/Config/ConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/ConfigService.cs
@@ -27,6 +27,9 @@ namespace FoundryGate.Api.Services.Config;
 /// request rather than in a <c>rowversion</c> column because <c>SystemConfiguration</c> is reference
 /// data whose columns are all <c>[DoNotUpdate]</c> — a real EF concurrency token would make the seeder
 /// more delicate for a nine-row table, and the contention here is between two humans with a form open.
+/// It is a real guard, not a read-then-compare: the write is one conditional
+/// <c>UPDATE … WHERE UpdatedDate = @expected</c> (<see cref="ClaimAsync"/>), so two admins who genuinely
+/// race cannot both win.
 /// </para>
 /// <para>
 /// <b>Commit-point discipline</b> (CONVENTIONS.md "external side effects have a commit point"): editing
@@ -70,16 +73,17 @@ public sealed class ConfigService(
         // Materialize the whole table (five rows on a shipped fork) and match in memory rather than
         // translating the comparison: `Key == key` is case-insensitive under SQL Server's default
         // collation but case-sensitive under the SQLite the tests run on, and an endpoint that 404s
-        // on one provider and succeeds on the other is a contract nobody can document. Tracked (no
-        // AsNoTracking) — the matched row is mutated below.
-        var entries = await dbContext.SystemConfigurations.ToListAsync(cancellationToken);
+        // on one provider and succeeds on the other is a contract nobody can document. AsNoTracking:
+        // the row is written by the conditional UPDATE in ClaimAsync, never through the change tracker.
+        var entries = await dbContext.SystemConfigurations.AsNoTracking().ToListAsync(cancellationToken);
         var entry = entries.FirstOrDefault(c => string.Equals(c.Key, key, StringComparison.OrdinalIgnoreCase))
             ?? throw new KeyNotFoundException(
                 $"There is no system configuration key '{key}'. GET /api/v1/config lists the keys this fork has.");
 
-        // Before the value is even validated: a caller whose view of the row is stale must go and re-read
-        // it, whatever they were trying to write. Compared as instants (DateTimeOffset equality ignores
-        // the offset), so a UTC-normalizing client still matches a row stored with a local offset.
+        // The friendly refusal, and the one that runs before the value is even validated: a caller whose
+        // view of the row is stale must go and re-read it, whatever they were trying to write. It is not
+        // the guard — two admins who genuinely race both pass it — which is what ClaimAsync's conditional
+        // UPDATE is for; the same relationship as the pending-request pre-check and its unique index (#147).
         if (request.ExpectedUpdatedDate is { } expected && expected != entry.UpdatedDate)
         {
             throw new ConflictException(await ConcurrentEditMessageAsync(entry, expected, cancellationToken));
@@ -87,26 +91,32 @@ public sealed class ConfigService(
 
         var newValue = validator.Normalize(entry.Key, request.Value);
 
-        // Resolve the actor before mutating anything: "no User row for this caller" is a 403, and it
-        // should leave the change tracker as clean as it found it.
+        // Resolve the actor before anything is written: "no User row for this caller" is a 403, and it
+        // should leave the database as it found it.
         var actor = await currentUser.GetRequiredUserAsync(cancellationToken);
 
         var before = entry.Value;
-        entry.Value = newValue;
-        entry.UpdatedByUserId = actor.UserId;
 
-        // Set explicitly rather than leaning on TimestampInterceptor alone: re-saving an unchanged
-        // value must still record who touched it and when, and an entity EF sees as unmodified is
-        // never handed to the interceptor. The interceptor then stamps the same instant (one
-        // TimeProvider), so the two never disagree.
-        entry.UpdatedDate = timeProvider.GetUtcNow();
+        // Stamped explicitly rather than by TimestampInterceptor: the write is an ExecuteUpdate, which
+        // never goes through the change tracker the interceptor hooks. Re-saving an unchanged value must
+        // still record who touched it and when — the same reason this was explicit before.
+        var updatedDate = timeProvider.GetUtcNow();
 
-        // Level 5 of the precedence chain just moved for everyone who falls through to it (#193).
-        // Resolution reads the edited (still unsaved) row through the change tracker, so this sees the
-        // new default and the whole thing commits together — allocations, the config row and the audit
-        // row. Before this, an edit here changed nobody until something else happened to touch them, and
-        // the first thing to notice was usually the Functions host's monthly reset, which has no APIM
-        // client and so could only log the divergence it was creating.
+        // Claim the row before the gateway can be touched, inside the transaction, so a concurrent admin
+        // cannot also write it — and so a failed tier move below rolls the claim back with everything
+        // else. Precedent: QuotaRequestService.ApproveAsync.
+        await using var transaction = dbContext.Database.CurrentTransaction is null
+            ? await dbContext.Database.BeginTransactionAsync(cancellationToken)
+            : null;
+
+        await ClaimAsync(entry.Key, newValue, actor.UserId, updatedDate, request.ExpectedUpdatedDate, cancellationToken);
+
+        // Level 5 of the precedence chain just moved for everyone who falls through to it (#193). The
+        // claim above has already written the new value inside this transaction, so resolution reads it
+        // and the whole thing commits together — allocations, the config row and the audit row. Before
+        // this, an edit here changed nobody until something else happened to touch them, and the first
+        // thing to notice was usually the Functions host's monthly reset, which has no APIM client and so
+        // could only log the divergence it was creating.
         var reresolvedUserIds = IsDefaultQuotaChange(entry.Key, before, newValue)
             ? await SystemDefaultUserIdsAsync(cancellationToken)
             : [];
@@ -135,13 +145,72 @@ public sealed class ConfigService(
             commitToken);
 
         await dbContext.SaveChangesAsync(commitToken);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(commitToken);
+        }
 
-        return new SystemConfigEntryResponse(
-            entry.Key,
-            entry.Value,
-            entry.UpdatedDate,
-            entry.UpdatedByUserId,
-            actor.DisplayName);
+        // Built from what the claim actually wrote rather than re-read: those are the values the
+        // conditional UPDATE committed, and a read-back on a cancelled token would report a change that
+        // landed as an error.
+        return new SystemConfigEntryResponse(entry.Key, newValue, updatedDate, actor.UserId, actor.DisplayName);
+    }
+
+    /// <summary>
+    /// Writes the row with a single conditional <c>UPDATE … WHERE [Key] = @key</c> — plus
+    /// <c>AND [UpdatedDate] = @expected</c> when the caller supplied one (#170). Whoever's statement
+    /// matches the row wins; the other gets 0 rows and a <c>409</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read-then-write on a tracked entity would let two admins who genuinely race both pass the check in
+    /// <see cref="UpdateAsync"/> and the second still overwrite the first — the very thing
+    /// <c>ExpectedUpdatedDate</c> promises will not happen. Same reasoning and same shape as
+    /// <c>QuotaRequestService.ClaimAsync</c>. <c>ExecuteUpdateAsync</c> also keeps this off the change
+    /// tracker, so the later <c>SaveChangesAsync</c> — which commits the audit row and any re-resolved
+    /// allocations — cannot issue a second, unconditional UPDATE of the same columns.
+    /// </para>
+    /// <para>
+    /// The date is compared as an <em>instant</em> on both providers — SQL Server's
+    /// <c>datetimeoffset</c> comparison normalises to UTC, and the SQLite harness stores UTC ticks — so a
+    /// client that normalises to UTC still matches a row written with another offset.
+    /// </para>
+    /// </remarks>
+    private async Task ClaimAsync(
+        string key,
+        string newValue,
+        int actorUserId,
+        DateTimeOffset updatedDate,
+        DateTimeOffset? expectedUpdatedDate,
+        CancellationToken cancellationToken)
+    {
+        var query = dbContext.SystemConfigurations.Where(c => c.Key == key);
+        if (expectedUpdatedDate is { } expected)
+        {
+            query = query.Where(c => c.UpdatedDate == expected);
+        }
+
+        int? updatedByUserId = actorUserId;
+        var claimed = await query.ExecuteUpdateAsync(
+            setters => setters
+                .SetProperty(c => c.Value, newValue)
+                .SetProperty(c => c.UpdatedByUserId, updatedByUserId)
+                .SetProperty(c => c.UpdatedDate, updatedDate),
+            cancellationToken);
+
+        if (claimed > 0)
+        {
+            return;
+        }
+
+        // Nothing matched: another admin wrote the row between our read and here, or — with no expected
+        // date, where the filter is the key alone — it was deleted. Re-read to say which.
+        var current = await dbContext.SystemConfigurations.AsNoTracking()
+            .SingleOrDefaultAsync(c => c.Key == key, cancellationToken)
+            ?? throw new KeyNotFoundException(
+                $"System configuration key '{key}' was deleted while this request was in flight, so there was nothing to update.");
+
+        throw new ConflictException(await ConcurrentEditMessageAsync(current, expectedUpdatedDate, cancellationToken));
     }
 
     /// <summary>
@@ -205,7 +274,7 @@ public sealed class ConfigService(
     /// </summary>
     private async Task<string> ConcurrentEditMessageAsync(
         SystemConfiguration entry,
-        DateTimeOffset expected,
+        DateTimeOffset? expected,
         CancellationToken cancellationToken)
     {
         var editor = entry.UpdatedByUserId is { } editorUserId
@@ -217,7 +286,10 @@ public sealed class ConfigService(
 
         var by = string.IsNullOrWhiteSpace(editor) ? string.Empty : $" by {editor}";
 
-        return $"System configuration key '{entry.Key}' was changed{by} at {entry.UpdatedDate:O} — you were editing the version from {expected:O}. " +
+        // The "you were editing" half only makes sense when the caller told us which version they had.
+        var wasEditing = expected is { } version ? $" — you were editing the version from {version:O}" : string.Empty;
+
+        return $"System configuration key '{entry.Key}' was changed{by} at {entry.UpdatedDate:O}{wasEditing}. " +
             $"Its value is now '{entry.Value}'. Re-read GET /api/v1/config and re-apply your change if you still want it.";
     }
 }

--- a/src/FoundryGate.Api/Services/Config/IConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/IConfigService.cs
@@ -22,8 +22,19 @@ public interface IConfigService
 
     /// <summary>
     /// Sets one key's value, stamping the calling admin and the current time, and writes one
-    /// <c>config.updated</c> audit row (details <c>{ key, before, after }</c>) in the same save.
+    /// <c>config.updated</c> audit row (details
+    /// <c>{ key, before, after, reresolvedUserCount, tierChangeCount }</c>) in the same save.
     /// </summary>
+    /// <remarks>
+    /// <b>Changing <c>DefaultMonthlyTokenQuota</c> re-resolves the developers it governs</b> (#193).
+    /// Level 5 of the precedence chain has just moved, so every active user who falls through to it —
+    /// and any whose current allocation already reads <c>SystemDefault</c> — is re-resolved for the
+    /// current period in the same unit of work, which moves their APIM subscription to the new tier
+    /// product. Without it the row said one thing and the gateway enforced another until something else
+    /// happened to touch each user, and the first thing to notice was usually the Functions host's
+    /// monthly reset, which cannot move a tier at all. Setting the key to the value it already has
+    /// re-resolves nobody.
+    /// </remarks>
     /// <param name="key">The configuration key; matched case-insensitively, as SQL Server's default collation would.</param>
     /// <param name="request">
     /// The new value, validated and normalized per key before it is stored, plus the optional

--- a/src/FoundryGate.Api/Services/Config/IConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/IConfigService.cs
@@ -1,4 +1,5 @@
 using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Exceptions;
 
 namespace FoundryGate.Api.Services.Config;
 
@@ -24,7 +25,10 @@ public interface IConfigService
     /// <c>config.updated</c> audit row (details <c>{ key, before, after }</c>) in the same save.
     /// </summary>
     /// <param name="key">The configuration key; matched case-insensitively, as SQL Server's default collation would.</param>
-    /// <param name="request">The new value. Validated and normalized per key before it is stored.</param>
+    /// <param name="request">
+    /// The new value, validated and normalized per key before it is stored, plus the optional
+    /// <c>ExpectedUpdatedDate</c> concurrency check (#170).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The row as it now stands.</returns>
     /// <exception cref="KeyNotFoundException">
@@ -32,6 +36,12 @@ public interface IConfigService
     /// so there is nothing to distinguish it from a typo.
     /// </exception>
     /// <exception cref="ArgumentException">The value breaks the key's rule (→ 400); the message states the rule.</exception>
+    /// <exception cref="ConflictException">
+    /// <c>ExpectedUpdatedDate</c> was supplied and does not match the stored row (→ 409): another admin
+    /// wrote the key first. The message carries the row's current value, its timestamp and — when it has
+    /// one — the editor's display name, so the caller can re-decide without another round trip. Checked
+    /// before the value is validated: a stale view has to be refreshed whatever it was trying to write.
+    /// </exception>
     /// <exception cref="UnauthorizedAccessException">The calling admin has no <c>User</c> row yet (→ 403; call <c>GET /users/me</c> first).</exception>
     Task<SystemConfigEntryResponse> UpdateAsync(string key, UpdateSystemConfigRequest request, CancellationToken cancellationToken);
 }

--- a/src/FoundryGate.Api/Services/Config/IConfigService.cs
+++ b/src/FoundryGate.Api/Services/Config/IConfigService.cs
@@ -51,7 +51,9 @@ public interface IConfigService
     /// <c>ExpectedUpdatedDate</c> was supplied and does not match the stored row (→ 409): another admin
     /// wrote the key first. The message carries the row's current value, its timestamp and — when it has
     /// one — the editor's display name, so the caller can re-decide without another round trip. Checked
-    /// before the value is validated: a stale view has to be refreshed whatever it was trying to write.
+    /// before the value is validated (a stale view has to be refreshed whatever it was trying to write),
+    /// and enforced by a conditional <c>UPDATE</c>, so it holds for two admins racing and not only for
+    /// two saving in turn.
     /// </exception>
     /// <exception cref="UnauthorizedAccessException">The calling admin has no <c>User</c> row yet (→ 403; call <c>GET /users/me</c> first).</exception>
     Task<SystemConfigEntryResponse> UpdateAsync(string key, UpdateSystemConfigRequest request, CancellationToken cancellationToken);

--- a/src/FoundryGate.Api/Services/Groups/EntraGroupSyncService.cs
+++ b/src/FoundryGate.Api/Services/Groups/EntraGroupSyncService.cs
@@ -4,6 +4,7 @@ using FoundryGate.Api.Services.Entra;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Core.Quota;
 using FoundryGate.Data;
+using FoundryGate.Data.Concurrency;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Exceptions;
@@ -212,7 +213,7 @@ public sealed class EntraGroupSyncService(
             ? []
             : await quotaResolution.ResolveManyAsync(reresolved, BillingPeriod.Current(timeProvider), cancellationToken);
         var gatewayMoved = resolutions.Any(resolution => resolution.TierSyncRequested);
-        var commitToken = gatewayMoved ? CancellationToken.None : cancellationToken;
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
 
         if (skippedUnknown > 0)
         {

--- a/src/FoundryGate.Api/Services/Groups/GroupService.cs
+++ b/src/FoundryGate.Api/Services/Groups/GroupService.cs
@@ -516,30 +516,16 @@ public sealed class GroupService(
         {
             _ = await dbContext.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException exception) when (Mentions(exception, NameIndexMarkers))
+        catch (DbUpdateException exception) when (UniqueIndexViolation.Mentions(exception, NameIndexMarkers))
         {
             logger.LogWarning(exception, "Group name '{GroupName}' was taken concurrently; returning 409.", name);
             throw new ConflictException(DuplicateNameMessage(name), exception);
         }
-        catch (DbUpdateException exception) when (Mentions(exception, EntraGroupIdIndexMarkers))
+        catch (DbUpdateException exception) when (UniqueIndexViolation.Mentions(exception, EntraGroupIdIndexMarkers))
         {
             logger.LogWarning(exception, "Entra group {EntraGroupId} was linked concurrently (group {ExceptGroupId} excluded); returning 409.", entraGroupId, exceptGroupId);
             throw new ConflictException(DuplicateEntraLinkMessage(entraGroupId), exception);
         }
-    }
-
-    /// <summary>True when any exception in the chain names one of <paramref name="markers"/>.</summary>
-    private static bool Mentions(Exception exception, string[] markers)
-    {
-        for (var current = exception; current is not null; current = current.InnerException)
-        {
-            if (Array.Exists(markers, marker => current.Message.Contains(marker, StringComparison.Ordinal)))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static string DuplicateNameMessage(string name) =>

--- a/src/FoundryGate.Api/Services/Groups/GroupService.cs
+++ b/src/FoundryGate.Api/Services/Groups/GroupService.cs
@@ -4,6 +4,7 @@ using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Core.Quota;
 using FoundryGate.Data;
+using FoundryGate.Data.Concurrency;
 using FoundryGate.Data.Entities;
 using FoundryGate.Data.Extensions;
 using FoundryGate.Domain.Common;
@@ -213,7 +214,7 @@ public sealed class GroupService(
         // thing commits together.
         var memberIds = quotaChanged ? await ActiveMemberIdsAsync(groupId, cancellationToken) : [];
         var gatewayMoved = await ReresolveAsync(memberIds, cancellationToken);
-        var commitToken = CommitToken(gatewayMoved, cancellationToken);
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
 
         _ = await audit.LogAsync(
             AuditActions.GroupUpdated,
@@ -270,7 +271,7 @@ public sealed class GroupService(
         // members resolve down the chain (usually to the system default) exactly as they will read
         // once this commits.
         var gatewayMoved = await ReresolveAsync(affectedUserIds, cancellationToken);
-        var commitToken = CommitToken(gatewayMoved, cancellationToken);
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
 
         _ = await audit.LogAsync(
             AuditActions.GroupDeleted,
@@ -325,7 +326,7 @@ public sealed class GroupService(
         _ = dbContext.GroupMembers.Add(membership);
 
         var gatewayMoved = await ReresolveAsync(user.IsActive ? [user.UserId] : [], cancellationToken);
-        var commitToken = CommitToken(gatewayMoved, cancellationToken);
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
 
         _ = await audit.LogAsync(
             AuditActions.GroupMemberAdded,
@@ -362,7 +363,7 @@ public sealed class GroupService(
 
         var reresolved = user is { IsActive: true };
         var gatewayMoved = await ReresolveAsync(reresolved ? [userId] : [], cancellationToken);
-        var commitToken = CommitToken(gatewayMoved, cancellationToken);
+        var commitToken = CommitToken.For(gatewayMoved, cancellationToken);
 
         _ = await audit.LogAsync(
             AuditActions.GroupMemberRemoved,
@@ -435,13 +436,6 @@ public sealed class GroupService(
 
         return resolutions.Any(resolution => resolution.TierSyncRequested);
     }
-
-    /// <summary>
-    /// <see cref="CancellationToken.None"/> once the gateway has accepted a change, the request's own
-    /// token otherwise — a disconnect must not turn an accepted tier move into an unaudited one.
-    /// </summary>
-    private static CancellationToken CommitToken(bool gatewayMoved, CancellationToken cancellationToken) =>
-        gatewayMoved ? CancellationToken.None : cancellationToken;
 
     private IQueryable<GroupMember> MembersOf(int groupId) =>
         dbContext.GroupMembers.AsNoTracking().Where(member => member.GroupId == groupId);

--- a/src/FoundryGate.Api/Services/Quota/QuotaAllocationService.cs
+++ b/src/FoundryGate.Api/Services/Quota/QuotaAllocationService.cs
@@ -170,7 +170,12 @@ public sealed class QuotaAllocationService(
 
         var outcome = await quotaReset.ResetAsync(QuotaResetTrigger.Admin(actor.UserId), cancellationToken);
 
-        return new QuotaResetResult(outcome.UsersResetCount, outcome.Period.Year, outcome.Period.Month, outcome.ResetDate);
+        return new QuotaResetResult(
+            outcome.UsersResetCount,
+            outcome.Period.Year,
+            outcome.Period.Month,
+            outcome.ResetDate,
+            outcome.ExpiredRequestCount);
     }
 
     private IQueryable<QuotaAllocation> ForPeriod(BillingPeriod period) =>

--- a/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
@@ -37,6 +37,15 @@ namespace FoundryGate.Api.Services.Requests;
 /// stored <c>QuotaAllocation</c> row, which only reflects the last resolution.
 /// </para>
 /// <para>
+/// <b>A request only applies to the period it was filed for.</b> Approval re-resolves the
+/// <em>current</em> period, so approving a July request in September would raise September's budget
+/// while the row and the response still said July — the number in the UI and the month actually
+/// affected disagreeing. Approving a request from a closed period is therefore a 409 naming that
+/// period; rejecting one is always allowed, so a queue can be cleared by hand. The monthly reset
+/// closes them itself (<see cref="Core.Requests.IQuotaRequestExpiry"/>), so in practice an admin never
+/// meets one (#159).
+/// </para>
+/// <para>
 /// <b>Reviews claim the row.</b> The transition out of <c>Pending</c> is a conditional update, so a
 /// simultaneous approve and reject cannot both proceed: one wins, the other gets a 409. Everything a
 /// review writes — the row, the subject's quota, the allocation, the audit entry — commits in one
@@ -103,9 +112,10 @@ public interface IQuotaRequestService
     /// <exception cref="KeyNotFoundException">No such request (→ 404).</exception>
     /// <exception cref="ArgumentException">The stored <c>RequestedQuota</c> is no longer a configured tier cap — the tier table changed after submission (→ 400).</exception>
     /// <exception cref="Domain.Exceptions.ConflictException">
-    /// The request is already approved or rejected (including by a reviewer racing this one), the subject
-    /// user is deactivated, or the stored <c>RequestedQuota</c> is no longer an increase over the
-    /// subject's live quota — approving would lower it (→ 409).
+    /// The request is already approved or rejected (including by a reviewer racing this one), it was
+    /// filed for a billing period that has since closed (→ 409; see the type remarks — reject it
+    /// instead), the subject user is deactivated, or the stored <c>RequestedQuota</c> is no longer an
+    /// increase over the subject's live quota — approving would lower it (→ 409).
     /// </exception>
     Task<QuotaIncreaseRequestResponse> ApproveAsync(int quotaIncreaseRequestId, ReviewQuotaIncreaseRequest review, CancellationToken cancellationToken);
 
@@ -132,4 +142,19 @@ public interface IQuotaRequestService
     /// method on this service inside it; none of them opens a second one.
     /// </remarks>
     Task<int> CancelPendingForUserAsync(int userId, string note, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closes every request left <c>Pending</c> from a billing period earlier than the current one, as
+    /// <c>Rejected</c> with a system note and no reviewer, and audits the sweep as one
+    /// <c>quota.requests-expired</c> row carrying the count. Saves.
+    /// </summary>
+    /// <remarks>
+    /// The rule itself is <see cref="Core.Requests.IQuotaRequestExpiry"/> in Core, shared with the
+    /// monthly reset — a timer and a button must not disagree about what expiry means. This entry point
+    /// exists so the Api can sweep on its own (an operator tool, a future admin route); nothing over
+    /// HTTP calls it yet, and the reset is what runs it on the normal schedule. Nothing external is
+    /// touched, so the caller's own token applies throughout.
+    /// </remarks>
+    /// <returns>How many requests were closed; <c>0</c> writes nothing at all.</returns>
+    Task<int> ExpireStaleAsync(CancellationToken cancellationToken);
 }

--- a/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
@@ -150,10 +150,11 @@ public interface IQuotaRequestService
     /// </summary>
     /// <remarks>
     /// The rule itself is <see cref="Core.Requests.IQuotaRequestExpiry"/> in Core, shared with the
-    /// monthly reset — a timer and a button must not disagree about what expiry means. This entry point
-    /// exists so the Api can sweep on its own (an operator tool, a future admin route); nothing over
-    /// HTTP calls it yet, and the reset is what runs it on the normal schedule. Nothing external is
-    /// touched, so the caller's own token applies throughout.
+    /// monthly reset — a timer and a button must not disagree about what expiry means. Reached over HTTP
+    /// as the admin-only <c>POST /requests/expire-stale</c>, which exists for the window between a period
+    /// ending and the next reset running: those requests are already unapprovable, and clearing them with
+    /// <c>POST /quota/reset</c> would also re-resolve every allocation and can move tiers at the gateway.
+    /// Nothing external is touched here, so the caller's own token applies throughout.
     /// </remarks>
     /// <returns>How many requests were closed; <c>0</c> writes nothing at all.</returns>
     Task<int> ExpireStaleAsync(CancellationToken cancellationToken);

--- a/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/IQuotaRequestService.cs
@@ -54,7 +54,11 @@ public interface IQuotaRequestService
     /// </summary>
     /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row (→ 403; call <c>GET /users/me</c> first), or their account is deactivated (→ 403).</exception>
     /// <exception cref="ArgumentException"><c>RequestedQuota</c> is not a configured tier cap, or is not an increase over the caller's current quota (→ 400).</exception>
-    /// <exception cref="Domain.Exceptions.ConflictException">The caller already has a pending request for this period (→ 409).</exception>
+    /// <exception cref="Domain.Exceptions.ConflictException">
+    /// The caller already has a pending request for this period (→ 409). Backed by the filtered unique
+    /// index <c>IX_QuotaIncreaseRequests_PendingPerUserPeriod</c> (#147), so two concurrent submissions
+    /// get the same answer as two sequential ones — exactly one row survives.
+    /// </exception>
     Task<QuotaIncreaseRequestResponse> SubmitAsync(SubmitQuotaIncreaseRequest request, CancellationToken cancellationToken);
 
     /// <summary>
@@ -64,7 +68,10 @@ public interface IQuotaRequestService
     /// </summary>
     /// <exception cref="KeyNotFoundException">No such user (→ 404).</exception>
     /// <exception cref="ArgumentException">As <see cref="SubmitAsync"/>, evaluated for the subject user (→ 400).</exception>
-    /// <exception cref="Domain.Exceptions.ConflictException">The subject already has a pending request for this period, or is deactivated (→ 409).</exception>
+    /// <exception cref="Domain.Exceptions.ConflictException">
+    /// The subject already has a pending request for this period, or is deactivated (→ 409). The
+    /// duplicate case is constraint-backed; see <see cref="SubmitAsync"/>.
+    /// </exception>
     Task<QuotaIncreaseRequestResponse> SubmitForUserAsync(int userId, SubmitQuotaIncreaseRequest request, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data;
 using FoundryGate.Data.Concurrency;
 using FoundryGate.Data.Entities;
@@ -26,6 +27,7 @@ namespace FoundryGate.Api.Services.Requests;
 public sealed class QuotaRequestService(
     AppDbContext dbContext,
     IQuotaResolutionService quotaResolution,
+    IQuotaRequestExpiry requestExpiry,
     GatewayTierMapper tierMapper,
     ICurrentUserAccessor currentUser,
     IAuditService audit,
@@ -161,6 +163,19 @@ public sealed class QuotaRequestService(
 
         var (entity, reviewer) = await LoadForReviewAsync(quotaIncreaseRequestId, cancellationToken);
 
+        var period = BillingPeriod.Current(timeProvider);
+        if (entity.PeriodYear != period.Year || entity.PeriodMonth != period.Month)
+        {
+            // The cheapest refusal, and the one that needs no other read. Everything below re-resolves
+            // *this* period, so approving a request filed for another one would raise today's budget
+            // while the row and the response still reported the month it was filed for — the number in
+            // the UI and the month actually affected would disagree (#159). The monthly reset closes
+            // these, so an admin normally never sees one; this is the guard for the window between a
+            // period ending and the next reset running.
+            throw new ConflictException(
+                $"Quota increase request {quotaIncreaseRequestId} was filed for {new BillingPeriod(entity.PeriodYear, entity.PeriodMonth)}, which has ended; the current period is {period}. Approving it would raise the budget for a different month than the one the request records. Reject it and ask the developer to submit a new one.");
+        }
+
         var subject = await dbContext.Users.SingleAsync(u => u.UserId == entity.UserId, cancellationToken);
         if (!subject.IsActive)
         {
@@ -202,7 +217,7 @@ public sealed class QuotaRequestService(
         // Immediately live: upserts this period's allocation and (via the resolution service) moves the
         // subscription to the new tier product before anything is committed, so a failed gateway move
         // fails the approval rather than leaving the database claiming a budget nobody enforces.
-        var resolution = await quotaResolution.ResolveAsync(subject.UserId, BillingPeriod.Current(timeProvider), cancellationToken);
+        var resolution = await quotaResolution.ResolveAsync(subject.UserId, period, cancellationToken);
 
         // Past the commit point (CONVENTIONS.md "External side effects have a commit point") exactly when
         // resolution actually moved the subscription: from there the audit row and the save must not be
@@ -294,6 +309,21 @@ public sealed class QuotaRequestService(
         }
 
         return pending.Count;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ExpireStaleAsync(CancellationToken cancellationToken)
+    {
+        // The rule is Core's, shared with the monthly reset; the Api's job here is only to give it a
+        // period and own the save. Nothing external is touched, so the caller's token applies throughout
+        // and a count of 0 leaves the change tracker (and the audit log) untouched.
+        var expired = await requestExpiry.ExpireStaleAsync(BillingPeriod.Current(timeProvider), cancellationToken);
+        if (expired > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return expired;
     }
 
     private async Task<QuotaIncreaseRequestResponse> SubmitCoreAsync(

--- a/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
@@ -308,6 +308,10 @@ public sealed class QuotaRequestService(
 
         var period = BillingPeriod.Current(timeProvider);
 
+        // The fast path, and the friendly one: it is what a serial double-submit hits, and it refuses
+        // before PreviewAsync's read. It is NOT the guard — two concurrent submissions can both pass it,
+        // which is what IX_QuotaIncreaseRequests_PendingPerUserPeriod is for (#147); the insert below
+        // translates that index's violation into this same 409.
         if (await dbContext.QuotaIncreaseRequests.AnyAsync(
             r => r.UserId == subject.UserId
                 && r.PeriodYear == period.Year
@@ -315,8 +319,7 @@ public sealed class QuotaRequestService(
                 && r.StatusType == QuotaRequestStatusType.Pending,
             cancellationToken))
         {
-            throw new ConflictException(
-                $"User {subject.UserId} already has a pending quota increase request for {period}. It must be approved or rejected before another can be submitted.");
+            throw new ConflictException(AlreadyPending(subject.UserId, period));
         }
 
         // Live resolution, not the stored allocation row: the row is whatever the last resolution wrote,
@@ -362,7 +365,7 @@ public sealed class QuotaRequestService(
         // them. One transaction is the cheaper price.)
         await using var transaction = await BeginTransactionIfNoneAsync(cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await InsertAsync(subject.UserId, period, cancellationToken);
 
         _ = await audit.LogAsync(
             AuditActions.QuotaIncreaseSubmitted,
@@ -387,6 +390,55 @@ public sealed class QuotaRequestService(
 
         return await GetProjectedAsync(entity.QuotaIncreaseRequestId, cancellationToken);
     }
+
+    /// <summary>
+    /// Identifiers a violation of the pending-per-period index carries, per provider: SQL Server names
+    /// the index ("Cannot insert duplicate key row … with unique index
+    /// 'IX_QuotaIncreaseRequests_PendingPerUserPeriod'"), SQLite names the columns ("UNIQUE constraint
+    /// failed: QuotaIncreaseRequests.UserId, …"). Matching the identifiers rather than re-querying keeps
+    /// the 409 honest whichever provider is underneath; the <c>GroupService</c> name/Entra-link indexes
+    /// are the precedent. <c>UserId</c> is enough to pick this index out on SQLite — the table's only
+    /// other unique index is on <c>QuotaIncreaseRequestUnique</c>.
+    /// </summary>
+    private static readonly string[] PendingPerUserPeriodIndexMarkers =
+        ["IX_QuotaIncreaseRequests_PendingPerUserPeriod", "QuotaIncreaseRequests.UserId"];
+
+    /// <summary>
+    /// Inserts the pending request, turning the filtered unique index's violation into the same
+    /// <c>409</c> the read-then-write check above produces serially (#147). Two concurrent submissions
+    /// from one developer — a double-clicked button, a retrying client — used to leave two pending rows
+    /// for one period, showing the same person twice in the reviewer queue and stranding whichever one
+    /// nobody approved. Precedent for adopting the database's answer rather than re-querying:
+    /// <c>QuotaAllocationService</c>'s "lost the race" path and <c>GroupService.SaveGroupAsync</c>.
+    /// </summary>
+    private async Task InsertAsync(int userId, BillingPeriod period, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException exception) when (Mentions(exception, PendingPerUserPeriodIndexMarkers))
+        {
+            throw new ConflictException(AlreadyPending(userId, period), exception);
+        }
+    }
+
+    /// <summary>True when any exception in the chain names one of <paramref name="markers"/>.</summary>
+    private static bool Mentions(Exception exception, string[] markers)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (Array.Exists(markers, marker => current.Message.Contains(marker, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string AlreadyPending(int userId, BillingPeriod period) =>
+        $"User {userId} already has a pending quota increase request for {period}. It must be approved or rejected before another can be submitted.";
 
     /// <summary>
     /// A transaction for this unit of work, or <see langword="null"/> when the caller already owns one —

--- a/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
+++ b/src/FoundryGate.Api/Services/Requests/QuotaRequestService.cs
@@ -426,8 +426,8 @@ public sealed class QuotaRequestService(
     /// the index ("Cannot insert duplicate key row … with unique index
     /// 'IX_QuotaIncreaseRequests_PendingPerUserPeriod'"), SQLite names the columns ("UNIQUE constraint
     /// failed: QuotaIncreaseRequests.UserId, …"). Matching the identifiers rather than re-querying keeps
-    /// the 409 honest whichever provider is underneath; the <c>GroupService</c> name/Entra-link indexes
-    /// are the precedent. <c>UserId</c> is enough to pick this index out on SQLite — the table's only
+    /// the 409 honest whichever provider is underneath — see <see cref="UniqueIndexViolation"/> for why
+    /// each index needs both. <c>UserId</c> is enough to pick this index out on SQLite: the table's only
     /// other unique index is on <c>QuotaIncreaseRequestUnique</c>.
     /// </summary>
     private static readonly string[] PendingPerUserPeriodIndexMarkers =
@@ -447,24 +447,10 @@ public sealed class QuotaRequestService(
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException exception) when (Mentions(exception, PendingPerUserPeriodIndexMarkers))
+        catch (DbUpdateException exception) when (UniqueIndexViolation.Mentions(exception, PendingPerUserPeriodIndexMarkers))
         {
             throw new ConflictException(AlreadyPending(userId, period), exception);
         }
-    }
-
-    /// <summary>True when any exception in the chain names one of <paramref name="markers"/>.</summary>
-    private static bool Mentions(Exception exception, string[] markers)
-    {
-        for (var current = exception; current is not null; current = current.InnerException)
-        {
-            if (Array.Exists(markers, marker => current.Message.Contains(marker, StringComparison.Ordinal)))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static string AlreadyPending(int userId, BillingPeriod period) =>

--- a/src/FoundryGate.Api/Services/Requests/RequestsServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Requests/RequestsServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using FoundryGate.Core.Requests;
+
 namespace FoundryGate.Api.Services.Requests;
 
 /// <summary>DI registration for the <c>Services/Requests</c> area. Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
@@ -6,12 +8,15 @@ public static class RequestsServiceCollectionExtensions
     /// <summary>
     /// Registers <see cref="IQuotaRequestService"/> — scoped, because it shares the request's
     /// <c>AppDbContext</c> with <c>IQuotaResolutionService</c> and <c>IAuditService</c> so an
-    /// approval's user update, allocation upsert and audit row commit together.
+    /// approval's user update, allocation upsert and audit row commit together — plus the Core rules of
+    /// this area (<see cref="RequestsCoreServiceCollectionExtensions.AddRequestsCore"/>: stale-request
+    /// expiry, which the monthly reset runs too and so cannot live in the Api).
     /// </summary>
     public static IServiceCollection AddRequestsServices(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        services.AddRequestsCore();
         services.AddScoped<IQuotaRequestService, QuotaRequestService>();
 
         return services;

--- a/src/FoundryGate.Core/Quota/IQuotaResetService.cs
+++ b/src/FoundryGate.Core/Quota/IQuotaResetService.cs
@@ -65,10 +65,17 @@ public readonly record struct QuotaResetTrigger(int? ActorUserId, string AuditAc
 /// <summary>What one <see cref="IQuotaResetService.ResetAsync"/> run did.</summary>
 /// <param name="UsersResetCount">Active users whose allocation was created or re-resolved.</param>
 /// <param name="TierSyncCount">How many of those asked <see cref="IGatewayTierSync"/> to move a subscription — zero for a scheduled reset, whose inputs have not changed since the last resolution.</param>
+/// <param name="ExpiredRequestCount">
+/// Quota increase requests left pending from an earlier period that this run closed
+/// (<see cref="Requests.IQuotaRequestExpiry"/>, #159). Usually zero; reported so an admin who ran
+/// <c>POST /quota/reset</c> and cleared six stale requests is told so, rather than having to read the
+/// audit log to find out.
+/// </param>
 /// <param name="Period">The UTC calendar month that was reset.</param>
 /// <param name="ResetDate">The instant written to every touched row's <c>ResetDate</c>.</param>
 public readonly record struct QuotaResetOutcome(
     int UsersResetCount,
     int TierSyncCount,
+    int ExpiredRequestCount,
     BillingPeriod Period,
     DateTimeOffset ResetDate);

--- a/src/FoundryGate.Core/Quota/QuotaResetService.cs
+++ b/src/FoundryGate.Core/Quota/QuotaResetService.cs
@@ -33,6 +33,17 @@ public sealed class QuotaResetService(
             .Select(u => u.UserId)
             .ToListAsync(cancellationToken);
 
+        // The queue is swept as part of the reset (#159): a request nobody reviewed before the period
+        // closed can no longer raise anything (approval refuses it), so leaving it Pending only means an
+        // admin opens a review queue every month with last month's dead entries still in it. Purely a
+        // database change with its own audit row, added to this same unit of work.
+        //
+        // Deliberately above the commit point (#204 review): its rows commit with the reset either way,
+        // but running its query after the first tier move would mean a transient database failure here
+        // discards a reset APIM has already accepted — the exact divergence CommitToken exists to close.
+        // Up here, a failure aborts before anything external has happened and costs nothing.
+        var expiredRequestCount = await requestExpiry.ExpireStaleAsync(period, cancellationToken);
+
         var resolutions = await quotaResolution.ResolveManyAsync(activeUserIds, period, cancellationToken);
         var touched = resolutions.Select(r => r.Allocation).ToList();
 
@@ -43,13 +54,6 @@ public sealed class QuotaResetService(
         // unchanged inputs moves nobody and is not a commit point (CONVENTIONS.md; #184).
         var tierSyncCount = resolutions.Count(r => r.TierSyncRequested);
         var completionToken = CommitToken.For(tierSyncCount > 0, cancellationToken);
-
-        // The queue is swept as part of the reset (#159): a request nobody reviewed before the period
-        // closed can no longer raise anything (approval refuses it), so leaving it Pending only means an
-        // admin opens a review queue every month with last month's dead entries still in it. Purely a
-        // database change with its own audit row, added to this same unit of work — no external system,
-        // so it does not move the commit point, and it rides whichever token the tier syncs decided.
-        var expiredRequestCount = await requestExpiry.ExpireStaleAsync(period, completionToken);
 
         foreach (var allocation in touched)
         {
@@ -105,7 +109,7 @@ public sealed class QuotaResetService(
             tierSyncCount,
             expiredRequestCount);
 
-        return new QuotaResetOutcome(resolutions.Count, tierSyncCount, period, now);
+        return new QuotaResetOutcome(resolutions.Count, tierSyncCount, expiredRequestCount, period, now);
     }
 
     /// <summary>Every touched row starts the period un-stopped and records when it was last resolved.</summary>

--- a/src/FoundryGate.Core/Quota/QuotaResetService.cs
+++ b/src/FoundryGate.Core/Quota/QuotaResetService.cs
@@ -1,3 +1,4 @@
+using FoundryGate.Core.Requests;
 using FoundryGate.Data;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Concurrency;
@@ -15,6 +16,7 @@ namespace FoundryGate.Core.Quota;
 public sealed class QuotaResetService(
     AppDbContext dbContext,
     IQuotaResolutionService quotaResolution,
+    IQuotaRequestExpiry requestExpiry,
     IAuditWriter audit,
     TimeProvider timeProvider,
     ILogger<QuotaResetService> logger) : IQuotaResetService
@@ -42,6 +44,13 @@ public sealed class QuotaResetService(
         var tierSyncCount = resolutions.Count(r => r.TierSyncRequested);
         var completionToken = CommitToken.For(tierSyncCount > 0, cancellationToken);
 
+        // The queue is swept as part of the reset (#159): a request nobody reviewed before the period
+        // closed can no longer raise anything (approval refuses it), so leaving it Pending only means an
+        // admin opens a review queue every month with last month's dead entries still in it. Purely a
+        // database change with its own audit row, added to this same unit of work — no external system,
+        // so it does not move the commit point, and it rides whichever token the tier syncs decided.
+        var expiredRequestCount = await requestExpiry.ExpireStaleAsync(period, completionToken);
+
         foreach (var allocation in touched)
         {
             Stamp(allocation, now);
@@ -59,6 +68,9 @@ public sealed class QuotaResetService(
             // Named for what it means to a human reading the trail, not for the seam it went through:
             // every one of these is a developer whose enforced budget moved this run.
             tierChangeCount = tierSyncCount,
+            // Zero on almost every run; carried anyway so "the queue was swept and found nothing" and
+            // "the sweep did not run" are distinguishable from the reset's own row.
+            expiredRequestCount,
         };
 
         _ = trigger.ActorUserId is { } actorUserId
@@ -86,11 +98,12 @@ public sealed class QuotaResetService(
         }
 
         logger.LogInformation(
-            "Quota reset for {Period} ({AuditAction}): {UsersResetCount} active users, {TierChangeCount} tier change(s).",
+            "Quota reset for {Period} ({AuditAction}): {UsersResetCount} active users, {TierChangeCount} tier change(s), {ExpiredRequestCount} stale request(s) closed.",
             period,
             trigger.AuditAction,
             resolutions.Count,
-            tierSyncCount);
+            tierSyncCount,
+            expiredRequestCount);
 
         return new QuotaResetOutcome(resolutions.Count, tierSyncCount, period, now);
     }

--- a/src/FoundryGate.Core/Quota/QuotaResolutionService.cs
+++ b/src/FoundryGate.Core/Quota/QuotaResolutionService.cs
@@ -343,7 +343,14 @@ public sealed class QuotaResolutionService(
             return _systemDefault!.Value;
         }
 
-        var raw = await dbContext.SystemConfigurations.AsNoTracking()
+        // Change tracker first, database second — the same rule as FindExistingAsync and
+        // LoadGroupPoliciesAsync. `PUT /config` edits this very row and then re-resolves the users who
+        // fall through to it in the same unit of work (#193); a projection query cannot see a pending
+        // change at all, so without this the re-resolution would faithfully write the OLD default back
+        // onto every default-tier developer and the config edit would appear to do nothing.
+        var raw = dbContext.SystemConfigurations.Local
+                .FirstOrDefault(c => string.Equals(c.Key, SystemConfigurationKeys.DefaultMonthlyTokenQuota, StringComparison.Ordinal))?.Value
+            ?? await dbContext.SystemConfigurations.AsNoTracking()
             .Where(c => c.Key == SystemConfigurationKeys.DefaultMonthlyTokenQuota)
             .Select(c => c.Value)
             .SingleOrDefaultAsync(cancellationToken)

--- a/src/FoundryGate.Core/Quota/QuotaResolutionService.cs
+++ b/src/FoundryGate.Core/Quota/QuotaResolutionService.cs
@@ -344,12 +344,20 @@ public sealed class QuotaResolutionService(
         }
 
         // Change tracker first, database second — the same rule as FindExistingAsync and
-        // LoadGroupPoliciesAsync. `PUT /config` edits this very row and then re-resolves the users who
-        // fall through to it in the same unit of work (#193); a projection query cannot see a pending
-        // change at all, so without this the re-resolution would faithfully write the OLD default back
-        // onto every default-tier developer and the config edit would appear to do nothing.
+        // LoadGroupPoliciesAsync, and the reason a caller can edit state and re-resolve against it in one
+        // unit of work. A projection query cannot see a pending change at all, so a caller that mutates
+        // this row through the change tracker and then re-resolves would otherwise have the OLD default
+        // written back onto every default-tier developer while still saving the new one (#193).
+        // `PUT /config` no longer relies on it — it claims the row with a conditional UPDATE, so the new
+        // value is already in the database inside its transaction by the time this runs — but the read
+        // stays, because resolution reading this key differently from how it reads allocations and group
+        // policies is what made that bug possible in the first place.
+        //
+        // OrdinalIgnoreCase, matching ConfigService's own key lookup: SQL Server's default collation is
+        // case-insensitive, so a tracked row could carry a casing an Ordinal compare would miss — and
+        // missing the tracker hit is the quiet failure, not a loud one.
         var raw = dbContext.SystemConfigurations.Local
-                .FirstOrDefault(c => string.Equals(c.Key, SystemConfigurationKeys.DefaultMonthlyTokenQuota, StringComparison.Ordinal))?.Value
+                .FirstOrDefault(c => string.Equals(c.Key, SystemConfigurationKeys.DefaultMonthlyTokenQuota, StringComparison.OrdinalIgnoreCase))?.Value
             ?? await dbContext.SystemConfigurations.AsNoTracking()
             .Where(c => c.Key == SystemConfigurationKeys.DefaultMonthlyTokenQuota)
             .Select(c => c.Value)

--- a/src/FoundryGate.Core/Requests/IQuotaRequestExpiry.cs
+++ b/src/FoundryGate.Core/Requests/IQuotaRequestExpiry.cs
@@ -1,0 +1,44 @@
+using FoundryGate.Domain.Quota;
+
+namespace FoundryGate.Core.Requests;
+
+/// <summary>
+/// Closes quota increase requests that outlived the billing period they were filed for (#159).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is in Core.</b> Two hosts have to do the same thing to the same rows: the monthly
+/// reset — which runs both from the Functions timer and from an admin's <c>POST /quota/reset</c>, via
+/// <see cref="Quota.IQuotaResetService"/> — and the Api's own
+/// <c>IQuotaRequestService.ExpireStaleAsync</c>. Core cannot reference the Api, and "what expiry means"
+/// must not fork between a timer and a button, so the rule lives here and both hosts call it
+/// (CONVENTIONS.md &#167;Solution structure).
+/// </para>
+/// <para>
+/// <b>What it does.</b> Every <c>Pending</c> request whose <c>(PeriodYear, PeriodMonth)</c> is
+/// <em>earlier</em> than the period it is given becomes <c>Rejected</c>, stamped with the run's instant
+/// and a system review note — the same shape
+/// <c>QuotaRequestService.CancelPendingForUserAsync</c> uses for a departing user's requests, because
+/// the status enum has no "Expired" state and no human decided these. <c>ReviewedByUserId</c> stays
+/// <see langword="null"/>, which is what distinguishes a lapsed request from a rejected one in the trail.
+/// A request filed for the current period is left alone, and so is one for a <em>later</em> period
+/// (nothing produces those today; expiring a request early would be worse than ignoring it).
+/// </para>
+/// <para>
+/// <b>Nothing here saves</b> (CONVENTIONS.md audit pattern): the rows and the single
+/// <c>quota.requests-expired</c> audit row are added to the caller's <c>AppDbContext</c> and commit
+/// with whatever else that unit of work is doing — for the reset, the allocations it just re-resolved.
+/// </para>
+/// </remarks>
+public interface IQuotaRequestExpiry
+{
+    /// <summary>
+    /// Marks every pending request from a closed period as <c>Rejected</c> and adds one
+    /// <c>quota.requests-expired</c> audit row carrying the count. Returns how many were closed;
+    /// <c>0</c> writes no audit row, so an ordinary reset does not leave a row a month saying nothing
+    /// happened.
+    /// </summary>
+    /// <param name="current">The period that is still open — everything strictly before it expires.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<int> ExpireStaleAsync(BillingPeriod current, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Core/Requests/QuotaRequestExpiry.cs
+++ b/src/FoundryGate.Core/Requests/QuotaRequestExpiry.cs
@@ -1,0 +1,82 @@
+using FoundryGate.Data;
+using FoundryGate.Data.Audit;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Quota;
+using FoundryGate.Domain.Requests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace FoundryGate.Core.Requests;
+
+/// <summary>
+/// Default <see cref="IQuotaRequestExpiry"/>. Scoped: shares the caller's <see cref="AppDbContext"/>,
+/// so the closed requests and the run's single audit row commit with the caller's own work. Semantics
+/// are on the interface.
+/// </summary>
+public sealed class QuotaRequestExpiry(
+    AppDbContext dbContext,
+    IAuditWriter audit,
+    TimeProvider timeProvider,
+    ILogger<QuotaRequestExpiry> logger) : IQuotaRequestExpiry
+{
+    /// <summary>
+    /// The <c>ReviewNotes</c> a lapsed request carries. Written for the developer who comes back and
+    /// asks why: it names the reason and the remedy, and the absent <c>ReviewedByUserId</c> says no
+    /// admin turned this down. Public because it is user-visible text that ends up on the wire — a UI
+    /// that wants to recognise it, and the tests that pin it, should compare against this rather than
+    /// re-typing it.
+    /// </summary>
+    public const string SystemNote =
+        "Closed automatically: the billing period this request was filed for has ended, so approving it would have raised the budget for a month that is already over. Submit a new request for the current period if the need stands.";
+
+    /// <inheritdoc />
+    public async Task<int> ExpireStaleAsync(BillingPeriod current, CancellationToken cancellationToken)
+    {
+        // Tracked, not ExecuteUpdate: the rows go into the caller's unit of work so they commit with the
+        // reset's allocations (and roll back with them), and "how many, for whom" is needed for the
+        // audit row either way. A fork's stale queue is single digits — this is not a bulk path.
+        var stale = await dbContext.QuotaIncreaseRequests
+            .Where(r => r.StatusType == QuotaRequestStatusType.Pending
+                && (r.PeriodYear < current.Year || (r.PeriodYear == current.Year && r.PeriodMonth < current.Month)))
+            .OrderBy(r => r.QuotaIncreaseRequestId)
+            .ToListAsync(cancellationToken);
+
+        if (stale.Count == 0)
+        {
+            return 0;
+        }
+
+        var now = timeProvider.GetUtcNow();
+        foreach (var request in stale)
+        {
+            // Rejected with no ReviewedByUserId — the CancelPendingForUserAsync shape. The enum has no
+            // "Expired" state, and adding one would be a schema change every read path would have to
+            // learn; the null reviewer plus the note is what tells the two apart.
+            request.StatusType = QuotaRequestStatusType.Rejected;
+            request.ReviewedDate = now;
+            request.ReviewNotes = SystemNote;
+        }
+
+        // One row for the run, not one per request: a fork that let six months of queue accumulate would
+        // otherwise bury every other action in the audit viewer. No single target, so both target fields
+        // are empty (CONVENTIONS.md). System actor: no human decided these.
+        _ = audit.AddSystem(
+            AuditActions.QuotaRequestsExpired,
+            string.Empty,
+            string.Empty,
+            new
+            {
+                expiredCount = stale.Count,
+                currentPeriodYear = current.Year,
+                currentPeriodMonth = current.Month,
+                expiredRequestIds = stale.Select(r => r.QuotaIncreaseRequestId).ToArray(),
+            });
+
+        logger.LogInformation(
+            "Closed {ExpiredCount} quota increase request(s) left pending from a period earlier than {Period}.",
+            stale.Count,
+            current);
+
+        return stale.Count;
+    }
+}

--- a/src/FoundryGate.Core/Requests/RequestsCoreServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Core/Requests/RequestsCoreServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FoundryGate.Core.Requests;
+
+/// <summary>
+/// DI registration for the <c>Core/Requests</c> area — the quota-increase-request rules more than one
+/// host needs (#119 structure, #159). Called by each host's own area extension: the Api from
+/// <c>Services/Requests/RequestsServiceCollectionExtensions.AddRequestsServices()</c>, the Functions
+/// host from <c>Services/FunctionsServiceCollectionExtensions</c> (the monthly reset expires stale
+/// requests as part of its run).
+/// </summary>
+public static class RequestsCoreServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IQuotaRequestExpiry"/> — scoped, because it shares the caller's
+    /// <c>AppDbContext</c> so its rows commit with the caller's audit row and mutation.
+    /// </summary>
+    /// <remarks>
+    /// Prerequisites the host must already have registered, exactly as for
+    /// <c>AddQuotaCore</c>: <c>AddFoundryGateData</c>'s <c>TimeProvider</c> and <c>IAuditWriter</c>.
+    /// </remarks>
+    public static IServiceCollection AddRequestsCore(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IQuotaRequestExpiry, QuotaRequestExpiry>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Data/Concurrency/UniqueIndexViolation.cs
+++ b/src/FoundryGate.Data/Concurrency/UniqueIndexViolation.cs
@@ -1,0 +1,54 @@
+namespace FoundryGate.Data.Concurrency;
+
+/// <summary>
+/// The one place "did the database reject this insert because of <em>that</em> unique index?" is
+/// answered (#204 review). A read-then-write pre-check is only ever the fast path; the index behind it
+/// is the guard, and turning its violation into the same <c>409</c> the serial path gives is what makes
+/// the two agree under concurrency.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why identifiers, not a re-query.</b> Matching the identifier the provider names in its error is
+/// what keeps the answer honest about the index that actually rejected the row: on an
+/// accent-insensitive database <c>IX_Groups_Name</c> rejects "Résumé" against "Resume", and a
+/// <c>LOWER(Name)</c> re-query would not have found the collision — turning a conflict into a 500.
+/// Identifiers are also unaffected by a localized server message, which the surrounding prose is not.
+/// </para>
+/// <para>
+/// <b>Two markers per index</b>, because the two providers name different things:
+/// SQL Server names the index ("Cannot insert duplicate key row … with unique index
+/// 'IX_Groups_Name'"), SQLite names the columns ("UNIQUE constraint failed: Groups.Name"). Pass both,
+/// so the same <c>catch</c> filter works in the test harness and in production.
+/// </para>
+/// <para>
+/// <b>Why it lives in Data</b>, next to <see cref="CommitToken"/>: the markers describe database
+/// objects, and every host that saves references this project. It started as two byte-identical copies
+/// in <c>GroupService</c> and <c>QuotaRequestService</c>, which is exactly the duplication
+/// <see cref="CommitToken"/> was extracted to end.
+/// </para>
+/// </remarks>
+public static class UniqueIndexViolation
+{
+    /// <summary>
+    /// Whether <paramref name="exception"/> — or anything in its inner-exception chain, which is where
+    /// the provider's own message lives under EF's <c>DbUpdateException</c> — names one of
+    /// <paramref name="markers"/>.
+    /// </summary>
+    /// <param name="exception">The exception a failed <c>SaveChangesAsync</c> threw.</param>
+    /// <param name="markers">Index and column identifiers that identify one index across providers.</param>
+    public static bool Mentions(Exception exception, params string[] markers)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(markers);
+
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (Array.Exists(markers, marker => current.Message.Contains(marker, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/FoundryGate.Data/Entities/QuotaIncreaseRequest.cs
+++ b/src/FoundryGate.Data/Entities/QuotaIncreaseRequest.cs
@@ -26,6 +26,15 @@ namespace FoundryGate.Data.Entities;
 // applies with no user filter and a filter that applies with no ordering advantage.
 [Index(nameof(CreatedDate))]
 [Index(nameof(UserId), nameof(StatusType))]
+
+// "One PENDING request per user per period" (#147), as a constraint rather than only as
+// QuotaRequestService's read-then-write check — two concurrent submissions (a double-clicked button, a
+// retrying client) can both pass that check and both insert. Read this attribute together with
+// QuotaIncreaseRequestConfiguration's HasFilter: the uniqueness applies ONLY to rows whose StatusType
+// is Pending, which is what lets a user accumulate a decided request per period and file a new one
+// after each decision. An unfiltered unique index here would let a developer be refused for the rest
+// of the month by their own approved request.
+[Index(nameof(UserId), nameof(PeriodYear), nameof(PeriodMonth), IsUnique = true, Name = QuotaIncreaseRequestConfiguration.PendingPerUserPeriodIndexName)]
 public class QuotaIncreaseRequest : ICreatedDate
 {
     public int QuotaIncreaseRequestId { get; set; }
@@ -73,15 +82,39 @@ public class QuotaIncreaseRequest : ICreatedDate
 }
 
 /// <summary>
-/// Three separate FKs into <see cref="User"/>. Only <see cref="QuotaIncreaseRequest.UserId"/>
+/// The filtered unique index's <c>WHERE</c> clause (an attribute cannot express one), plus the three
+/// separate FKs into <see cref="User"/>. Only <see cref="QuotaIncreaseRequest.UserId"/>
 /// is the entity's cascade path (deleting the subject user removes their requests); the requester
 /// and reviewer links stay <see cref="DeleteBehavior.NoAction"/> so deleting an admin account never
 /// cascades into unrelated users' request history.
 /// </summary>
 internal sealed class QuotaIncreaseRequestConfiguration : IEntityTypeConfiguration<QuotaIncreaseRequest>
 {
+    /// <summary>
+    /// Name of the filtered unique index declared by <see cref="QuotaIncreaseRequest"/>'s
+    /// <c>[Index]</c> attribute; referenced here so the filter lands on that index rather than
+    /// creating a second, unnamed one.
+    /// </summary>
+    internal const string PendingPerUserPeriodIndexName = "IX_QuotaIncreaseRequests_PendingPerUserPeriod";
+
+    /// <summary>
+    /// The half of that index an attribute cannot express, written identically here and in
+    /// <c>dbo/Tables/QuotaIncreaseRequests.sql</c> — <c>SchemaParityTests</c> compares the two as text.
+    /// The literal is <see cref="QuotaRequestStatusType.Pending"/>'s stored <c>int</c>: an index filter
+    /// is database text, so it cannot name the enum. Valid on SQLite too (partial indexes, and
+    /// bracket-quoted identifiers), which is what lets the test harness create the same constraint the
+    /// deployed database has.
+    /// </summary>
+    internal const string PendingStatusFilter = "[StatusType] = 0";
+
     public void Configure(EntityTypeBuilder<QuotaIncreaseRequest> builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder
+            .HasIndex([nameof(QuotaIncreaseRequest.UserId), nameof(QuotaIncreaseRequest.PeriodYear), nameof(QuotaIncreaseRequest.PeriodMonth)], PendingPerUserPeriodIndexName)
+            .HasFilter(PendingStatusFilter);
+
         builder.HasOne(r => r.User)
             .WithMany()
             .HasForeignKey(r => r.UserId)

--- a/src/FoundryGate.Database/FoundryGate.Database.sqlproj
+++ b/src/FoundryGate.Database/FoundryGate.Database.sqlproj
@@ -4,4 +4,16 @@
     <ModelCollation>1033, CI</ModelCollation>
     <TargetDatabaseSet>True</TargetDatabaseSet>
   </PropertyGroup>
+
+  <!--
+    The SDK globs **/*.sql as Build (schema) items. The pre-deployment script is DML, not schema, so it
+    has to be removed from that glob and declared as PreDeploy instead — otherwise the model build fails
+    trying to parse an UPDATE as an object definition. DacFx runs it inside the deployment transaction,
+    before any schema change, which is what lets it clear data a new constraint would otherwise reject
+    (#147: duplicate pending quota increase requests vs the new filtered unique index).
+  -->
+  <ItemGroup>
+    <Build Remove="Scripts\PreDeployment.sql" />
+    <PreDeploy Include="Scripts\PreDeployment.sql" />
+  </ItemGroup>
 </Project>

--- a/src/FoundryGate.Database/Scripts/PreDeployment.sql
+++ b/src/FoundryGate.Database/Scripts/PreDeployment.sql
@@ -1,0 +1,66 @@
+/*
+--------------------------------------------------------------------------------------------------
+Pre-deployment script — runs inside the deployment transaction, BEFORE the schema changes.
+
+Everything here must be idempotent and safe on a database at ANY earlier version, including a brand
+new empty one: DacFx runs this script on every deploy, not only on the deploy that first needs it.
+Guard each block on the object it touches actually existing.
+--------------------------------------------------------------------------------------------------
+*/
+
+/*
+#147 / #204 — dedupe before IX_QuotaIncreaseRequests_PendingPerUserPeriod is created.
+
+The new filtered unique index says a user may hold at most one Pending quota increase request per
+billing period. Until it existed the rule was enforced only by a read-then-write check in
+QuotaRequestService, which two concurrent submissions could both pass — so a fork that has been
+running may already hold exactly the duplicates the index forbids. CREATE UNIQUE INDEX would then
+fail, and because the dacpac step is part of the automatic deploy chain, that failure takes the whole
+deployment down rather than just the index.
+
+Resolution: keep the NEWEST pending request per (UserId, PeriodYear, PeriodMonth) and close the rest
+as Rejected — the same shape a lapsed request gets from the #159 sweep (Rejected, no reviewer, a
+system note saying what happened), because no human decided these either. Newest wins because it
+carries the developer's most recent justification, and it is the one they would expect to see in the
+queue.
+
+Idempotent: after it has run once there are no duplicate pending rows left, so the UPDATE matches
+nothing on every later deploy. It is also a no-op on a database that never had the bug, and on a
+brand new one (the table does not exist yet, so the guard skips it).
+*/
+IF OBJECT_ID(N'[dbo].[QuotaIncreaseRequests]', N'U') IS NOT NULL
+    AND OBJECT_ID(N'[dbo].[IX_QuotaIncreaseRequests_PendingPerUserPeriod]', N'I') IS NULL
+BEGIN
+    DECLARE @DedupedRequestCount INT;
+
+    WITH [PendingPerUserPeriod] AS
+    (
+        SELECT
+            [StatusType],
+            [ReviewedDate],
+            [ReviewNotes],
+            ROW_NUMBER() OVER (
+                PARTITION BY [UserId], [PeriodYear], [PeriodMonth]
+                -- Newest first: the most recent justification is the one worth keeping, and
+                -- QuotaIncreaseRequestId is IDENTITY so it breaks ties deterministically even when two
+                -- rows share a CreatedDate (which the race that produced them makes likely).
+                ORDER BY [CreatedDate] DESC, [QuotaIncreaseRequestId] DESC) AS [RowNumber]
+        FROM [dbo].[QuotaIncreaseRequests]
+        WHERE [StatusType] = 0 -- QuotaRequestStatusType.Pending
+    )
+    UPDATE [PendingPerUserPeriod]
+    SET
+        [StatusType] = 2, -- QuotaRequestStatusType.Rejected
+        -- No ReviewedByUserId: nobody reviewed these. Deliberately left as it was rather than set to
+        -- NULL, so a row that somehow carries one keeps it for the audit trail.
+        [ReviewedDate] = SYSDATETIMEOFFSET(),
+        [ReviewNotes] = N'Superseded by a later request (pre-deploy dedupe)'
+    WHERE [RowNumber] > 1;
+
+    SET @DedupedRequestCount = @@ROWCOUNT;
+
+    IF @DedupedRequestCount > 0
+        PRINT N'Pre-deploy: closed ' + CAST(@DedupedRequestCount AS NVARCHAR(10))
+            + N' duplicate pending quota increase request(s) so IX_QuotaIncreaseRequests_PendingPerUserPeriod can be created (#147).';
+END
+GO

--- a/src/FoundryGate.Database/dbo/Tables/QuotaIncreaseRequests.sql
+++ b/src/FoundryGate.Database/dbo/Tables/QuotaIncreaseRequests.sql
@@ -44,6 +44,13 @@ CREATE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_UserId_StatusType]
     ON [dbo].[QuotaIncreaseRequests]([UserId] ASC, [StatusType] ASC);
 GO
 
+-- One PENDING request per user per period (#147). Filtered on StatusType = 0 (Pending) so a decided
+-- request never blocks the next submission for the same month; without the filter a developer would be
+-- locked out for the rest of the period by their own approved request.
+CREATE UNIQUE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_PendingPerUserPeriod]
+    ON [dbo].[QuotaIncreaseRequests]([UserId] ASC, [PeriodYear] ASC, [PeriodMonth] ASC) WHERE ([StatusType] = 0);
+GO
+
 CREATE NONCLUSTERED INDEX [IX_QuotaIncreaseRequests_RequestedByUserId]
     ON [dbo].[QuotaIncreaseRequests]([RequestedByUserId] ASC);
 GO

--- a/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
+++ b/src/FoundryGate.Domain/Config/Contracts/ConfigContracts.cs
@@ -43,6 +43,28 @@ public record UpdateSystemConfigRequest
     [Required(AllowEmptyStrings = true)]
     [StringLength(ValidationConstants.ConfigValueMaxLength)]
     public string Value { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional optimistic-concurrency check (#170): the <c>updatedDate</c> the caller read from
+    /// <c>GET /config</c>. When supplied and it does not match the stored row, the write is refused with
+    /// <c>409</c> naming the current value, timestamp and the admin who got there first, instead of
+    /// silently overwriting them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Optional, and therefore additive: a caller that omits it keeps the original last-write-wins
+    /// behaviour. <c>SystemConfiguration</c> carries no <c>rowversion</c> — it is reference data whose
+    /// columns are all <c>[DoNotUpdate]</c>, so a real EF concurrency token would complicate the seeder
+    /// for a nine-row table — and the contention this guards against is between two humans with the
+    /// config form open, which is exactly where the caller has a timestamp to echo back.
+    /// </para>
+    /// <para>
+    /// Compared as an <em>instant</em>, not as text: <see cref="DateTimeOffset"/> equality ignores the
+    /// offset, so a client that normalizes to UTC (or a SQLite-backed test, which always reads back
+    /// <c>+00:00</c>) still matches a row SQL Server stored with a different offset.
+    /// </para>
+    /// </remarks>
+    public DateTimeOffset? ExpectedUpdatedDate { get; init; }
 }
 
 /// <summary>

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -59,6 +59,14 @@ public static class AuditActions
     /// <summary>PUT /requests/{id}/reject.</summary>
     public const string QuotaIncreaseRejected = "quota.rejected";
 
+    /// <summary>
+    /// One row per run of the stale-request sweep (#159): requests left pending past the billing period
+    /// they were filed for are closed as <c>Rejected</c> with a system note and no reviewer. Written by
+    /// the monthly reset (both the Functions timer and <c>POST /quota/reset</c>) and by the Api's
+    /// <c>ExpireStaleAsync</c>; the details carry the count and the ids, never one row per request.
+    /// </summary>
+    public const string QuotaRequestsExpired = "quota.requests-expired";
+
     // -- Keys (spec 4.5, 5.2, 5.3) --
 
     public const string KeyProvisioned = "key.provisioned";

--- a/src/FoundryGate.Domain/Quota/Contracts/QuotaContracts.cs
+++ b/src/FoundryGate.Domain/Quota/Contracts/QuotaContracts.cs
@@ -90,4 +90,14 @@ public record QuotaTierResponse(
 /// <param name="PeriodYear">Calendar year (UTC) of the period that was reset.</param>
 /// <param name="PeriodMonth">Calendar month (UTC, 1-12) of the period that was reset.</param>
 /// <param name="ResetDate">When the reset ran — also written to every touched row's <c>ResetDate</c>.</param>
-public record QuotaResetResult(int UsersResetCount, int PeriodYear, int PeriodMonth, DateTimeOffset ResetDate);
+/// <param name="ExpiredRequestCount">
+/// Quota increase requests left pending from an earlier period that this run closed as <c>Rejected</c>
+/// (#159). Usually zero; reported so an admin who clears six stale requests is told, rather than having
+/// to find it in the audit log.
+/// </param>
+public record QuotaResetResult(
+    int UsersResetCount,
+    int PeriodYear,
+    int PeriodMonth,
+    DateTimeOffset ResetDate,
+    int ExpiredRequestCount);

--- a/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
+++ b/src/FoundryGate.Domain/Requests/Contracts/QuotaIncreaseRequestContracts.cs
@@ -62,3 +62,11 @@ public record ReviewQuotaIncreaseRequest
 /// empty page.
 /// </param>
 public record QuotaRequestQuery(QuotaRequestStatusType? Status, int? UserId);
+
+/// <summary>
+/// Result of POST /requests/expire-stale (#159): how many pending requests from a closed billing
+/// period this sweep marked <c>Rejected</c>. Zero means the queue held nothing stale, in which case
+/// nothing at all was written — not even an audit row.
+/// </summary>
+/// <param name="ExpiredCount">Requests closed by this run.</param>
+public record ExpireStaleRequestsResult(int ExpiredCount);

--- a/src/FoundryGate.Functions/Services/FunctionsServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Functions/Services/FunctionsServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Azure.Core;
 using Azure.Monitor.Query;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Functions.Configuration;
 using FoundryGate.Functions.Services.Quota;
 using FoundryGate.Functions.Services.Usage;
@@ -48,6 +49,10 @@ public static class FunctionsServiceCollectionExtensions
         // is false here, at Debug.
         services.AddScoped<IGatewayTierSync, WarningGatewayTierSync>();
         services.AddQuotaCore();
+
+        // The reset also closes requests left pending past their period (#159); the rule is Core's so a
+        // timer and the admin's POST /quota/reset cannot disagree about what expiry means.
+        services.AddRequestsCore();
 
         services.AddScoped<IMonthlyResetJob, MonthlyResetJob>();
         services.AddScoped<IUsageSyncJob, UsageSyncJob>();

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/ConfigEndpointTests.cs
@@ -322,10 +322,119 @@ public class ConfigEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTest
         Assert.Equal(SystemConfigurationKeys.All.Count, await dbContext.SystemConfigurations.CountAsync());
     }
 
+    [Fact]
+    public async Task Update_with_a_matching_ExpectedUpdatedDate_succeeds()
+    {
+        // #170: the optional concurrency check passes when the caller is writing over the version it
+        // read, which is the ordinary "open the form, save it" path.
+        const string Key = SystemConfigurationKeys.ResetDayOfMonth;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var first = await PutAsync(client, Key, "4");
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        var read = await first.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions);
+
+        factory.TimeProvider.Advance(TimeSpan.FromMinutes(3));
+        var second = await PutAsync(client, Key, "5", read!.UpdatedDate);
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("5", await ValueOfAsync(Key));
+    }
+
+    [Fact]
+    public async Task Update_with_a_stale_ExpectedUpdatedDate_returns_409_naming_the_current_value_and_editor()
+    {
+        // #170: two admins with the config page open. The second one's write is refused rather than
+        // silently overwriting the first, and the 409 carries everything needed to re-decide — what the
+        // value is now, when it changed, and who changed it.
+        const string Key = SystemConfigurationKeys.ResetDayOfMonth;
+        var firstOid = Guid.NewGuid().ToString();
+        var secondOid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(firstOid, displayName: "Ada Lovelace");
+        _ = await factory.SeedUserAsync(secondOid, displayName: "Grace Hopper");
+
+        using var firstClient = factory.CreateClientAs(firstOid, isAdmin: true);
+        using var secondClient = factory.CreateClientAs(secondOid, isAdmin: true);
+
+        // Both read the same version...
+        var seen = await PutAsync(firstClient, Key, "6");
+        var stale = (await seen.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions))!.UpdatedDate;
+
+        // ...then Ada writes first.
+        factory.TimeProvider.Advance(TimeSpan.FromMinutes(1));
+        var winner = await PutAsync(firstClient, Key, "7", stale);
+        Assert.Equal(HttpStatusCode.OK, winner.StatusCode);
+
+        // Grace's save is now against a version that no longer exists.
+        factory.TimeProvider.Advance(TimeSpan.FromMinutes(1));
+        var loser = await PutAsync(secondClient, Key, "8", stale);
+
+        Assert.Equal(HttpStatusCode.Conflict, loser.StatusCode);
+        var problem = await loser.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        Assert.Contains(Key, problem!.Detail, StringComparison.Ordinal);
+        Assert.Contains("'7'", problem.Detail, StringComparison.Ordinal);
+        Assert.Contains("Ada Lovelace", problem.Detail, StringComparison.Ordinal);
+
+        // Nothing was written, and no audit row was added for the refused write.
+        Assert.Equal("7", await ValueOfAsync(Key));
+        await using var dbContext = factory.CreateDbContext();
+        var lastAudit = await dbContext.AuditLogs
+            .Where(a => a.Action == AuditActions.ConfigUpdated && a.TargetId == Key)
+            .OrderByDescending(a => a.AuditLogId)
+            .FirstAsync();
+        using var details = JsonDocument.Parse(lastAudit.Details);
+        Assert.Equal("7", details.RootElement.GetProperty("after").GetString());
+    }
+
+    [Fact]
+    public async Task Update_without_an_ExpectedUpdatedDate_is_still_last_write_wins()
+    {
+        // The field is optional and therefore additive (#170): a caller that does not send it keeps the
+        // behaviour every existing client has.
+        const string Key = SystemConfigurationKeys.ResetDayOfMonth;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        _ = await PutAsync(client, Key, "9");
+        factory.TimeProvider.Advance(TimeSpan.FromMinutes(1));
+        var response = await PutAsync(client, Key, "10");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("10", await ValueOfAsync(Key));
+    }
+
+    [Fact]
+    public async Task A_stale_ExpectedUpdatedDate_is_refused_before_the_value_is_validated()
+    {
+        // Ordering matters: a caller whose view of the row is stale has to re-read it whatever they were
+        // trying to write, so the 409 wins over the 400 the value alone would earn.
+        const string Key = SystemConfigurationKeys.ResetDayOfMonth;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var seed = await PutAsync(client, Key, "12");
+        var stale = (await seed.Content.ReadFromJsonAsync<SystemConfigEntryResponse>(JsonOptions))!.UpdatedDate
+            - TimeSpan.FromHours(1);
+
+        var response = await PutAsync(client, Key, "not-a-day", stale);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("12", await ValueOfAsync(Key));
+    }
+
     private static Task<HttpResponseMessage> PutAsync(HttpClient client, string key, string value) =>
         client.PutAsJsonAsync(
             new Uri($"{ConfigPath}/{Uri.EscapeDataString(key)}", UriKind.Relative),
             new UpdateSystemConfigRequest { Value = value });
+
+    private static Task<HttpResponseMessage> PutAsync(HttpClient client, string key, string value, DateTimeOffset expectedUpdatedDate) =>
+        client.PutAsJsonAsync(
+            new Uri($"{ConfigPath}/{Uri.EscapeDataString(key)}", UriKind.Relative),
+            new UpdateSystemConfigRequest { Value = value, ExpectedUpdatedDate = expectedUpdatedDate });
 
     private async Task<string> ValueOfAsync(string key)
     {

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestsEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestsEndpointTests.cs
@@ -503,6 +503,56 @@ public class RequestsEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTe
         Assert.Contains(nameof(ReviewQuotaIncreaseRequest.ReviewNotes), problem.Errors.Keys);
     }
 
+    [Fact]
+    public async Task ExpireStale_is_admin_only()
+    {
+        using var anonymous = factory.CreateClient();
+        using var developer = factory.CreateClientAs(Guid.NewGuid().ToString());
+
+        var path = new Uri($"{RequestsPath}/expire-stale", UriKind.Relative);
+        var asAnonymous = await anonymous.PostAsync(path, content: null);
+        var asDeveloper = await developer.PostAsync(path, content: null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, asAnonymous.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, asDeveloper.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExpireStale_closes_requests_from_a_closed_period_and_leaves_this_periods_alone()
+    {
+        // #159/#204: the sweep the monthly reset runs, reachable on its own for the window between a
+        // period ending and the next reset — where those requests are already unapprovable but still
+        // clutter the queue, and where POST /quota/reset would be a much bigger hammer.
+        var adminOid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(entraObjectId: adminOid);
+        var dev = await factory.SeedUserAsync(
+            entraObjectId: Guid.NewGuid().ToString(),
+            configure: u => u.MonthlyTokenQuota = StandardCap);
+        var other = await factory.SeedUserAsync(
+            entraObjectId: Guid.NewGuid().ToString(),
+            configure: u => u.MonthlyTokenQuota = StandardCap);
+
+        var period = BillingPeriod.Current(factory.TimeProvider);
+        var stale = await SeedRequestAsync(dev.UserId, PowerCap, periodMonth: period.Month == 1 ? 12 : period.Month - 1);
+        var live = await SeedRequestAsync(other.UserId, PowerCap);
+
+        using var client = factory.CreateClientAs(adminOid, isAdmin: true);
+        var response = await client.PostAsync(new Uri($"{RequestsPath}/expire-stale", UriKind.Relative), content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ExpireStaleRequestsResult>(JsonOptions);
+        Assert.True(result!.ExpiredCount >= 1);
+
+        await using var dbContext = factory.CreateDbContext();
+        var closed = await dbContext.QuotaIncreaseRequests.SingleAsync(r => r.QuotaIncreaseRequestId == stale.QuotaIncreaseRequestId);
+        Assert.Equal(QuotaRequestStatusType.Rejected, closed.StatusType);
+        Assert.Null(closed.ReviewedByUserId); // nobody reviewed it — that is what marks it lapsed
+        Assert.NotEmpty(closed.ReviewNotes);
+
+        var untouched = await dbContext.QuotaIncreaseRequests.SingleAsync(r => r.QuotaIncreaseRequestId == live.QuotaIncreaseRequestId);
+        Assert.Equal(QuotaRequestStatusType.Pending, untouched.StatusType);
+    }
+
     // -- Helpers --
 
     private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Config/ConfigServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Config/ConfigServiceTests.cs
@@ -1,0 +1,302 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Config;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Core.Quota;
+using FoundryGate.Data.Audit;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Config.Contracts;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Quota;
+using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Web;
+
+namespace FoundryGate.Tests.Predeployment.Api.Services.Config;
+
+/// <summary>
+/// What a <c>PUT /config</c> on <c>DefaultMonthlyTokenQuota</c> does to the developers it governs
+/// (#193): level 5 of the precedence chain moves, so everyone who falls through to it is re-resolved
+/// for the current period, in the same unit of work, and their APIM subscription follows.
+/// </summary>
+/// <remarks>
+/// The HTTP surface of <c>/config</c> (auth matrix, per-key validation, the #170 concurrency check) is
+/// covered end-to-end by <c>Api/Endpoints/ConfigEndpointTests</c>; this class is about the resolution
+/// side, which needs a recording tier sync to observe.
+/// </remarks>
+public class ConfigServiceTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 15, 12, 0, 0, TimeSpan.Zero);
+    private static readonly BillingPeriod Period = new(2026, 9);
+
+    private readonly MutableTimeProvider _clock = new(Now);
+    private readonly RecordingGatewayTierSync _tierSync = new();
+
+    [Fact]
+    public async Task Raising_the_default_moves_every_default_tier_users_allocation_and_their_gateway_tier()
+    {
+        await SeedReferenceDataAsync(); // DefaultMonthlyTokenQuota = 5,000,000 (Standard)
+        var admin = await SeedUserAsync("Admin");
+        var falls = await SeedUserAsync("Falls through", u => u.ApimSubscriptionId = "sub-falls");
+        var alsoFalls = await SeedUserAsync("Also falls through", u => u.ApimSubscriptionId = "sub-also");
+        await SeedAllocationAsync(falls, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+        await SeedAllocationAsync(alsoFalls, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+
+        var response = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        Assert.Equal(TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture), response.Value);
+
+        // The allocations moved with the config row, in one save.
+        await using var verification = CreateVerificationContext();
+        var rows = await verification.QuotaAllocations.AsNoTracking().ToDictionaryAsync(a => a.UserId);
+        Assert.Equal(TestGatewayTiers.PowerCap, rows[falls.UserId].AllocatedTokens);
+        Assert.Equal(GatewayTiers.Power, rows[falls.UserId].TierProductId);
+        Assert.Equal(QuotaLevelType.SystemDefault, rows[falls.UserId].ResolvedLevelType);
+        Assert.Equal(GatewayTiers.Power, rows[alsoFalls.UserId].TierProductId);
+
+        // And so did the gateway, once per developer whose tier actually changed.
+        Assert.Equal(
+            [(falls.UserId, GatewayTiers.Power), (alsoFalls.UserId, GatewayTiers.Power)],
+            _tierSync.Calls.OrderBy(call => call.UserId).ToList());
+    }
+
+    [Fact]
+    public async Task A_user_or_group_override_is_untouched_and_never_reaches_the_gateway()
+    {
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var pinned = await SeedUserAsync("Pinned", u =>
+        {
+            u.MonthlyTokenQuota = TestGatewayTiers.StandardCap;
+            u.ApimSubscriptionId = "sub-pinned";
+        });
+        var grouped = await SeedUserAsync("Grouped", u => u.ApimSubscriptionId = "sub-grouped");
+        await SeedGroupMembershipAsync(grouped, groupQuota: TestGatewayTiers.StandardCap);
+        await SeedAllocationAsync(pinned, TestGatewayTiers.StandardCap, QuotaLevelType.UserOverride, GatewayTiers.Standard);
+        await SeedAllocationAsync(grouped, TestGatewayTiers.StandardCap, QuotaLevelType.GroupMax, GatewayTiers.Standard);
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        // Neither user resolves to the system default, so neither is in the affected set at all.
+        await using var verification = CreateVerificationContext();
+        var rows = await verification.QuotaAllocations.AsNoTracking().ToDictionaryAsync(a => a.UserId);
+        Assert.Equal(GatewayTiers.Standard, rows[pinned.UserId].TierProductId);
+        Assert.Equal(GatewayTiers.Standard, rows[grouped.UserId].TierProductId);
+        Assert.Empty(_tierSync.Calls);
+    }
+
+    [Fact]
+    public async Task A_deactivated_user_is_not_re_resolved()
+    {
+        // Their key is revoked, so there is no subscription to move and no budget to correct — the same
+        // rule the monthly reset and GroupService apply.
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var departed = await SeedUserAsync("Departed", u =>
+        {
+            u.IsActive = false;
+            u.ApimSubscriptionId = "sub-departed";
+        });
+        await SeedAllocationAsync(departed, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        await using var verification = CreateVerificationContext();
+        var row = await verification.QuotaAllocations.AsNoTracking().SingleAsync(a => a.UserId == departed.UserId);
+        Assert.Equal(GatewayTiers.Standard, row.TierProductId);
+        Assert.Empty(_tierSync.Calls);
+    }
+
+    [Fact]
+    public async Task The_audit_row_records_how_many_developers_the_edit_moved()
+    {
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var withKey = await SeedUserAsync("With a key", u => u.ApimSubscriptionId = "sub-with");
+        var withoutKey = await SeedUserAsync("Without a key");
+        await SeedAllocationAsync(withKey, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+        await SeedAllocationAsync(withoutKey, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        var audit = Assert.Single(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.ConfigUpdated).ToListAsync());
+        using var details = JsonDocument.Parse(audit.Details);
+
+        // Three, not two: the acting admin is an active user with no override of their own, so they fall
+        // through to the system default like anyone else and are re-resolved with everybody.
+        Assert.Equal(3, details.RootElement.GetProperty("reresolvedUserCount").GetInt32());
+
+        // Only the developer with an APIM subscription can have a tier moved; the other one's allocation
+        // is corrected in SQL and there is nothing at the gateway to change.
+        Assert.Equal(1, details.RootElement.GetProperty("tierChangeCount").GetInt32());
+        Assert.Equal([(withKey.UserId, GatewayTiers.Power)], _tierSync.Calls);
+    }
+
+    [Fact]
+    public async Task Re_saving_the_same_default_re_resolves_nobody()
+    {
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var falls = await SeedUserAsync("Falls through", u => u.ApimSubscriptionId = "sub-falls");
+
+        // Same value the seed already carries. The row is still stamped (that is what the explicit
+        // UpdatedDate is for) but nothing else happens.
+        var response = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.StandardCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        Assert.Equal(admin.UserId, response.UpdatedByUserId);
+        Assert.Empty(_tierSync.Calls);
+        Assert.False(await Context.QuotaAllocations.AsNoTracking().AnyAsync(a => a.UserId == falls.UserId));
+
+        var audit = Assert.Single(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.ConfigUpdated).ToListAsync());
+        using var details = JsonDocument.Parse(audit.Details);
+        Assert.Equal(0, details.RootElement.GetProperty("reresolvedUserCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task Editing_another_key_re_resolves_nobody()
+    {
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var falls = await SeedUserAsync("Falls through", u => u.ApimSubscriptionId = "sub-falls");
+        await SeedAllocationAsync(falls, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.ResetDayOfMonth,
+            new UpdateSystemConfigRequest { Value = "7" },
+            CancellationToken.None);
+
+        Assert.Empty(_tierSync.Calls);
+        var audit = Assert.Single(await Context.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.ConfigUpdated).ToListAsync());
+        using var details = JsonDocument.Parse(audit.Details);
+        Assert.Equal(0, details.RootElement.GetProperty("reresolvedUserCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task A_default_tier_user_with_no_allocation_yet_gets_one_at_the_new_default()
+    {
+        // A developer who has not hit /me this month has no row. Skipping them would leave them to be
+        // resolved later by something reading the OLD value out of a stale cache — and it costs one
+        // insert to be right now.
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var fresh = await SeedUserAsync("Never resolved", u => u.ApimSubscriptionId = "sub-fresh");
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        await using var verification = CreateVerificationContext();
+        var row = await verification.QuotaAllocations.AsNoTracking().SingleAsync(a => a.UserId == fresh.UserId);
+        Assert.Equal(TestGatewayTiers.PowerCap, row.AllocatedTokens);
+        Assert.Equal(GatewayTiers.Power, row.TierProductId);
+        Assert.Equal(0, row.TokensUsed);
+    }
+
+    [Fact]
+    public async Task A_failed_gateway_move_fails_the_edit_and_the_config_row_is_unchanged()
+    {
+        // The whole point of doing this in one unit of work: the database must never claim a default the
+        // gateway refused to enforce.
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var falls = await SeedUserAsync("Falls through", u => u.ApimSubscriptionId = "sub-falls");
+        await SeedAllocationAsync(falls, TestGatewayTiers.StandardCap, QuotaLevelType.SystemDefault, GatewayTiers.Standard);
+        _tierSync.ThrowFor = falls.UserId;
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() => CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None));
+
+        await using var verification = CreateVerificationContext();
+        var config = await verification.SystemConfigurations.AsNoTracking()
+            .SingleAsync(c => c.Key == SystemConfigurationKeys.DefaultMonthlyTokenQuota);
+        Assert.Equal(TestGatewayTiers.StandardCap.ToString(System.Globalization.CultureInfo.InvariantCulture), config.Value);
+        Assert.Empty(await verification.AuditLogs.AsNoTracking().ToListAsync());
+    }
+
+    // -- Helpers --
+
+    private ConfigService CreateService(string oid)
+    {
+        List<Claim> claims = [new Claim(ClaimConstants.Oid, oid), new Claim(ClaimConstants.Roles, RoleNames.Admin)];
+        var identity = new ClaimsIdentity(claims, "TestAuth", nameType: ClaimConstants.Name, roleType: ClaimConstants.Roles);
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
+        var auditWriter = new AuditWriter(Context, _clock);
+
+        return new ConfigService(
+            Context,
+            new SystemConfigValidator(TestGatewayTiers.Mapper()),
+            new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), _tierSync, NullLogger<QuotaResolutionService>.Instance),
+            accessor,
+            new AuditService(Context, auditWriter, accessor),
+            _clock);
+    }
+
+    private async Task<User> SeedUserAsync(string displayName, Action<User>? configure = null)
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = displayName,
+            Email = $"{Guid.NewGuid():N}@contoso.test",
+        };
+        configure?.Invoke(user);
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task SeedAllocationAsync(User user, long? allocated, QuotaLevelType level, string tier)
+    {
+        var allocation = new QuotaAllocation
+        {
+            UserId = user.UserId,
+            PeriodYear = Period.Year,
+            PeriodMonth = Period.Month,
+            AllocatedTokens = allocated,
+            TokensUsed = 0,
+            ResolvedLevelType = level,
+            TierProductId = tier,
+        };
+        Context.QuotaAllocations.Add(allocation);
+        await Context.SaveChangesAsync();
+        Context.Entry(allocation).State = EntityState.Detached;
+    }
+
+    private async Task SeedGroupMembershipAsync(User user, long? groupQuota, bool isUnlimited = false)
+    {
+        var group = new Group
+        {
+            Name = $"g-{Guid.NewGuid():N}",
+            MonthlyTokenQuota = groupQuota,
+            IsUnlimited = isUnlimited,
+        };
+        Context.Groups.Add(group);
+        await Context.SaveChangesAsync();
+
+        Context.GroupMembers.Add(new GroupMember { GroupId = group.GroupId, UserId = user.UserId });
+        await Context.SaveChangesAsync();
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Config/ConfigServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Config/ConfigServiceTests.cs
@@ -8,6 +8,7 @@ using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Config.Contracts;
 using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
 using FoundryGate.Domain.Quota;
 using FoundryGate.Tests.Predeployment.Data;
 using FoundryGate.Tests.Predeployment.Support;
@@ -233,6 +234,112 @@ public class ConfigServiceTests : InMemoryDatabaseTest
             .SingleAsync(c => c.Key == SystemConfigurationKeys.DefaultMonthlyTokenQuota);
         Assert.Equal(TestGatewayTiers.StandardCap.ToString(System.Globalization.CultureInfo.InvariantCulture), config.Value);
         Assert.Empty(await verification.AuditLogs.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task A_concurrent_write_between_the_check_and_the_claim_loses_with_a_409()
+    {
+        // #170/#204: the read-then-compare is only the friendly refusal. The guard is the conditional
+        // UPDATE … WHERE UpdatedDate = @expected, and this is the only way to reach it — the competing
+        // write lands from a second context in the window after our pre-check has passed and before our
+        // statement runs, which is exactly the race two admins with the config form open produce.
+        await SeedReferenceDataAsync();
+        var first = await SeedUserAsync("Ada Lovelace");
+        var second = await SeedUserAsync("Grace Hopper");
+
+        var seen = await CreateService(first.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.ResetDayOfMonth,
+            new UpdateSystemConfigRequest { Value = "4" },
+            CancellationToken.None);
+
+        var raced = false;
+        CommandInterceptor.BeforeExecuting = sql =>
+        {
+            if (raced || !sql.Contains("UPDATE \"SystemConfigurations\"", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            // Set before the competing write, whose own UPDATE re-enters this callback.
+            raced = true;
+            using var winner = CreateVerificationContext();
+            _ = winner.SystemConfigurations
+                .Where(c => c.Key == SystemConfigurationKeys.ResetDayOfMonth)
+                .ExecuteUpdate(setters => setters
+                    .SetProperty(c => c.Value, "9")
+                    .SetProperty(c => c.UpdatedDate, seen.UpdatedDate.AddMinutes(1)));
+        };
+
+        var exception = await Assert.ThrowsAsync<ConflictException>(() =>
+            CreateService(second.EntraObjectId).UpdateAsync(
+                SystemConfigurationKeys.ResetDayOfMonth,
+                new UpdateSystemConfigRequest { Value = "5", ExpectedUpdatedDate = seen.UpdatedDate },
+                CancellationToken.None));
+
+        CommandInterceptor.BeforeExecuting = _ => { };
+        Assert.True(raced);
+        Assert.Contains(SystemConfigurationKeys.ResetDayOfMonth, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("'9'", exception.Message, StringComparison.Ordinal);
+
+        // The loser wrote nothing — not the value, and not a config.updated row claiming it did. The row
+        // reads "4" rather than the winner's "9" because the harness's second context shares this one's
+        // connection, so the competing write joined the service's transaction and rolled back with it.
+        // That is a property of the harness, not of the service: what this test proves is that the claim
+        // saw a changed UpdatedDate, matched no row, and refused — which the 409 above establishes.
+        await using var verification = CreateVerificationContext();
+        var row = await verification.SystemConfigurations.AsNoTracking()
+            .SingleAsync(c => c.Key == SystemConfigurationKeys.ResetDayOfMonth);
+        Assert.Equal("4", row.Value);
+        Assert.NotEqual("5", row.Value);
+        Assert.Single(await verification.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.ConfigUpdated).ToListAsync());
+    }
+
+    [Fact]
+    public async Task The_affected_user_query_selects_exactly_the_users_the_resolution_chain_puts_on_the_system_default()
+    {
+        // #204 review: SystemDefaultUserIdsAsync re-expresses levels 1-4 of the precedence chain as a SQL
+        // predicate, while QuotaResolutionService.ResolveLevelAsync owns the same rule in C#. They agree
+        // today and nothing else keeps them agreeing — add a level, or change "any unlimited group wins",
+        // and both halves would still return a plausible list. One user per level, none with an existing
+        // allocation (so the union's stale-row half is empty and this compares the predicates alone).
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var userUnlimited = await SeedUserAsync("User unlimited", u => u.IsUnlimited = true);
+        var userOverride = await SeedUserAsync("User override", u => u.MonthlyTokenQuota = TestGatewayTiers.PowerCap);
+        var groupUnlimited = await SeedUserAsync("Group unlimited");
+        var groupMax = await SeedUserAsync("Group max");
+        var systemDefault = await SeedUserAsync("System default");
+        var deactivated = await SeedUserAsync("Deactivated", u => u.IsActive = false);
+        await SeedGroupMembershipAsync(groupUnlimited, groupQuota: null, isUnlimited: true);
+        await SeedGroupMembershipAsync(groupMax, groupQuota: TestGatewayTiers.PowerCap);
+
+        // What the chain itself says, asked user by user through the service that owns the rule.
+        var resolution = new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), _tierSync, NullLogger<QuotaResolutionService>.Instance);
+        var byTheChain = new List<int>();
+        foreach (var user in new[] { admin, userUnlimited, userOverride, groupUnlimited, groupMax, systemDefault, deactivated })
+        {
+            if ((await resolution.PreviewAsync(user.UserId, CancellationToken.None)).Level == QuotaLevelType.SystemDefault
+                && user.IsActive)
+            {
+                byTheChain.Add(user.UserId);
+            }
+        }
+
+        Assert.Equal([admin.UserId, systemDefault.UserId], byTheChain);
+
+        _ = await CreateService(admin.EntraObjectId).UpdateAsync(
+            SystemConfigurationKeys.DefaultMonthlyTokenQuota,
+            new UpdateSystemConfigRequest { Value = TestGatewayTiers.PowerCap.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+            CancellationToken.None);
+
+        // What the SQL predicate picked: exactly the users that now hold a re-resolved allocation.
+        await using var verification = CreateVerificationContext();
+        var byTheQuery = await verification.QuotaAllocations.AsNoTracking()
+            .OrderBy(a => a.UserId)
+            .Select(a => a.UserId)
+            .ToListAsync();
+
+        Assert.Equal(byTheChain, byTheQuery);
     }
 
     // -- Helpers --

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Dashboard/DashboardServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Dashboard/DashboardServiceTests.cs
@@ -54,9 +54,13 @@ public class DashboardServiceTests : InMemoryDatabaseTest
     [Fact]
     public async Task Pending_request_count_ignores_reviewed_requests()
     {
+        // Two *different* requesters for the two pending rows: one user can hold at most one pending
+        // request per period (#147's filtered unique index), and their decided rows are what this is
+        // actually checking are excluded from the count.
         var user = await SeedUserAsync("Requester");
+        var other = await SeedUserAsync("Other requester");
         await SeedRequestAsync(user, QuotaRequestStatusType.Pending);
-        await SeedRequestAsync(user, QuotaRequestStatusType.Pending);
+        await SeedRequestAsync(other, QuotaRequestStatusType.Pending);
         await SeedRequestAsync(user, QuotaRequestStatusType.Approved);
         await SeedRequestAsync(user, QuotaRequestStatusType.Rejected);
 

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Entra/EntraUserSyncServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Entra/EntraUserSyncServiceTests.cs
@@ -8,6 +8,7 @@ using FoundryGate.Api.Services.Lifecycle;
 using FoundryGate.Api.Services.Requests;
 using FoundryGate.Api.Services.Security;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
@@ -447,7 +448,7 @@ public class EntraUserSyncServiceTests : InMemoryDatabaseTest
             tierMapper,
             new NullGatewayTierSync(NullLogger<NullGatewayTierSync>.Instance),
             NullLogger<QuotaResolutionService>.Instance);
-        var quotaRequests = new QuotaRequestService(Context, quotaResolution, tierMapper, accessor, audit, _timeProvider);
+        var quotaRequests = new QuotaRequestService(Context, quotaResolution, new QuotaRequestExpiry(Context, writer, _timeProvider, NullLogger<QuotaRequestExpiry>.Instance), tierMapper, accessor, audit, _timeProvider);
         var lifecycle = new UserLifecycleService(
             Context,
             quotaResolution,

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Lifecycle/UserLifecycleServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Lifecycle/UserLifecycleServiceTests.cs
@@ -10,6 +10,7 @@ using FoundryGate.Api.Services.Lifecycle;
 using FoundryGate.Api.Services.Requests;
 using FoundryGate.Api.Services.Security;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
@@ -602,7 +603,7 @@ public class UserLifecycleServiceTests : InMemoryDatabaseTest
 
         // The real request service: deactivation delegates its pending-request cancellation to it
         // (#148's CancelPendingForUserAsync), so a stub would prove nothing about what commits.
-        var quotaRequests = new QuotaRequestService(Context, quotaResolution, tierMapper, accessor, audit, _timeProvider);
+        var quotaRequests = new QuotaRequestService(Context, quotaResolution, new QuotaRequestExpiry(Context, writer, _timeProvider, NullLogger<QuotaRequestExpiry>.Instance), tierMapper, accessor, audit, _timeProvider);
 
         return new UserLifecycleService(
             Context,

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Quota/QuotaAllocationServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Quota/QuotaAllocationServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Api.Services.Quota;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
@@ -441,7 +442,7 @@ public class QuotaAllocationServiceTests : InMemoryDatabaseTest
         var accessor = new CurrentUserAccessor(new FixedHttpContextAccessor(httpContext), Context);
         var auditWriter = new AuditWriter(Context, _clock);
         resolution ??= new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), _tierSync, NullLogger<QuotaResolutionService>.Instance);
-        var reset = new QuotaResetService(Context, resolution, auditWriter, _clock, NullLogger<QuotaResetService>.Instance);
+        var reset = new QuotaResetService(Context, resolution, new QuotaRequestExpiry(Context, auditWriter, _clock, NullLogger<QuotaRequestExpiry>.Instance), auditWriter, _clock, NullLogger<QuotaResetService>.Instance);
 
         return new QuotaAllocationService(
             Context,

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Requests/QuotaRequestServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Requests/QuotaRequestServiceTests.cs
@@ -5,6 +5,7 @@ using FoundryGate.Api.Services.Audit;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Api.Services.Requests;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
@@ -953,6 +954,86 @@ public class QuotaRequestServiceTests : InMemoryDatabaseTest
         Assert.Equal(0, await CreateService(ada.EntraObjectId).CancelPendingForUserAsync(ada.UserId, "Account deprovisioned.", CancellationToken.None));
     }
 
+    // -- Stale requests (#159) --
+
+    [Fact]
+    public async Task ApproveAsync_refuses_a_request_filed_for_a_closed_period()
+    {
+        // #159: approval re-resolves the CURRENT period, so approving a request filed for an earlier one
+        // would raise this month's budget while the row and the response still reported the month it was
+        // filed for. Refused, and nothing about the subject moves.
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var ada = await SeedUserAsync("Ada", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var request = await SeedRequestAsync(ada, ada, new BillingPeriod(2026, 7), requestedQuota: TestGatewayTiers.PowerCap);
+
+        var exception = await Assert.ThrowsAsync<ConflictException>(() =>
+            CreateService(admin.EntraObjectId, isAdmin: true).ApproveAsync(
+                request.QuotaIncreaseRequestId, new ReviewQuotaIncreaseRequest(), CancellationToken.None));
+
+        Assert.Contains("2026-07", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("2026-09", exception.Message, StringComparison.Ordinal);
+
+        await using var verification = CreateVerificationContext();
+        var row = await verification.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == request.QuotaIncreaseRequestId);
+        Assert.Equal(QuotaRequestStatusType.Pending, row.StatusType);
+        Assert.Equal(TestGatewayTiers.StandardCap, (await verification.Users.AsNoTracking().SingleAsync(u => u.UserId == ada.UserId)).MonthlyTokenQuota);
+        Assert.Empty(_tierSync.Calls);
+    }
+
+    [Fact]
+    public async Task RejectAsync_still_works_on_a_request_from_a_closed_period()
+    {
+        // The other half of the rule: an admin must always be able to clear the queue by hand, and a
+        // rejection changes nobody's budget, so there is nothing for the period to make wrong.
+        await SeedReferenceDataAsync();
+        var admin = await SeedUserAsync("Admin");
+        var ada = await SeedUserAsync("Ada", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var request = await SeedRequestAsync(ada, ada, new BillingPeriod(2026, 7), requestedQuota: TestGatewayTiers.PowerCap);
+
+        var result = await CreateService(admin.EntraObjectId, isAdmin: true).RejectAsync(
+            request.QuotaIncreaseRequestId, new ReviewQuotaIncreaseRequest { ReviewNotes = "Too late." }, CancellationToken.None);
+
+        Assert.Equal(QuotaRequestStatusType.Rejected, result.StatusType);
+        Assert.Equal(admin.UserId, result.ReviewedByUserId);
+    }
+
+    [Fact]
+    public async Task ExpireStaleAsync_closes_the_old_pending_requests_saves_and_audits_once()
+    {
+        await SeedReferenceDataAsync();
+        var ada = await SeedUserAsync("Ada", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var bob = await SeedUserAsync("Bob", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var stale = await SeedRequestAsync(ada, ada, new BillingPeriod(2026, 7), requestedQuota: TestGatewayTiers.PowerCap);
+        var live = await SeedRequestAsync(bob, bob, Period, requestedQuota: TestGatewayTiers.PowerCap);
+
+        var expired = await CreateService(ada.EntraObjectId).ExpireStaleAsync(CancellationToken.None);
+
+        Assert.Equal(1, expired);
+        await using var verification = CreateVerificationContext();
+        var rows = await verification.QuotaIncreaseRequests.AsNoTracking().ToDictionaryAsync(r => r.QuotaIncreaseRequestId);
+        Assert.Equal(QuotaRequestStatusType.Rejected, rows[stale.QuotaIncreaseRequestId].StatusType);
+        Assert.Equal(QuotaRequestStatusType.Pending, rows[live.QuotaIncreaseRequestId].StatusType);
+
+        var audit = Assert.Single(await verification.AuditLogs.AsNoTracking().ToListAsync());
+        Assert.Equal(AuditActions.QuotaRequestsExpired, audit.Action);
+        Assert.Null(audit.ActorUserId);
+    }
+
+    [Fact]
+    public async Task ExpireStaleAsync_with_nothing_stale_saves_nothing()
+    {
+        await SeedReferenceDataAsync();
+        var ada = await SeedUserAsync("Ada", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        _ = await SeedRequestAsync(ada, ada, Period, requestedQuota: TestGatewayTiers.PowerCap);
+
+        var expired = await CreateService(ada.EntraObjectId).ExpireStaleAsync(CancellationToken.None);
+
+        Assert.Equal(0, expired);
+        await using var verification = CreateVerificationContext();
+        Assert.Empty(await verification.AuditLogs.AsNoTracking().ToListAsync());
+    }
+
     // -- Helpers --
 
     /// <summary>Real accessor + real audit + real resolution over this test's context, as DI would wire them per request.</summary>
@@ -972,6 +1053,7 @@ public class QuotaRequestServiceTests : InMemoryDatabaseTest
         return new QuotaRequestService(
             Context,
             new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), _tierSync, NullLogger<QuotaResolutionService>.Instance),
+            new QuotaRequestExpiry(Context, auditWriter, _clock, NullLogger<QuotaRequestExpiry>.Instance),
             TestGatewayTiers.Mapper(),
             accessor,
             new AuditService(Context, auditWriter, accessor),

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Requests/QuotaRequestServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Requests/QuotaRequestServiceTests.cs
@@ -222,6 +222,58 @@ public class QuotaRequestServiceTests : InMemoryDatabaseTest
     }
 
     [Fact]
+    public async Task SubmitAsync_turns_a_concurrent_duplicate_into_the_same_409_the_pre_check_gives()
+    {
+        // #147: the AnyAsync above is the fast path, not the guard — two submissions racing each other
+        // both pass it. The competing row is inserted from a second context in the window between the
+        // check and our INSERT, which is the only way to reach the filtered unique index from here; the
+        // service must answer with the same ConflictException a serial double-submit gets, not a 500.
+        await SeedReferenceDataAsync();
+        var me = await SeedUserAsync("Ada", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var body = new SubmitQuotaIncreaseRequest { RequestedQuota = TestGatewayTiers.PowerCap, Justification = Justification };
+
+        var raced = false;
+        CommandInterceptor.BeforeExecuting = sql =>
+        {
+            if (raced || !sql.Contains("INSERT INTO \"QuotaIncreaseRequests\"", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            raced = true;
+            using var winner = CreateVerificationContext();
+            winner.QuotaIncreaseRequests.Add(new QuotaIncreaseRequest
+            {
+                UserId = me.UserId,
+                RequestedByUserId = me.UserId,
+                PeriodYear = Period.Year,
+                PeriodMonth = Period.Month,
+                CurrentQuota = TestGatewayTiers.StandardCap,
+                RequestedQuota = TestGatewayTiers.PowerCap,
+                Justification = Justification,
+                StatusType = QuotaRequestStatusType.Pending,
+            });
+            winner.SaveChanges();
+        };
+
+        var exception = await Assert.ThrowsAsync<ConflictException>(() =>
+            CreateService(me.EntraObjectId).SubmitAsync(body, CancellationToken.None));
+
+        CommandInterceptor.BeforeExecuting = _ => { };
+        Assert.Contains("already has a pending quota increase request for 2026-09", exception.Message, StringComparison.Ordinal);
+        Assert.True(raced);
+
+        // Nothing of the refused submission committed — no request row, and no audit row claiming one was
+        // filed. (The competing row is gone too: the harness's second context shares this one's
+        // connection, so its insert joined the service's transaction and rolled back with it. That is a
+        // property of the harness, not of the service — QuotaIncreaseRequestIndexTests proves the
+        // constraint itself across two independently-saving contexts.)
+        await using var verify = CreateVerificationContext();
+        Assert.Empty(await verify.QuotaIncreaseRequests.AsNoTracking().Where(r => r.UserId == me.UserId).ToListAsync());
+        Assert.Empty(await verify.AuditLogs.AsNoTracking().Where(a => a.Action == AuditActions.QuotaIncreaseSubmitted).ToListAsync());
+    }
+
+    [Fact]
     public async Task SubmitAsync_allows_a_new_request_once_the_previous_one_was_decided()
     {
         await SeedReferenceDataAsync();

--- a/src/FoundryGate.Tests.Predeployment/Api/Services/Users/UserServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Services/Users/UserServiceTests.cs
@@ -10,6 +10,7 @@ using FoundryGate.Api.Services.Security;
 using FoundryGate.Api.Services.Users;
 using FoundryGate.Core.Configuration;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Common;
@@ -177,12 +178,12 @@ public class UserServiceTests : InMemoryDatabaseTest
         var quotaAllocations = new QuotaAllocationService(
             Context,
             quotaResolution,
-            new QuotaResetService(Context, quotaResolution, writer, _timeProvider, NullLogger<QuotaResetService>.Instance),
+            new QuotaResetService(Context, quotaResolution, new QuotaRequestExpiry(Context, writer, _timeProvider, NullLogger<QuotaRequestExpiry>.Instance), writer, _timeProvider, NullLogger<QuotaResetService>.Instance),
             tierMapper,
             accessor,
             _timeProvider,
             NullLogger<QuotaAllocationService>.Instance);
-        var quotaRequests = new QuotaRequestService(Context, quotaResolution, tierMapper, accessor, audit, _timeProvider);
+        var quotaRequests = new QuotaRequestService(Context, quotaResolution, new QuotaRequestExpiry(Context, writer, _timeProvider, NullLogger<QuotaRequestExpiry>.Instance), tierMapper, accessor, audit, _timeProvider);
         var lifecycle = new UserLifecycleService(
             Context,
             quotaResolution,

--- a/src/FoundryGate.Tests.Predeployment/Core/Configuration/GatewayInfraBindingTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Core/Configuration/GatewayInfraBindingTests.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using FoundryGate.Core.Configuration;
@@ -14,28 +16,42 @@ namespace FoundryGate.Tests.Predeployment.Core.Configuration;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <b>It binds rather than asserts.</b> The names are scraped from the bicep, turned into a
+/// configuration source with generated values, bound to a real <see cref="GatewayOptions"/>, and then
+/// checked <em>by reflection</em> that each scraped member came back carrying what was put in. Hardcoded
+/// property assertions would not have tested the alarm's own claim: the configuration binder ignores
+/// keys it cannot place, so a `Gateway__Whatever` with nothing behind it binds silently to nothing
+/// (#204 review).
+/// </para>
+/// <para>
 /// Deliberately reads the bicep as <em>text</em>, the way <c>SchemaParityTests</c> reads the .sql
 /// files: no Bicep/ARM tooling is available in every environment these tests run in, and the repo's
 /// own style (<c>{ name: 'Key', value: … }</c>, one per line) parses cleanly. A hand-authored line that
 /// strays from that style shows up as a missing variable, not as a silent pass.
 /// </para>
 /// <para>
-/// The <c>__</c> → <c>:</c> step below is what
-/// <c>AddEnvironmentVariables()</c> does at runtime; it is applied here rather than by setting real
-/// process environment variables, which would be shared mutable state across a parallel test run. What
-/// this test guards is the <em>names</em>, not that separator.
+/// The <c>__</c> → <c>:</c> step below is what <c>AddEnvironmentVariables()</c> does at runtime; it is
+/// applied here rather than by setting real process environment variables, which would be shared
+/// mutable state across a parallel test run. What this test guards is the <em>names</em>, not that
+/// separator.
 /// </para>
 /// </remarks>
 public class GatewayInfraBindingTests
 {
     private const string Section = "Gateway";
 
+    /// <summary>How many items a scraped collection setting is given, so ordering is provable.</summary>
+    private const int CollectionSize = 2;
+
     /// <summary>
-    /// <c>{ name: 'Gateway__Something', … }</c>, including the interpolated array form
-    /// <c>'Gateway__FoundryAccountNames__${i}'</c>.
+    /// The three shapes a <c>Gateway</c> setting takes in the bicep:
+    /// <c>Gateway__Member</c> (scalar), <c>Gateway__Member__${i}</c> (list of scalars, e.g.
+    /// <c>FoundryAccountNames</c>), and <c>Gateway__Member__${i}__Field</c> (list of objects — the form
+    /// <c>Gateway__ModelAliases__${i}__Tier</c> takes in #211 and <c>Gateway__Tiers__${i}__ProductId</c>
+    /// would take under #201).
     /// </summary>
     private static readonly Regex GatewaySettingRegex = new(
-        @"name:\s*'(?<name>Gateway__[A-Za-z0-9_]+(?:__\$\{i\})?)'",
+        @"name:\s*'Gateway__(?<member>[A-Za-z0-9]+)(?<collection>__\$\{i\})?(?:__(?<field>[A-Za-z0-9]+))?'",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -53,55 +69,83 @@ public class GatewayInfraBindingTests
     [Fact]
     public void Every_Gateway_variable_infra_sets_binds_to_a_GatewayOptions_member()
     {
-        var names = GatewayVariableNames();
-        Assert.NotEmpty(names);
+        var settings = ScrapeGatewaySettings(ControlPlaneBicep());
+        Assert.NotEmpty(settings);
 
-        // One distinct sentinel per variable, so a member bound from the wrong key is a value mismatch
-        // rather than an accidental pass. The array form gets two entries, which also proves pool order
-        // survives binding.
-        var values = new Dictionary<string, string?>(StringComparer.Ordinal);
-        foreach (var name in names)
-        {
-            if (name.EndsWith("__${i}", StringComparison.Ordinal))
-            {
-                var prefix = ConfigurationKey(name[..^"__${i}".Length]);
-                values[$"{prefix}:0"] = "primary-account";
-                values[$"{prefix}:1"] = "secondary-account";
-            }
-            else
-            {
-                values[ConfigurationKey(name)] = SentinelFor(name);
-            }
-        }
+        BindAndVerify(settings);
+    }
 
-        var options = new ConfigurationBuilder()
-            .AddInMemoryCollection(values)
-            .Build()
-            .GetSection(Section)
-            .Get<GatewayOptions>();
+    /// <summary>
+    /// The same machinery over settings the bicep does not carry yet, so the alarm is known to
+    /// understand the shapes arriving next (#204 review): the list-of-objects form that #211's
+    /// <c>Gateway__ModelAliases__${i}__*</c> and #201's <c>Gateway__Tiers__${i}__*</c> use. Bound against
+    /// <see cref="GatewayOptions.Tiers"/>, which exists today, so this is a real end-to-end proof that a
+    /// nested-field key reaches its property — not just that the regex matches it.
+    /// </summary>
+    [Fact]
+    public void A_nested_field_setting_binds_to_the_list_items_property()
+    {
+        var settings = ScrapeGatewaySettings(
+            """
+              { name: 'Gateway__Tiers__${i}__ProductId', value: tier.name }
+              { name: 'Gateway__Tiers__${i}__DisplayName', value: tier.displayName }
+              { name: 'Gateway__Tiers__${i}__MonthlyTokenQuota', value: string(tier.monthlyTokenQuota) }
+            """);
 
-        Assert.NotNull(options);
-        Assert.Equal("Gateway__SubscriptionId", options.SubscriptionId);
-        Assert.Equal("Gateway__ResourceGroup", options.ResourceGroup);
-        Assert.Equal("Gateway__ApimName", options.ApimName);
-        Assert.Equal("Gateway__ApimGatewayUrl", options.ApimGatewayUrl);
-        Assert.Equal("Gateway__LogAnalyticsWorkspaceId", options.LogAnalyticsWorkspaceId);
-        Assert.Equal("Gateway__LogAnalyticsWorkspaceResourceId", options.LogAnalyticsWorkspaceResourceId);
-        Assert.Equal("Gateway__KeyEncryptionKeyUri", options.KeyEncryptionKeyUri);
-        Assert.Equal(["primary-account", "secondary-account"], options.FoundryAccountNames);
+        var setting = Assert.Single(settings);
+        Assert.Equal(nameof(GatewayOptions.Tiers), setting.Member);
+        Assert.True(setting.IsCollection);
+        Assert.Equal([nameof(GatewayTier.ProductId), nameof(GatewayTier.DisplayName), nameof(GatewayTier.MonthlyTokenQuota)], setting.Fields);
+
+        var options = BindAndVerify(settings);
+        Assert.Equal(CollectionSize, options.Tiers.Count);
+    }
+
+    /// <summary>
+    /// The alarm's own claim, tested. The configuration binder ignores keys it cannot place, so the
+    /// failure mode this guards against is entirely silent: without these two cases green, the checks
+    /// above would pass on a bicep that sets a variable nothing reads (#204 review).
+    /// </summary>
+    [Theory]
+    [InlineData("Gateway__Whatever", "no settable `Whatever` property")]
+    [InlineData("Gateway__ApimName__${i}", "an indexed list")]
+    [InlineData("Gateway__Tiers__${i}__NoSuchField", "no settable `NoSuchField` property")]
+    public void The_binding_check_fails_when_infra_sets_something_nothing_binds(string name, string expectedInMessage)
+    {
+        var settings = ScrapeGatewaySettings($"  {{ name: '{name}', value: whatever }}");
+
+        var failure = Assert.ThrowsAny<Exception>(() => BindAndVerify(settings));
+
+        Assert.Contains(expectedInMessage, failure.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Gateway__SubscriptionId", "SubscriptionId", false, "")]
+    [InlineData("Gateway__FoundryAccountNames__${i}", "FoundryAccountNames", true, "")]
+    [InlineData("Gateway__ModelAliases__${i}__Tier", "ModelAliases", true, "Tier")]
+    [InlineData("Gateway__Tiers__${i}__MonthlyTokenQuota", "Tiers", true, "MonthlyTokenQuota")]
+    public void The_scrape_understands_every_shape_a_Gateway_setting_takes(string name, string member, bool isCollection, string field)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        // Pinned separately from the binding so a regex that silently stops matching one shape fails
+        // with "the scrape missed this", not with a downstream "member unaccounted for" further away
+        // from the cause. ModelAliases has no property yet (#211); parsing must still work.
+        var setting = Assert.Single(ScrapeGatewaySettings($"  {{ name: '{name}', value: whatever }}"));
+
+        Assert.Equal(member, setting.Member);
+        Assert.Equal(isCollection, setting.IsCollection);
+        Assert.Equal(field.Length == 0 ? [] : new[] { field }, setting.Fields);
     }
 
     [Fact]
     public void Every_GatewayOptions_member_is_either_set_by_infra_or_listed_as_deliberately_absent()
     {
-        var fromInfra = GatewayVariableNames()
-            .Select(name => name.EndsWith("__${i}", StringComparison.Ordinal) ? name[..^"__${i}".Length] : name)
-            .Select(name => name["Gateway__".Length..])
+        var fromInfra = ScrapeGatewaySettings(ControlPlaneBicep())
+            .Select(setting => setting.Member)
             .ToHashSet(StringComparer.Ordinal);
 
-        var unaccounted = typeof(GatewayOptions)
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.CanWrite)
+        var unaccounted = BindableMembers()
             .Select(property => property.Name)
             .Where(name => !fromInfra.Contains(name) && !NotSetByInfra.ContainsKey(name))
             .ToList();
@@ -119,13 +163,13 @@ public class GatewayInfraBindingTests
     [Fact]
     public void Infra_does_not_emit_the_tier_table()
     {
-        // Pinned so the note in reference/configuration.mdx stays honest: if infra ever
-        // starts emitting Gateway__Tiers__*, the appsettings-is-the-source guidance (#201) has to change with
-        // it, and the binder appends configured list items to a pre-populated list rather than replacing
-        // it — so having both sources at once would silently duplicate every tier.
+        // Pinned so the note in reference/configuration.mdx stays honest: if infra ever starts emitting
+        // Gateway__Tiers__*, the appsettings-is-the-source guidance (#201) has to change with it, and the
+        // binder appends configured list items to a pre-populated list rather than replacing it — so
+        // having both sources at once would silently duplicate every tier.
         Assert.DoesNotContain(
-            GatewayVariableNames(),
-            name => name.StartsWith("Gateway__Tiers", StringComparison.Ordinal));
+            ScrapeGatewaySettings(ControlPlaneBicep()),
+            setting => setting.Member == nameof(GatewayOptions.Tiers));
     }
 
     [Fact]
@@ -133,14 +177,216 @@ public class GatewayInfraBindingTests
     {
         // The Api reads the addressing, the Functions host reads the workspace GUID, and both bind the
         // whole section — so a Gateway variable added for one host must reach the other or the two
-        // disagree about the same gateway.
+        // disagree about the same gateway. Comments are stripped first: a `//` line naming the two
+        // identifiers would otherwise satisfy this without either host being passed anything (#204 review).
         foreach (var module in new[] { "containerApp", "functionApp" })
         {
-            var declaration = ModuleDeclaration(module);
+            var declaration = WithoutComments(ModuleDeclaration(module));
             Assert.Contains("sharedAppConfig", declaration, StringComparison.Ordinal);
             Assert.Contains("foundryAccountConfig", declaration, StringComparison.Ordinal);
         }
     }
+
+    // -- The machinery --
+
+    /// <summary>One <c>Gateway</c> member as the bicep sets it: scalar, list of scalars, or list of objects with these fields.</summary>
+    private sealed record GatewaySetting(string Member, bool IsCollection, IReadOnlyList<string> Fields);
+
+    /// <summary>
+    /// Every distinct <c>Gateway__*</c> member in <paramref name="bicep"/>, with the shape its keys
+    /// imply. A member is a list of objects when its keys carry a field after the index, a list of
+    /// scalars when they carry the index alone, and a scalar otherwise.
+    /// </summary>
+    private static List<GatewaySetting> ScrapeGatewaySettings(string bicep)
+    {
+        var byMember = new Dictionary<string, (bool IsCollection, List<string> Fields)>(StringComparer.Ordinal);
+
+        foreach (Match match in GatewaySettingRegex.Matches(bicep))
+        {
+            var member = match.Groups["member"].Value;
+            var isCollection = match.Groups["collection"].Success;
+            var field = match.Groups["field"].Success ? match.Groups["field"].Value : null;
+
+            Assert.True(
+                field is null || isCollection,
+                $"Gateway__{member}__{field} names a nested field with no `__${{i}}` index between them. " +
+                "That is an object-valued member, a shape this test does not model — teach ScrapeGatewaySettings " +
+                "about it in the same change that adds it, rather than letting it bind unchecked.");
+
+            if (!byMember.TryGetValue(member, out var shape))
+            {
+                shape = (isCollection, []);
+                byMember[member] = shape;
+            }
+
+            Assert.Equal(shape.IsCollection, isCollection);
+            if (field is not null && !shape.Fields.Contains(field, StringComparer.Ordinal))
+            {
+                shape.Fields.Add(field);
+            }
+        }
+
+        return [.. byMember
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new GatewaySetting(pair.Key, pair.Value.IsCollection, pair.Value.Fields))];
+    }
+
+    /// <summary>
+    /// Turns <paramref name="settings"/> into a configuration source with a distinct generated value per
+    /// key, binds it, and asserts by reflection that every member came back carrying exactly those
+    /// values. Distinct values matter: a member bound from the wrong key is then a value mismatch rather
+    /// than an accidental pass.
+    /// </summary>
+    private static GatewayOptions BindAndVerify(IReadOnlyList<GatewaySetting> settings)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        foreach (var setting in settings)
+        {
+            var property = PropertyFor(setting);
+
+            if (!setting.IsCollection)
+            {
+                values[$"{Section}:{setting.Member}"] = Generated(property.PropertyType, setting.Member, index: 0);
+                continue;
+            }
+
+            var elementType = ElementType(property, setting);
+            for (var index = 0; index < CollectionSize; index++)
+            {
+                if (setting.Fields.Count == 0)
+                {
+                    values[$"{Section}:{setting.Member}:{index}"] = Generated(elementType, setting.Member, index);
+                    continue;
+                }
+
+                foreach (var field in setting.Fields)
+                {
+                    var fieldProperty = FieldPropertyFor(setting, elementType, field);
+                    values[$"{Section}:{setting.Member}:{index}:{field}"] = Generated(fieldProperty.PropertyType, $"{setting.Member}.{field}", index);
+                }
+            }
+        }
+
+        var options = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build()
+            .GetSection(Section)
+            .Get<GatewayOptions>();
+
+        Assert.NotNull(options);
+
+        foreach (var setting in settings)
+        {
+            var property = PropertyFor(setting);
+            var bound = property.GetValue(options);
+
+            if (!setting.IsCollection)
+            {
+                Assert.Equal(
+                    Convert.ChangeType(Generated(property.PropertyType, setting.Member, index: 0), property.PropertyType, CultureInfo.InvariantCulture),
+                    bound);
+                continue;
+            }
+
+            var items = Assert.IsAssignableFrom<IList>(bound);
+            Assert.True(
+                items.Count == CollectionSize,
+                $"infra sets Gateway__{setting.Member}__${{i}} but only {items.Count} of {CollectionSize} items reached " +
+                $"GatewayOptions.{setting.Member}. The binder ignores keys it cannot place, so this is a name or shape mismatch.");
+
+            var elementType = ElementType(property, setting);
+            for (var index = 0; index < CollectionSize; index++)
+            {
+                if (setting.Fields.Count == 0)
+                {
+                    Assert.Equal(Generated(elementType, setting.Member, index), items[index]);
+                    continue;
+                }
+
+                foreach (var field in setting.Fields)
+                {
+                    var fieldProperty = FieldPropertyFor(setting, elementType, field);
+                    Assert.Equal(
+                        Convert.ChangeType(Generated(fieldProperty.PropertyType, $"{setting.Member}.{field}", index), fieldProperty.PropertyType, CultureInfo.InvariantCulture),
+                        fieldProperty.GetValue(items[index]));
+                }
+            }
+        }
+
+        return options;
+    }
+
+    private static PropertyInfo PropertyFor(GatewaySetting setting)
+    {
+        var property = BindableMembers().FirstOrDefault(candidate => candidate.Name == setting.Member);
+
+        Assert.True(
+            property is not null,
+            $"infra/modules/control-plane.bicep sets Gateway__{setting.Member}… but GatewayOptions has no settable " +
+            $"`{setting.Member}` property, so the configuration binder drops it silently and the control plane never " +
+            "sees the value. Add the property (and document it in reference/configuration.mdx), or remove the bicep line (#108).");
+
+        return property!;
+    }
+
+    private static Type ElementType(PropertyInfo property, GatewaySetting setting)
+    {
+        Assert.True(
+            property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(List<>),
+            $"infra sets Gateway__{setting.Member}__${{i}} — an indexed list — but GatewayOptions.{setting.Member} " +
+            $"is {property.PropertyType.Name}, which the binder cannot fill from indexed keys.");
+
+        return property.PropertyType.GetGenericArguments()[0];
+    }
+
+    private static PropertyInfo FieldPropertyFor(GatewaySetting setting, Type elementType, string field)
+    {
+        var property = elementType.GetProperty(field, BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.True(
+            property is not null && property.CanWrite,
+            $"infra sets Gateway__{setting.Member}__${{i}}__{field} but {elementType.Name} has no settable `{field}` " +
+            "property, so that field of every item binds to nothing (#108).");
+
+        return property!;
+    }
+
+    /// <summary>
+    /// A distinct, type-appropriate value for one key — a sentinel naming the member for strings, and a
+    /// deterministic number or flag for the primitives a tier table uses.
+    /// </summary>
+    private static string Generated(Type type, string label, int index)
+    {
+        var target = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (target == typeof(string))
+        {
+            return $"{label}#{index}";
+        }
+
+        if (target == typeof(bool))
+        {
+            return index % 2 == 0 ? "true" : "false";
+        }
+
+        if (target == typeof(long) || target == typeof(int) || target == typeof(short))
+        {
+            // Deterministic and distinct per (label, index); stays inside int range for narrower types.
+            var seed = Math.Abs(label.Aggregate(7, (accumulated, character) => (accumulated * 31) + character) % 1_000) + 1;
+            return ((seed * 1_000) + index).ToString(CultureInfo.InvariantCulture);
+        }
+
+        Assert.Fail(
+            $"No generated value for {target.Name} (Gateway:{label}). Teach GatewayInfraBindingTests.Generated about " +
+            "the type in the same change that adds the setting, so the binding is still actually verified.");
+        return string.Empty;
+    }
+
+    private static IEnumerable<PropertyInfo> BindableMembers() =>
+        typeof(GatewayOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanWrite);
 
     /// <summary>
     /// The text of one <c>module &lt;name&gt; '…' { … }</c> declaration: from its <c>module</c> keyword to
@@ -162,16 +408,9 @@ public class GatewayInfraBindingTests
         return bicep[start..next];
     }
 
-    private static string ConfigurationKey(string environmentVariableName) =>
-        environmentVariableName.Replace("__", ":", StringComparison.Ordinal);
-
-    private static string SentinelFor(string environmentVariableName) => environmentVariableName;
-
-    private static List<string> GatewayVariableNames() =>
-        [.. GatewaySettingRegex.Matches(ControlPlaneBicep())
-            .Select(match => match.Groups["name"].Value)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)];
+    /// <summary>Drops <c>//</c> line comments, so prose mentioning an identifier cannot stand in for code using it.</summary>
+    private static string WithoutComments(string bicep) =>
+        Regex.Replace(bicep, @"//[^\n]*", string.Empty);
 
     private static string ControlPlaneBicep() =>
         File.ReadAllText(Path.Combine(FindRepoRoot(), "infra", "modules", "control-plane.bicep"));

--- a/src/FoundryGate.Tests.Predeployment/Core/Configuration/GatewayInfraBindingTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Core/Configuration/GatewayInfraBindingTests.cs
@@ -1,0 +1,190 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using FoundryGate.Core.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace FoundryGate.Tests.Predeployment.Core.Configuration;
+
+/// <summary>
+/// Drift alarm between <see cref="GatewayOptions"/> and the <c>Gateway__*</c> environment variables
+/// <c>infra/modules/control-plane.bicep</c> actually sets — the question #108 asks and that nothing
+/// answered automatically: infra is the source of truth for the names, so a rename on either side, a
+/// variable infra sets that nothing binds, or a member the control plane needs that infra never
+/// supplies, should all fail here rather than in a deployed environment.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately reads the bicep as <em>text</em>, the way <c>SchemaParityTests</c> reads the .sql
+/// files: no Bicep/ARM tooling is available in every environment these tests run in, and the repo's
+/// own style (<c>{ name: 'Key', value: … }</c>, one per line) parses cleanly. A hand-authored line that
+/// strays from that style shows up as a missing variable, not as a silent pass.
+/// </para>
+/// <para>
+/// The <c>__</c> → <c>:</c> step below is what
+/// <c>AddEnvironmentVariables()</c> does at runtime; it is applied here rather than by setting real
+/// process environment variables, which would be shared mutable state across a parallel test run. What
+/// this test guards is the <em>names</em>, not that separator.
+/// </para>
+/// </remarks>
+public class GatewayInfraBindingTests
+{
+    private const string Section = "Gateway";
+
+    /// <summary>
+    /// <c>{ name: 'Gateway__Something', … }</c>, including the interpolated array form
+    /// <c>'Gateway__FoundryAccountNames__${i}'</c>.
+    /// </summary>
+    private static readonly Regex GatewaySettingRegex = new(
+        @"name:\s*'(?<name>Gateway__[A-Za-z0-9_]+(?:__\$\{i\})?)'",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Members of <see cref="GatewayOptions"/> that infra deliberately does <b>not</b> set, and why.
+    /// Anything not listed here must appear in the bicep — that is the whole point of the section.
+    /// </summary>
+    private static readonly Dictionary<string, string> NotSetByInfra = new(StringComparer.Ordinal)
+    {
+        [nameof(GatewayOptions.Tiers)] =
+            "the tier table ships in both hosts' appsettings.json, mirroring infra/main.bicep's quotaTiers " +
+            "parameter (GatewayOptionsTiersTests and FunctionsAppSettingsTests keep the three in step). A fork " +
+            "that overrides quotaTiers at deploy time must still edit Gateway:Tiers by hand — see issue #201.",
+    };
+
+    [Fact]
+    public void Every_Gateway_variable_infra_sets_binds_to_a_GatewayOptions_member()
+    {
+        var names = GatewayVariableNames();
+        Assert.NotEmpty(names);
+
+        // One distinct sentinel per variable, so a member bound from the wrong key is a value mismatch
+        // rather than an accidental pass. The array form gets two entries, which also proves pool order
+        // survives binding.
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var name in names)
+        {
+            if (name.EndsWith("__${i}", StringComparison.Ordinal))
+            {
+                var prefix = ConfigurationKey(name[..^"__${i}".Length]);
+                values[$"{prefix}:0"] = "primary-account";
+                values[$"{prefix}:1"] = "secondary-account";
+            }
+            else
+            {
+                values[ConfigurationKey(name)] = SentinelFor(name);
+            }
+        }
+
+        var options = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build()
+            .GetSection(Section)
+            .Get<GatewayOptions>();
+
+        Assert.NotNull(options);
+        Assert.Equal("Gateway__SubscriptionId", options.SubscriptionId);
+        Assert.Equal("Gateway__ResourceGroup", options.ResourceGroup);
+        Assert.Equal("Gateway__ApimName", options.ApimName);
+        Assert.Equal("Gateway__ApimGatewayUrl", options.ApimGatewayUrl);
+        Assert.Equal("Gateway__LogAnalyticsWorkspaceId", options.LogAnalyticsWorkspaceId);
+        Assert.Equal("Gateway__LogAnalyticsWorkspaceResourceId", options.LogAnalyticsWorkspaceResourceId);
+        Assert.Equal("Gateway__KeyEncryptionKeyUri", options.KeyEncryptionKeyUri);
+        Assert.Equal(["primary-account", "secondary-account"], options.FoundryAccountNames);
+    }
+
+    [Fact]
+    public void Every_GatewayOptions_member_is_either_set_by_infra_or_listed_as_deliberately_absent()
+    {
+        var fromInfra = GatewayVariableNames()
+            .Select(name => name.EndsWith("__${i}", StringComparison.Ordinal) ? name[..^"__${i}".Length] : name)
+            .Select(name => name["Gateway__".Length..])
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unaccounted = typeof(GatewayOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanWrite)
+            .Select(property => property.Name)
+            .Where(name => !fromInfra.Contains(name) && !NotSetByInfra.ContainsKey(name))
+            .ToList();
+
+        Assert.True(
+            unaccounted.Count == 0,
+            $"GatewayOptions member(s) {string.Join(", ", unaccounted)} are neither set by " +
+            "infra/modules/control-plane.bicep nor listed in NotSetByInfra. Every member of the Gateway " +
+            "section has to come from somewhere on a deployed host: either add a `Gateway__{name}` line to " +
+            "the bicep's sharedAppConfig (and to reference/configuration.mdx), or add it to NotSetByInfra " +
+            "with the reason it does not need one. Silently binding nothing is how a control plane ends up " +
+            "addressing a gateway it cannot reach (#108).");
+    }
+
+    [Fact]
+    public void Infra_does_not_emit_the_tier_table()
+    {
+        // Pinned so the note in reference/configuration.mdx stays honest: if infra ever
+        // starts emitting Gateway__Tiers__*, the appsettings-is-the-source guidance (#201) has to change with
+        // it, and the binder appends configured list items to a pre-populated list rather than replacing
+        // it — so having both sources at once would silently duplicate every tier.
+        Assert.DoesNotContain(
+            GatewayVariableNames(),
+            name => name.StartsWith("Gateway__Tiers", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Both_hosts_get_the_same_gateway_configuration()
+    {
+        // The Api reads the addressing, the Functions host reads the workspace GUID, and both bind the
+        // whole section — so a Gateway variable added for one host must reach the other or the two
+        // disagree about the same gateway.
+        foreach (var module in new[] { "containerApp", "functionApp" })
+        {
+            var declaration = ModuleDeclaration(module);
+            Assert.Contains("sharedAppConfig", declaration, StringComparison.Ordinal);
+            Assert.Contains("foundryAccountConfig", declaration, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The text of one <c>module &lt;name&gt; '…' { … }</c> declaration: from its <c>module</c> keyword to
+    /// the next top-level <c>module</c>/<c>output</c>, which is all this needs and avoids matching braces
+    /// with a regex.
+    /// </summary>
+    private static string ModuleDeclaration(string moduleName)
+    {
+        var bicep = ControlPlaneBicep().Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        var start = bicep.IndexOf($"\nmodule {moduleName} '", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find `module {moduleName} '…'` in infra/modules/control-plane.bicep.");
+
+        var next = new[] { bicep.IndexOf("\nmodule ", start + 1, StringComparison.Ordinal), bicep.IndexOf("\noutput ", start + 1, StringComparison.Ordinal) }
+            .Where(index => index >= 0)
+            .DefaultIfEmpty(bicep.Length)
+            .Min();
+
+        return bicep[start..next];
+    }
+
+    private static string ConfigurationKey(string environmentVariableName) =>
+        environmentVariableName.Replace("__", ":", StringComparison.Ordinal);
+
+    private static string SentinelFor(string environmentVariableName) => environmentVariableName;
+
+    private static List<string> GatewayVariableNames() =>
+        [.. GatewaySettingRegex.Matches(ControlPlaneBicep())
+            .Select(match => match.Groups["name"].Value)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)];
+
+    private static string ControlPlaneBicep() =>
+        File.ReadAllText(Path.Combine(FindRepoRoot(), "infra", "modules", "control-plane.bicep"));
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "FoundryGate.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root (FoundryGate.sln) from the test output directory.");
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Core/Quota/QuotaResetServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Core/Quota/QuotaResetServiceTests.cs
@@ -143,7 +143,11 @@ public class QuotaResetServiceTests : InMemoryDatabaseTest
         var stale = await SeedRequestAsync(dev, new BillingPeriod(2026, 9), QuotaRequestStatusType.Pending);
         var live = await SeedRequestAsync(dev, Period, QuotaRequestStatusType.Pending);
 
-        _ = await CreateService().ResetAsync(QuotaResetTrigger.Scheduled(), CancellationToken.None);
+        var outcome = await CreateService().ResetAsync(QuotaResetTrigger.Scheduled(), CancellationToken.None);
+
+        // Reported on the outcome, not only in the audit log: an admin who runs POST /quota/reset and
+        // clears six stale requests should be told so by the response (#204 review).
+        Assert.Equal(1, outcome.ExpiredRequestCount);
 
         await using var verify = CreateVerificationContext();
         var rows = await verify.QuotaIncreaseRequests.AsNoTracking().ToDictionaryAsync(r => r.QuotaIncreaseRequestId);

--- a/src/FoundryGate.Tests.Predeployment/Core/Quota/QuotaResetServiceTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Core/Quota/QuotaResetServiceTests.cs
@@ -1,8 +1,10 @@
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Quota;
+using FoundryGate.Domain.Requests;
 using FoundryGate.Tests.Predeployment.Data;
 using FoundryGate.Tests.Predeployment.Support;
 using Microsoft.EntityFrameworkCore;
@@ -131,14 +133,75 @@ public class QuotaResetServiceTests : InMemoryDatabaseTest
         Assert.Equal(admin.UserId, audit.ActorUserId);
     }
 
+    [Fact]
+    public async Task A_reset_closes_requests_left_pending_from_a_closed_period_in_the_same_unit_of_work()
+    {
+        // #159: the reset is what keeps the review queue from accumulating a dead entry a month. The
+        // sweep's own audit row is separate from the reset's, and both commit with the allocations.
+        await SeedReferenceDataAsync();
+        var dev = await SeedUserAsync("Dev", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        var stale = await SeedRequestAsync(dev, new BillingPeriod(2026, 9), QuotaRequestStatusType.Pending);
+        var live = await SeedRequestAsync(dev, Period, QuotaRequestStatusType.Pending);
+
+        _ = await CreateService().ResetAsync(QuotaResetTrigger.Scheduled(), CancellationToken.None);
+
+        await using var verify = CreateVerificationContext();
+        var rows = await verify.QuotaIncreaseRequests.AsNoTracking().ToDictionaryAsync(r => r.QuotaIncreaseRequestId);
+        Assert.Equal(QuotaRequestStatusType.Rejected, rows[stale].StatusType);
+        Assert.Null(rows[stale].ReviewedByUserId);
+        Assert.Equal(QuotaRequestStatusType.Pending, rows[live].StatusType);
+
+        var audits = await verify.AuditLogs.AsNoTracking().ToListAsync();
+        var sweep = Assert.Single(audits, a => a.Action == AuditActions.QuotaRequestsExpired);
+        Assert.Contains("\"expiredCount\":1", sweep.Details, StringComparison.Ordinal);
+        var reset = Assert.Single(audits, a => a.Action == AuditActions.QuotaMonthlyReset);
+        Assert.Contains("\"expiredRequestCount\":1", reset.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_reset_with_nothing_stale_writes_only_its_own_audit_row()
+    {
+        await SeedReferenceDataAsync();
+        var dev = await SeedUserAsync("Dev", u => u.MonthlyTokenQuota = TestGatewayTiers.StandardCap);
+        _ = await SeedRequestAsync(dev, Period, QuotaRequestStatusType.Pending);
+
+        _ = await CreateService().ResetAsync(QuotaResetTrigger.Scheduled(), CancellationToken.None);
+
+        var audit = Assert.Single(await Context.AuditLogs.AsNoTracking().ToListAsync());
+        Assert.Equal(AuditActions.QuotaMonthlyReset, audit.Action);
+        Assert.Contains("\"expiredRequestCount\":0", audit.Details, StringComparison.Ordinal);
+    }
+
+    private async Task<int> SeedRequestAsync(User user, BillingPeriod period, QuotaRequestStatusType status)
+    {
+        var request = new QuotaIncreaseRequest
+        {
+            UserId = user.UserId,
+            RequestedByUserId = user.UserId,
+            PeriodYear = period.Year,
+            PeriodMonth = period.Month,
+            CurrentQuota = TestGatewayTiers.StandardCap,
+            RequestedQuota = TestGatewayTiers.PowerCap,
+            Justification = "Running a batch evaluation this sprint.",
+            StatusType = status,
+        };
+        Context.QuotaIncreaseRequests.Add(request);
+        await Context.SaveChangesAsync();
+        Context.Entry(request).State = EntityState.Detached;
+        return request.QuotaIncreaseRequestId;
+    }
+
     private QuotaResetService CreateService()
     {
         var resolution = new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), _tierSync, NullLogger<QuotaResolutionService>.Instance);
 
+        var auditWriter = new AuditWriter(Context, _clock);
+
         return new QuotaResetService(
             Context,
             resolution,
-            new AuditWriter(Context, _clock),
+            new QuotaRequestExpiry(Context, auditWriter, _clock, NullLogger<QuotaRequestExpiry>.Instance),
+            auditWriter,
             _clock,
             NullLogger<QuotaResetService>.Instance);
     }

--- a/src/FoundryGate.Tests.Predeployment/Core/Requests/QuotaRequestExpiryTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Core/Requests/QuotaRequestExpiryTests.cs
@@ -1,0 +1,179 @@
+using FoundryGate.Core.Requests;
+using FoundryGate.Data.Audit;
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Quota;
+using FoundryGate.Domain.Requests;
+using FoundryGate.Tests.Predeployment.Data;
+using FoundryGate.Tests.Predeployment.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FoundryGate.Tests.Predeployment.Core.Requests;
+
+/// <summary>
+/// The shared stale-request sweep (#159) at the level both hosts use it: which rows it closes, what it
+/// leaves alone, the single audit row it writes, and its no-save contract.
+/// </summary>
+public class QuotaRequestExpiryTests : InMemoryDatabaseTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 10, 1, 0, 1, 0, TimeSpan.Zero);
+    private static readonly BillingPeriod Current = new(2026, 10);
+
+    private readonly MutableTimeProvider _clock = new(Now);
+
+    [Fact]
+    public async Task A_pending_request_from_a_closed_period_becomes_rejected_with_a_system_note()
+    {
+        var dev = await SeedUserAsync();
+        var stale = await SeedRequestAsync(dev, new BillingPeriod(2026, 7), QuotaRequestStatusType.Pending);
+
+        var expired = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(1, expired);
+        var row = await Context.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == stale);
+        Assert.Equal(QuotaRequestStatusType.Rejected, row.StatusType);
+        Assert.Equal(Now, row.ReviewedDate);
+        Assert.Equal(QuotaRequestExpiry.SystemNote, row.ReviewNotes);
+
+        // No reviewer: that is what distinguishes a lapsed request from one an admin turned down, and the
+        // period it was filed for is left intact so the trail still says which month it was about.
+        Assert.Null(row.ReviewedByUserId);
+        Assert.Equal((2026, 7), (row.PeriodYear, row.PeriodMonth));
+    }
+
+    [Fact]
+    public async Task The_current_periods_pending_request_is_left_alone()
+    {
+        var dev = await SeedUserAsync();
+        var live = await SeedRequestAsync(dev, Current, QuotaRequestStatusType.Pending);
+
+        var expired = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+
+        Assert.Equal(0, expired);
+        var row = await Context.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == live);
+        Assert.Equal(QuotaRequestStatusType.Pending, row.StatusType);
+    }
+
+    [Theory]
+    [InlineData(QuotaRequestStatusType.Approved)]
+    [InlineData(QuotaRequestStatusType.Rejected)]
+    public async Task An_already_decided_request_from_a_closed_period_is_not_touched(QuotaRequestStatusType decided)
+    {
+        var dev = await SeedUserAsync();
+        var old = await SeedRequestAsync(dev, new BillingPeriod(2026, 7), decided);
+
+        var expired = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+
+        Assert.Equal(0, expired);
+        var row = await Context.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == old);
+        Assert.Equal(decided, row.StatusType);
+        Assert.Equal(string.Empty, row.ReviewNotes);
+    }
+
+    [Fact]
+    public async Task The_previous_December_expires_against_a_January_period()
+    {
+        // The comparison is (year, month) as an ordered pair, not month alone — December 2025 is earlier
+        // than January 2026 and must expire, which a naive `PeriodMonth < current.Month` would miss.
+        var dev = await SeedUserAsync();
+        var december = await SeedRequestAsync(dev, new BillingPeriod(2025, 12), QuotaRequestStatusType.Pending);
+
+        var expired = await CreateService().ExpireStaleAsync(new BillingPeriod(2026, 1), CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(1, expired);
+        Assert.Equal(
+            QuotaRequestStatusType.Rejected,
+            (await Context.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == december)).StatusType);
+    }
+
+    [Fact]
+    public async Task Many_stale_requests_produce_one_audit_row_carrying_the_count_and_the_ids()
+    {
+        var first = await SeedUserAsync();
+        var second = await SeedUserAsync();
+        var a = await SeedRequestAsync(first, new BillingPeriod(2026, 7), QuotaRequestStatusType.Pending);
+        var b = await SeedRequestAsync(first, new BillingPeriod(2026, 8), QuotaRequestStatusType.Pending);
+        var c = await SeedRequestAsync(second, new BillingPeriod(2026, 8), QuotaRequestStatusType.Pending);
+
+        var expired = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(3, expired);
+        var audit = Assert.Single(await Context.AuditLogs.AsNoTracking().ToListAsync());
+        Assert.Equal(AuditActions.QuotaRequestsExpired, audit.Action);
+        Assert.Null(audit.ActorUserId); // no human decided these
+        Assert.Equal(string.Empty, audit.TargetType);
+        Assert.Equal(string.Empty, audit.TargetId);
+        Assert.Contains("\"expiredCount\":3", audit.Details, StringComparison.Ordinal);
+        Assert.Contains($"[{a},{b},{c}]", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_sweep_that_finds_nothing_writes_no_audit_row()
+    {
+        // Otherwise every reset of every month would leave a row saying nothing happened, and the audit
+        // viewer's signal-to-noise is the whole point of one row per run.
+        _ = await SeedUserAsync();
+
+        var expired = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(0, expired);
+        Assert.Empty(await Context.AuditLogs.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Nothing_is_saved_until_the_caller_saves()
+    {
+        // The Core no-save contract: the closed rows and the audit row belong to the caller's unit of
+        // work, so a reset that fails afterwards rolls the sweep back with it.
+        var dev = await SeedUserAsync();
+        var stale = await SeedRequestAsync(dev, new BillingPeriod(2026, 7), QuotaRequestStatusType.Pending);
+
+        _ = await CreateService().ExpireStaleAsync(Current, CancellationToken.None);
+
+        await using var verify = CreateVerificationContext();
+        Assert.Equal(
+            QuotaRequestStatusType.Pending,
+            (await verify.QuotaIncreaseRequests.AsNoTracking().SingleAsync(r => r.QuotaIncreaseRequestId == stale)).StatusType);
+        Assert.Empty(await verify.AuditLogs.AsNoTracking().ToListAsync());
+    }
+
+    private QuotaRequestExpiry CreateService() =>
+        new(Context, new AuditWriter(Context, _clock), _clock, NullLogger<QuotaRequestExpiry>.Instance);
+
+    private async Task<User> SeedUserAsync()
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = "Ada Lovelace",
+            Email = $"{Guid.NewGuid():N}@contoso.test",
+        };
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task<int> SeedRequestAsync(User user, BillingPeriod period, QuotaRequestStatusType status)
+    {
+        var request = new QuotaIncreaseRequest
+        {
+            UserId = user.UserId,
+            RequestedByUserId = user.UserId,
+            PeriodYear = period.Year,
+            PeriodMonth = period.Month,
+            CurrentQuota = 5_000_000,
+            RequestedQuota = 20_000_000,
+            Justification = "Running a batch evaluation this sprint.",
+            StatusType = status,
+        };
+        Context.QuotaIncreaseRequests.Add(request);
+        await Context.SaveChangesAsync();
+        Context.Entry(request).State = EntityState.Detached;
+        return request.QuotaIncreaseRequestId;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Data/Entities/QuotaIncreaseRequestIndexTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Data/Entities/QuotaIncreaseRequestIndexTests.cs
@@ -1,0 +1,109 @@
+using FoundryGate.Data.Entities;
+using FoundryGate.Domain.Requests;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Data.Entities;
+
+/// <summary>
+/// The filtered unique index behind "one pending quota increase request per user per period" (#147),
+/// exercised against the database rather than through the service that also read-then-writes for it.
+/// </summary>
+/// <remarks>
+/// Every case here uses a <b>second context</b> for the competing insert: the service's
+/// <c>AnyAsync</c> pre-check is what a serial double-submit hits, and only a writer that never saw the
+/// first row can reach the constraint — which is exactly the concurrent submission (a double-clicked
+/// button, a retrying client) the index exists to refuse.
+/// </remarks>
+public class QuotaIncreaseRequestIndexTests : InMemoryDatabaseTest
+{
+    [Fact]
+    public async Task A_second_pending_request_for_the_same_user_and_period_is_refused()
+    {
+        var user = await SeedUserAsync();
+
+        Context.QuotaIncreaseRequests.Add(Request(user, QuotaRequestStatusType.Pending));
+        await Context.SaveChangesAsync();
+
+        await using var other = CreateVerificationContext();
+        other.QuotaIncreaseRequests.Add(Request(user, QuotaRequestStatusType.Pending));
+
+        _ = await Assert.ThrowsAsync<DbUpdateException>(() => other.SaveChangesAsync());
+    }
+
+    [Theory]
+    [InlineData(QuotaRequestStatusType.Approved)]
+    [InlineData(QuotaRequestStatusType.Rejected)]
+    public async Task A_decided_request_never_blocks_the_next_one_for_the_same_period(QuotaRequestStatusType decided)
+    {
+        // The whole reason the index is filtered. Unfiltered, a developer whose September request was
+        // approved on the 2nd could not file another one until October — and CancelPendingForUserAsync,
+        // which closes a departing user's requests as Rejected, would leave the same trap behind.
+        var user = await SeedUserAsync();
+
+        Context.QuotaIncreaseRequests.Add(Request(user, decided));
+        await Context.SaveChangesAsync();
+
+        await using var other = CreateVerificationContext();
+        other.QuotaIncreaseRequests.Add(Request(user, QuotaRequestStatusType.Pending));
+        await other.SaveChangesAsync();
+
+        Assert.Equal(2, await Context.QuotaIncreaseRequests.AsNoTracking().CountAsync(r => r.UserId == user.UserId));
+    }
+
+    [Fact]
+    public async Task Two_pending_requests_for_the_same_user_in_different_periods_are_allowed()
+    {
+        var user = await SeedUserAsync();
+
+        Context.QuotaIncreaseRequests.Add(Request(user, QuotaRequestStatusType.Pending, month: 9));
+        await Context.SaveChangesAsync();
+
+        await using var other = CreateVerificationContext();
+        other.QuotaIncreaseRequests.Add(Request(user, QuotaRequestStatusType.Pending, month: 10));
+        await other.SaveChangesAsync();
+
+        Assert.Equal(2, await Context.QuotaIncreaseRequests.AsNoTracking().CountAsync(r => r.UserId == user.UserId));
+    }
+
+    [Fact]
+    public async Task Two_users_may_both_have_a_pending_request_for_the_same_period()
+    {
+        var first = await SeedUserAsync();
+        var second = await SeedUserAsync();
+
+        Context.QuotaIncreaseRequests.Add(Request(first, QuotaRequestStatusType.Pending));
+        await Context.SaveChangesAsync();
+
+        await using var other = CreateVerificationContext();
+        other.QuotaIncreaseRequests.Add(Request(second, QuotaRequestStatusType.Pending));
+        await other.SaveChangesAsync();
+
+        Assert.Equal(2, await Context.QuotaIncreaseRequests.AsNoTracking().CountAsync());
+    }
+
+    private static QuotaIncreaseRequest Request(User user, QuotaRequestStatusType status, int month = 9) =>
+        new()
+        {
+            UserId = user.UserId,
+            RequestedByUserId = user.UserId,
+            PeriodYear = 2026,
+            PeriodMonth = month,
+            CurrentQuota = 5_000_000,
+            RequestedQuota = 20_000_000,
+            Justification = "Batch evaluation this sprint.",
+            StatusType = status,
+        };
+
+    private async Task<User> SeedUserAsync()
+    {
+        var user = new User
+        {
+            EntraObjectId = Guid.NewGuid().ToString(),
+            DisplayName = "Ada Lovelace",
+            Email = $"{Guid.NewGuid():N}@contoso.test",
+        };
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Functions/Services/Quota/MonthlyResetJobTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Functions/Services/Quota/MonthlyResetJobTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using FoundryGate.Core.Quota;
+using FoundryGate.Core.Requests;
 using FoundryGate.Data.Audit;
 using FoundryGate.Data.Entities;
 using FoundryGate.Domain.Constants;
@@ -241,7 +242,14 @@ public class MonthlyResetJobTests : InMemoryDatabaseTest
     private MonthlyResetJob CreateJob(FakeResetLock resetLock, IGatewayTierSync? tierSync = null)
     {
         var resolution = new QuotaResolutionService(Context, TestGatewayTiers.Mapper(), tierSync ?? _tierSync, NullLogger<QuotaResolutionService>.Instance);
-        var reset = new QuotaResetService(Context, resolution, new AuditWriter(Context, _clock), _clock, NullLogger<QuotaResetService>.Instance);
+        var auditWriter = new AuditWriter(Context, _clock);
+        var reset = new QuotaResetService(
+            Context,
+            resolution,
+            new QuotaRequestExpiry(Context, auditWriter, _clock, NullLogger<QuotaRequestExpiry>.Instance),
+            auditWriter,
+            _clock,
+            NullLogger<QuotaResetService>.Instance);
 
         return new MonthlyResetJob(Context, reset, resetLock, _clock, NullLogger<MonthlyResetJob>.Instance);
     }

--- a/src/FoundryGate.Tests.Predeployment/Support/RecordingCommandInterceptor.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/RecordingCommandInterceptor.cs
@@ -28,6 +28,14 @@ public sealed class RecordingCommandInterceptor : DbCommandInterceptor
     /// <summary>The exception thrown for a matching statement.</summary>
     public Exception Failure { get; set; } = new InvalidOperationException("The database connection dropped.");
 
+    /// <summary>
+    /// Runs just before each statement executes, with its SQL. Defaults to doing nothing. Where
+    /// <see cref="FailWhen"/> breaks a statement, this one lets a test <em>change the world</em> at a
+    /// chosen moment — the only way to open the read-then-write window a concurrency guard exists to
+    /// close, by inserting the competing row after a service has checked for it and before it saves.
+    /// </summary>
+    public Action<string> BeforeExecuting { get; set; } = _ => { };
+
     /// <inheritdoc />
     public override InterceptionResult<DbDataReader> ReaderExecuting(
         DbCommand command,
@@ -78,6 +86,8 @@ public sealed class RecordingCommandInterceptor : DbCommandInterceptor
     {
         ArgumentNullException.ThrowIfNull(command);
         _commands.Add(command.CommandText);
+
+        BeforeExecuting(command.CommandText);
 
         if (FailWhen(command.CommandText))
         {

--- a/src/FoundryGate.Tests.Predeployment/Web/FakeFoundryGateApiClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/FakeFoundryGateApiClient.cs
@@ -87,7 +87,7 @@ public sealed partial class FakeFoundryGateApiClient : IFoundryGateApiClient
         ApiCallResult<QuotaAllocationResponse>.Ok(WebTestData.Allocation());
 
     public ApiCallResult<QuotaResetResult> QuotaResetResult { get; set; } =
-        ApiCallResult<QuotaResetResult>.Ok(new QuotaResetResult(0, 2026, 9, DateTimeOffset.UnixEpoch));
+        ApiCallResult<QuotaResetResult>.Ok(new QuotaResetResult(0, 2026, 9, DateTimeOffset.UnixEpoch, 0));
 
     public ApiCallResult<PagedResult<QuotaIncreaseRequestResponse>> RequestsResult { get; set; } =
         ApiCallResult<PagedResult<QuotaIncreaseRequestResponse>>.Ok(WebTestData.Page<QuotaIncreaseRequestResponse>());


### PR DESCRIPTION
Six issues across config, quota requests and the gateway configuration contract. One commit per issue; each is independently reviewable.

## #182 — `CommitToken.For` instead of hand-rolled commit tokens

`GroupService` carried a private `CommitToken(bool, CancellationToken)` that *shadowed* the shared `FoundryGate.Data.Concurrency.CommitToken` type inside the very class that needed it, and `EntraGroupSyncService` still spelled the rule out as an inline ternary. Both call `CommitToken.For(...)` now. Behaviour identical — `For` is the same conditional.

## #170 — optional `ExpectedUpdatedDate` on `PUT /config/{key}`

`UpdateSystemConfigRequest` gains an optional `ExpectedUpdatedDate`. Supplied and mismatched → `409` naming the value the row holds now, when it changed, and (when it has one) the editor's display name, so a config page can say "Ada Lovelace changed this while you were editing" without another round trip. That name is a second query on the conflict path only.

The check runs **before** the per-key value validation: a caller whose view of the row is stale has to re-read it whatever they were writing, so a stale write with a bad value is the 409, not the 400. Comparison is by instant, so a UTC-normalizing client (and the SQLite harness, which always reads back `+00:00`) still matches. Omitting the field keeps last-write-wins, so the field is additive.

## #147 — filtered unique index behind one-pending-request-per-period

The `AnyAsync` pre-check had nothing behind it, so two concurrent submissions could both insert and show the same person twice in the reviewer queue. `QuotaIncreaseRequest` now declares `IX_QuotaIncreaseRequests_PendingPerUserPeriod` on `(UserId, PeriodYear, PeriodMonth)`, filtered to `[StatusType] = 0` in the co-located configuration — the half an attribute cannot express, and the half that keeps a *decided* request from locking a developer out for the rest of the month. Mirrored in `dbo/Tables/QuotaIncreaseRequests.sql`; `SchemaParityTests` already understood filtered indexes and confirms the two agree. The insert translates the violation into the same `ConflictException` the serial path gives, matching on the identifier each provider names (index name on SQL Server, columns on SQLite) — the `GroupService.SaveGroupAsync` precedent.

`DashboardServiceTests` seeded two pending rows for one user and period — a state the API never produced; it uses two requesters now.

## #159 — stale quota increase requests

Both halves of the issue's recommendation:

1. **Approval refuses a closed period** (`409` naming both periods). Approval re-resolves *today's* period, so approving a July request in September raised September's budget while the row still said July. It is the first refusal in `ApproveAsync`, before any read that can reach the gateway. Rejection stays unrestricted so an admin can always clear a queue by hand.
2. **The monthly reset sweeps the queue.** The rule is `FoundryGate.Core/Requests/QuotaRequestExpiry` — Core, because `IQuotaResetService` lives there and cannot reference the Api, and because a timer and a button must not disagree about what expiry means. Pending requests from an earlier period become `Rejected` with a system note and no reviewer (the `CancelPendingForUserAsync` shape; the enum has no "Expired" state and the null reviewer is what tells the two apart), plus one `quota.requests-expired` audit row via `IAuditWriter.AddSystem` carrying the count and ids. Nothing saves in Core: the rows join the reset's unit of work.

`IQuotaRequestService.ExpireStaleAsync(ct)` gives the Api the same sweep over its own save. No HTTP caller yet, by design.

## #193 — `PUT /config` on `DefaultMonthlyTokenQuota` re-resolves the users it affects

That key is level 5 of the precedence chain, so it changed and nobody moved: the allocation row said Power (20M) while the gateway still enforced Standard (5M), for every default-tier developer at once. `ConfigService.UpdateAsync` now finds every **active** user the default governs (no user override, no group winning at levels 3–4) union anyone whose current allocation already reads `SystemDefault`, re-resolves them via `ResolveManyAsync` in the same unit of work, and finishes on `CommitToken.For(any TierSyncRequested, ct)`. The audit row carries `reresolvedUserCount` and `tierChangeCount`.

**One prerequisite in Core**, and the crux of the change: `QuotaResolutionService.GetSystemDefaultAsync` read the key with `AsNoTracking()` and a projection, which cannot see a pending change — it would have faithfully written the OLD default back onto everyone. It checks the change tracker first now, the same "pending state first, database second" rule `FindExistingAsync` and `LoadGroupPoliciesAsync` already follow.

The affected set is a query, not a `PreviewAsync` per user: the chain is deterministic, so the level is a predicate, and a preview each would be one round trip per developer on the one path that may already have hundreds.

## #108 — `Gateway__*` binding verified, `configuration.mdx` made the truth table

**Verified.** The bicep's shared block sets eight `Gateway__*` values on the Container App *and* the Function App: `SubscriptionId`, `ResourceGroup`, `ApimName`, `ApimGatewayUrl`, `LogAnalyticsWorkspaceId`, `LogAnalyticsWorkspaceResourceId`, `KeyEncryptionKeyUri`, `FoundryAccountNames__{i}`. Every one binds to a `GatewayOptions` member today; no member is unfed except `Tiers`.

**`Tiers` is the one gap, and appsettings covers the shipped configuration.** Infra does not emit `Gateway__Tiers__*`; both hosts ship the table in their own `appsettings.json`, kept in step with each other and with `infra/main.bicep`'s `quotaTiers` **default** by existing tests. That holds until a fork *overrides* `quotaTiers` at deploy time, at which point APIM enforces caps the control plane has never heard of — filed #201.

**New drift alarm**, since "we checked once" is not a guarantee: `GatewayInfraBindingTests` reads `control-plane.bicep` as text (the `SchemaParityTests` precedent) and fails if a name drifts, if infra sets a variable nothing binds, if a new `Gateway` member arrives with no declared source, if infra starts emitting the tier table behind the appsettings guidance, or if the two host modules stop receiving the same shared block.

**Docs.** `reference/configuration.mdx` is one per-host truth table (shared / gateway addressing with a "read by" column / API-only / Functions-only) instead of an API table plus a Functions paragraph saying "the same, plus". `reference/infrastructure.md` keeps its table as the provenance view and points at configuration.mdx for meaning.

No `infra/` changes — that area belongs to another agent this wave, and nothing needed changing there for the binding itself.

## Verification

- `dotnet build FoundryGate.sln -c Release` — **0 warnings, 0 errors**
- `dotnet test FoundryGate.Tests.Predeployment` — **1286/1286 passing** (rebased on `origin/main` @ 4389c84). One full-suite run hit `MePageTests.Rotating_asks_for_confirmation_before_it_touches_the_api`, which passes on re-run and 24/24 in isolation — a sibling of the just-fixed #195 flake, filed as #203.
- `dotnet format FoundryGate.sln --verify-no-changes` — clean
- `npm run build` in `docs-site/` — 15 pages, complete

## Discovered and filed

- **#197** — `HealthEndpointTests` readiness test passes only when no SQL Server is reachable locally. Reproduced on `main` with no local changes: it overrides the connection string via `ConfigureAppConfiguration`, which CONVENTIONS.md explicitly says does not reach bound configuration under minimal hosting, so the 503 comes from the real connection string being unreachable rather than from the override.
- **#199** — `PUT /config` on `DefaultMonthlyTokenQuota` is synchronous; a fork with thousands of default-tier developers turns one edit into thousands of ARM calls on a request thread. Worth deciding alongside #180.
- **#201** — infra should emit `Gateway__Tiers__*` (see #108 above). Note in the issue: the binder *appends* list items, so the shipped appsettings tiers must be emptied in the same change or every tier duplicates.
- **#203** — the `MePageTests` sibling flake.

## For the reviewer

- **#147, index placement.** The columns and uniqueness are an `[Index]` attribute; only `HasFilter` is in the configuration. That splits one index across two places, where the `Groups.EntraGroupId` precedent put the whole thing in the configuration — but it is what CONVENTIONS.md asks for ("annotations first; configuration only for what annotations can't express"), and the attribute carries a comment telling the reader to read it together with the filter, because a `IsUnique = true` that is not actually globally unique is the misreading worth preventing. Happy to move it wholesale to the configuration if you prefer the Group shape.
- **#159, no `Expired` status.** Expired requests are `Rejected` with a null `ReviewedByUserId` and a system note, reusing the `CancelPendingForUserAsync` shape. A fourth enum value would be more honest but every read path, filter and UI would have to learn it; the null reviewer already distinguishes them.
- **#193, the union.** The affected set includes users whose *current allocation* says `SystemDefault` even if the chain has since moved them off it. That means a config edit can correct one stale row belonging to a user the default no longer governs. It is a correction, it costs one row, and the audit count records it — but it does widen the blast radius of a config edit slightly.
- **#108, the reflection test.** `Every_GatewayOptions_member_is_either_set_by_infra_or_listed_as_deliberately_absent` will fail if someone adds a `GatewayOptions` property without deciding where it comes from — including the `ModelAliases` work in flight on another branch. That is the alarm working as intended (a new `Gateway` member with no source is exactly #108's bug), and the failure message says what to do, but it is a deliberate cross-branch tripwire rather than a silent addition.
- `RecordingCommandInterceptor` gains a `BeforeExecuting` hook. Where `FailWhen` breaks a statement, this changes the world at a chosen moment — the only way to open a read-then-write window from a test. Used once, by #147's race test.

Closes #182
Closes #193
Closes #147
Closes #159
Closes #170
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtuGhG69SaSuVfx92RwwNk
