### PR TITLE
Admin UI: provision models and manage allowed models per tier

### DIFF
--- a/docs-site/src/content/docs/architecture/overview.mdx
+++ b/docs-site/src/content/docs/architecture/overview.mdx
@@ -169,6 +169,21 @@ product's policy carries that tier's budget and TPM cap, and changing a develope
 quota means moving their subscription between products. Subscription *suspension* is
 reserved for deactivation and offboarding — not quota exhaustion.
 
+**Which models a tier may use is enforced in the same place.** Each tier product carries a
+model alias map — an APIM named value holding `{ alias: { deployment, backend, provider } }`
+— and a policy fragment that runs *before* `llm-token-limit` rewrites the alias a developer
+pinned (`sonnet`, `haiku`, `gpt`) to the real Foundry deployment and routes it at the right
+backend. The map **is** the allowlist: an alias a tier does not list is refused with
+`403 model_not_permitted`, ahead of the quota policy, so a blocked model costs the developer
+nothing. Because it lives in a named value rather than in policy text, admins edit it from
+the **Models &amp; access** page (`/models`) through the APIM Management API — granting a tier
+a model, or re-pointing an alias at a newer deployment, takes effect without redeploying a
+policy or an infrastructure template. The API validates before it writes: an alias must be
+lower-case and url-safe, and it must point at a deployment the configured Foundry accounts
+actually have — in *every* account when it routes at the multi-region Anthropic pool, because
+the pool sends a throttled request to another region and a region missing the deployment would
+turn a `429` into a `404`.
+
 The usage-sync Function still runs, but as **reconciliation**, not enforcement. It is a
 .NET isolated worker on a Flex Consumption plan — scale-to-zero, so it costs nothing between
 ticks — reading the gateway's own log with the Function App's managed identity. The query it

--- a/docs-site/src/content/docs/getting-started/why-foundrygate.mdx
+++ b/docs-site/src/content/docs/getting-started/why-foundrygate.mdx
@@ -69,6 +69,7 @@ That works fine when you have three engineers sharing a dev environment. It brea
 | Quota increase workflow | ❌ None | ✅ Submit → admin approves → quota applied |
 | Per-developer usage visibility | ❌ Aggregate only | ✅ Dashboard + audit log per user |
 | Model deployment management | ❌ Portal only | ✅ Claude models are set up by the infrastructure deploy; admins manage OpenAI model deployments from the FoundryGate UI |
+| Which models a team may use | ❌ Everything on the deployment, or nothing | ✅ Admins choose which models each budget tier is allowed to use, from the FoundryGate UI — anything else is refused at the gateway |
 | Deployment-level rate limits (TPM/RPM) | ⚠️ Shared ceiling, 429s passed to callers | ⚠️ Mitigated — backend pools + circuit breakers reroute around saturated deployments; the platform ceiling itself remains |
 
 ## How it works

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -481,6 +481,30 @@ one, and every open of the create dialog asks for it. Nothing invalidates it ear
 does not change what is deployable. An **empty** answer is not cached at all, so a transient window
 where every account 404s cannot pin "catalogue unavailable" on the dialog for five minutes.
 
+## Gateway — model allowlist
+
+Each quota-tier product carries a **model alias map**: an APIM named value `fg-model-map-{tier}` holding `{ alias: { deployment, backend, provider } }`, which a policy fragment applies *before* `llm-token-limit`. It rewrites the alias a developer pinned to the real Foundry deployment and routes it at the mapped backend. **The map is the allowlist** — an alias a tier does not list is refused `403 model_not_permitted` ahead of the quota policy, so a blocked model costs the developer no quota, and a tier with no map permits nothing at all (fail loud, by design).
+
+These endpoints edit that named value through the APIM Management API, so a change takes effect **without redeploying a policy or an infrastructure template**.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/gateway/tiers` | Admin | The gateway's quota tiers with the size of each one's allowlist: `{ tier, displayName, monthlyTokenQuota, isUnlimited, allowedModelCount }`. Tier identity and caps come from the same `Gateway:Tiers` table quota resolution uses; the counts come from APIM. |
+| `GET` | `/gateway/tiers/{tier}/models` | Admin | One tier's allowlist as APIM holds it: `{ tier, displayName, aliases: [{ alias, deploymentName, pool, provider, deploymentExists, missingFromAccounts }] }`, ordered by alias. `deploymentExists` and `missingFromAccounts` are checked live against the configured Foundry accounts, so a map that would 404 is visible before a developer finds it. `404` for an unknown tier. |
+| `PUT` | `/gateway/tiers/{tier}/models` | Admin | Replace a tier's allowlist in full. Body: `{ "aliases": [{ "alias", "deploymentName", "pool", "provider" }] }`. Returns the tier's allowlist as stored. An empty list is legal and permits nothing. |
+
+`PUT` is a **full replace**, not a patch: the named value is one JSON document and the gateway reads it whole, so add, retarget and remove are all the same call with a different list.
+
+Rules it enforces before touching APIM:
+
+- **`alias` is lower-case and url-safe** (`^[a-z0-9][a-z0-9._-]*$`) — it travels in a request's `model` field and the policy compares it without normalizing, so `Sonnet` would silently miss an allowlist that lists `sonnet`. `400` otherwise.
+- **An alias may appear once.** The gateway's map is keyed by alias, so a duplicate would let list order decide which deployment a developer actually reaches. `400`.
+- **`pool` is `anthropic` or `openai`**, resolved to the real APIM backend id exactly as `infra/modules/ai-gateway.bicep` resolves it (`anthropic` → the multi-region pool, `openai` → the primary account's backend), so a map written here and a map written by a deploy are the same document. `provider` (`anthropic` / `openai`) is the front door the alias belongs to, which is what lets the policy refuse a right-plan/wrong-door request by naming the base path the caller should have used.
+- **The deployment must exist** in at least one configured Foundry account — and in **every** account when `pool` is `anthropic`. The Anthropic pool sends a throttled request to another region, so a region missing the deployment turns a `429` into a `404`; the refusal names the accounts it is missing from. `400` either way.
+- **APIM refusing the write is `409 Conflict`**, with what APIM said, and the allowlist is unchanged.
+- **`503 Service Unavailable — feature not configured`** when the `Gateway__*` section does not address APIM, or does not name any Foundry account (existence cannot be checked without the accounts).
+- A change writes one audit entry — `gateway.models.updated`, target type `GatewayTier`, target id the tier product id, details carrying the whole map `{ before, after }`. As on `/foundry/*`, the admin must have loaded the app once (`GET /users/me`) or the write is refused `403` before APIM is touched; once APIM has accepted, the entry is written regardless of the client disconnecting. **Writing the map a tier already holds is a no-op** — no APIM call and no audit row, because an audit trail claiming a change that did not happen is worse than silence.
+
 ## Admin
 
 | Method | Path | Auth | Description |

--- a/docs-site/src/content/docs/reference/web-ui.md
+++ b/docs-site/src/content/docs/reference/web-ui.md
@@ -72,6 +72,7 @@ answers `409` anyway, the page says so and locks the form instead of navigating 
 | `/requests` | Any | The quota increase review queue. **Not admin-only**: a developer sees their own requests here (the nav links it as "My Requests"), an admin sees everyone's — the API scopes the list, not the route |
 | `/requests/{id}` | Owner or Admin | One request, with the approve/reject panel for admins |
 | `/foundry` | Admin | Foundry model deployments |
+| `/models` | Admin | Which models each quota tier is allowed to use — the gateway's own allowlist |
 | `/config` | Admin | Edit the `SystemConfiguration` key-value rows (the `RateCard` gets a multi-line box — it is JSON) |
 | `/audit` | Admin | Browse and filter the audit trail |
 
@@ -235,8 +236,52 @@ still coerces whatever is typed, so a model Azure lists before this endpoint doe
 deployable — ARM decides either way. If the catalogue can't be read, the dialog says so and the
 fields fall back to plain free text rather than to another hardcoded list.
 
+The dialog creates one deployment per account and can name **several accounts** — the chosen one,
+plus anything picked under "Also create in". That is one `POST /foundry/deployments` per account, run
+in order and reported separately, so a second region failing never reads as the first one having
+failed too. Which accounts a model belongs in is not a preference: a model served through the
+multi-region Anthropic pool must exist in every region, because the pool sends a throttled request to
+another one. OpenAI-format models are primary-account-only, so nothing extra is pre-selected today.
+
+After a create the page **polls each new deployment** until ARM stops moving it (`Succeeded`,
+`Failed` or `Canceled`), refreshing the grid as it goes, so you find out whether the thing you asked
+for works without pressing refresh. It gives up after about a minute; the state chips are still the
+truth at that point, they just stop updating themselves.
+
 A new deployment reaches developers through the gateway only once it is in the right backend pool
-([#83](https://github.com/kolatts/foundry-gate/issues/83)), which the page also says.
+([#83](https://github.com/kolatts/foundry-gate/issues/83)), which the page also says — and only once
+a tier is allowed to use it. So a successful create ends with a link into `/models` carrying the new
+deployment's name, which that page pre-fills into its "allow a model" dialog.
+
+### `/models`
+
+**Models &amp; access** — which models each quota tier is allowed to use, backed by
+[`GET`/`PUT /gateway/tiers/{tier}/models`](/foundry-gate/reference/api/#gateway--model-allowlist).
+This list *is* the rule the gateway enforces: a developer asking for a model their tier does not list
+is refused `403 model_not_permitted` at the gateway, before it costs them any quota. Changes take
+effect without redeploying anything.
+
+The page has three parts:
+
+- **At a glance** — a matrix of every alias any tier permits against every tier, so "who can use
+  `opus`?" is one look rather than three page visits. A tier that does not permit an alias shows
+  `—`.
+- **One panel per tier** — the tier's rows (alias, deployment, front door, backend) with *allow*,
+  *retarget* and *remove*. Each of those sends the tier's whole map, because the gateway reads one
+  JSON document; the page composes the new list from what is already there. Remove asks first and
+  says what happens: developers who have that model configured start being refused, and nothing is
+  deleted in Azure.
+- **What developers on this tier see** — the aliases as they would appear in a developer's
+  "Configure your CLI" panel. A tier with no models says so plainly: nothing is available to anyone
+  on it.
+
+Two fields the dialog **derives rather than asks**: the front door (`provider`) and the backend
+(`pool`) both follow from the chosen deployment's ARM `model.format`. Getting either wrong produces a
+failure that looks like something else — a Claude alias routed at the OpenAI backend dies as an
+opaque 404 — so the form asks the question once, in the deployment picker. Rows whose deployment is
+missing entirely, or missing from a region a pooled alias needs, are flagged in the grid rather than
+hidden; the API refuses to *write* such a map, so a flagged row is one a deploy or a later deletion
+left behind.
 
 ### `/config`
 

--- a/plans/25-model-aliases-routing.md
+++ b/plans/25-model-aliases-routing.md
@@ -127,8 +127,11 @@ Streaming caveat documented: response-side enforcement silently stops the stream
       as the values for `ANTHROPIC_DEFAULT_*_MODEL` / Codex `model`. **Deliberately not
       done yet**: CLAUDE.md requires cli-setup to contain only empirically verified
       configuration, and aliases have not been exercised against a live gateway.
-- [ ] Control plane (later, with #82): admin endpoint to edit alias maps via Management
-      API
+- [x] Control plane: admin endpoints to edit alias maps via the Management API — `GET/PUT
+      /api/v1/gateway/tiers/{tier}/models` plus the `/models` admin page (#225). Validation
+      refuses a map the gateway would answer with a 404 rather than an honest 403 (alias
+      grammar, deployment existence, and existence in *every* pool member for an
+      `anthropic`-pool alias). The named-value round trip against real APIM is #226.
 
 ## Verification
 

--- a/src/FoundryGate.Api/Controllers/GatewayController.cs
+++ b/src/FoundryGate.Api/Controllers/GatewayController.cs
@@ -1,0 +1,56 @@
+using FoundryGate.Api.Services.Gateway;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Gateway.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoundryGate.Api.Controllers;
+
+/// <summary>
+/// <c>/api/v1/gateway</c> — the gateway's own configuration surface (#225). Today that is the
+/// per-tier model allowlist: the alias map each quota-tier product carries as the APIM named value
+/// <c>fg-model-map-{tier}</c> (#86, plans/25). The map <b>is</b> the allowlist — a model a tier does
+/// not list is a <c>403 model_not_permitted</c> at the gateway — so these endpoints are what the
+/// <c>/models</c> admin page uses to grant, retarget and remove models without an infra deploy.
+/// </summary>
+/// <remarks>
+/// Admin-only at class level: this changes what every developer on a tier can reach. Errors arrive as
+/// ProblemDetails via <c>GlobalExceptionHandler</c> — <c>404</c> for an unknown tier, <c>400</c> for a
+/// map the gateway would answer with a 404 instead of an honest 403, <c>409</c> when APIM refuses the
+/// write, <c>503</c> when APIM or Foundry addressing is absent.
+/// </remarks>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+public sealed class GatewayController(IGatewayModelService gatewayModels) : ApiControllerBase
+{
+    /// <summary>The gateway's quota tiers with the size of each one's current model allowlist.</summary>
+    [HttpGet("tiers")]
+    [ProducesResponseType<IReadOnlyList<GatewayTierResponse>>(StatusCodes.Status200OK)]
+    public Task<IReadOnlyList<GatewayTierResponse>> ListTiersAsync(CancellationToken cancellationToken) =>
+        gatewayModels.ListTiersAsync(cancellationToken);
+
+    /// <summary>
+    /// One tier's allowlist as APIM holds it, each row flagged for whether its deployment exists in
+    /// the configured Foundry accounts (and which accounts are missing it).
+    /// </summary>
+    [HttpGet("tiers/{tier}/models")]
+    [ProducesResponseType<GatewayTierModelsResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public Task<GatewayTierModelsResponse> GetTierModelsAsync(string tier, CancellationToken cancellationToken) =>
+        gatewayModels.GetTierModelsAsync(tier, cancellationToken);
+
+    /// <summary>
+    /// Replaces a tier's allowlist in full (<c>{ "aliases": [ … ] }</c>) and returns it as stored.
+    /// A full replace, not a patch: the named value is one JSON document, and "these are the models
+    /// this tier may use" is the sentence an admin is writing. An empty list permits nothing.
+    /// </summary>
+    [HttpPut("tiers/{tier}/models")]
+    [ProducesResponseType<GatewayTierModelsResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public Task<GatewayTierModelsResponse> ReplaceTierModelsAsync(
+        string tier,
+        [FromBody] ReplaceTierModelsRequest request,
+        CancellationToken cancellationToken) =>
+        gatewayModels.ReplaceTierModelsAsync(tier, request, cancellationToken);
+}

--- a/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/ApiServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using FoundryGate.Api.Services.Cost;
 using FoundryGate.Api.Services.Dashboard;
 using FoundryGate.Api.Services.Entra;
 using FoundryGate.Api.Services.Foundry;
+using FoundryGate.Api.Services.Gateway;
 using FoundryGate.Api.Services.Groups;
 using FoundryGate.Api.Services.Identity;
 using FoundryGate.Api.Services.Keys;
@@ -36,6 +37,7 @@ public static class ApiServiceCollectionExtensions
         services.AddGroupsServices();
         services.AddRequestsServices();
         services.AddFoundryServices();
+        services.AddGatewayServices();
         services.AddEntraServices();
         services.AddSecurityServices();
         services.AddKeysServices();

--- a/src/FoundryGate.Api/Services/Gateway/GatewayModelService.cs
+++ b/src/FoundryGate.Api/Services/Gateway/GatewayModelService.cs
@@ -13,6 +13,7 @@ using FoundryGate.Domain.Config;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Exceptions;
 using FoundryGate.Domain.Gateway.Contracts;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace FoundryGate.Api.Services.Gateway;
 
@@ -29,9 +30,26 @@ public sealed partial class GatewayModelService(
     IAuditService auditService,
     ICurrentUserAccessor currentUser,
     AppDbContext dbContext,
+    IMemoryCache cache,
     ILogger<GatewayModelService> logger)
     : IGatewayModelService
 {
+    /// <summary>
+    /// How long a tier's map and the Foundry deployment placement are reused. Rendering <c>/models</c>
+    /// asks for every tier's map twice — once for the counts on <c>GET /gateway/tiers</c>, once per
+    /// tier for the rows — and each of those reads would otherwise re-enumerate every Foundry account
+    /// to answer "does this deployment exist". Short enough that an edit made in the Azure portal shows
+    /// up while the admin is still looking, and a write through this service replaces its own entry
+    /// rather than waiting for it to expire.
+    /// </summary>
+    public static readonly TimeSpan ReadCacheDuration = TimeSpan.FromSeconds(15);
+
+    /// <summary><see cref="IMemoryCache"/> key for the deployment-name → accounts placement map.</summary>
+    public const string PlacementCacheKey = "FoundryGate.Gateway.DeploymentPlacement";
+
+    /// <summary><see cref="IMemoryCache"/> key for one tier's parsed alias map.</summary>
+    public static string MapCacheKey(string tierProductId) => $"FoundryGate.Gateway.ModelMap.{tierProductId}";
+
     /// <summary>
     /// How the named value is written: camelCase, no indentation. The bicep writes it with ARM's
     /// <c>string()</c>, which is compact camelCase too — a value written here and a value written by a
@@ -125,6 +143,8 @@ public sealed partial class GatewayModelService(
         }
 
         // ---- commit point: APIM has accepted the new map. Nothing below observes cancellationToken. ----
+        _ = cache.Set(MapCacheKey(configured.ProductId), desired, ReadCacheDuration);
+
         logger.LogInformation(
             "Gateway tier {Tier} model allowlist replaced: {Before} -> {After} aliases ({Aliases})",
             configured.ProductId,
@@ -231,18 +251,29 @@ public sealed partial class GatewayModelService(
     /// <summary>Reads and parses one tier's named value; an absent or unparseable map is an empty allowlist, which is what the gateway itself makes of it.</summary>
     private async Task<SortedDictionary<string, ModelMapEntry>> ReadMapAsync(string tierProductId, CancellationToken cancellationToken)
     {
+        if (cache.TryGetValue(MapCacheKey(tierProductId), out SortedDictionary<string, ModelMapEntry>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
         var namedValueName = GatewayModelMap.NamedValueName(tierProductId);
         var raw = await apim.GetNamedValueAsync(namedValueName, cancellationToken);
 
         if (string.IsNullOrWhiteSpace(raw))
         {
-            return new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+            return Cache(tierProductId, []);
         }
 
         try
         {
             var parsed = JsonSerializer.Deserialize<Dictionary<string, ModelMapEntry>>(raw, MapJson) ?? [];
-            return new SortedDictionary<string, ModelMapEntry>(parsed, StringComparer.Ordinal);
+
+            // plans/25: an entry missing any of its three fields is blocked by the policy exactly as an
+            // absent one is, so a half-written entry is dropped here rather than rendered as a row —
+            // and the projection below never has to look a null deployment name up.
+            return Cache(
+                tierProductId,
+                [.. parsed.Where(entry => !string.IsNullOrWhiteSpace(entry.Value?.Deployment))]);
         }
         catch (JsonException exception)
         {
@@ -252,13 +283,30 @@ public sealed partial class GatewayModelService(
                 exception,
                 "APIM named value {NamedValue} does not hold a readable model alias map; reporting the tier as permitting no models",
                 namedValueName);
-            return new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+            return Cache(tierProductId, []);
         }
+    }
+
+    /// <summary>Stores a tier's parsed map under <see cref="MapCacheKey"/> and hands it back.</summary>
+    private SortedDictionary<string, ModelMapEntry> Cache(string tierProductId, IEnumerable<KeyValuePair<string, ModelMapEntry>> entries)
+    {
+        var map = new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+        foreach (var (alias, entry) in entries)
+        {
+            map[alias] = entry;
+        }
+
+        return cache.Set(MapCacheKey(tierProductId), map, ReadCacheDuration);
     }
 
     /// <summary>Deployment name → the configured accounts that carry it, case-insensitively on both.</summary>
     private async Task<IReadOnlyDictionary<string, List<string>>> ReadDeploymentPlacementAsync(CancellationToken cancellationToken)
     {
+        if (cache.TryGetValue(PlacementCacheKey, out IReadOnlyDictionary<string, List<string>>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
         // ListDeploymentsAsync raises FeatureNotConfiguredException (503) when Foundry addressing is
         // absent — the honest answer, since "does this deployment exist?" cannot be answered without it.
         var all = await deployments.ListDeploymentsAsync(cancellationToken);
@@ -275,7 +323,7 @@ public sealed partial class GatewayModelService(
             accounts.Add(deployment.AccountName);
         }
 
-        return placement;
+        return cache.Set<IReadOnlyDictionary<string, List<string>>>(PlacementCacheKey, placement, ReadCacheDuration);
     }
 
     private IReadOnlyList<GatewayModelAliasResponse> Project(

--- a/src/FoundryGate.Api/Services/Gateway/GatewayModelService.cs
+++ b/src/FoundryGate.Api/Services/Gateway/GatewayModelService.cs
@@ -1,0 +1,341 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Azure;
+using FoundryGate.Api.Configuration;
+using FoundryGate.Api.Services.Audit;
+using FoundryGate.Api.Services.Foundry;
+using FoundryGate.Api.Services.Identity;
+using FoundryGate.Core.Configuration;
+using FoundryGate.Core.Gateway;
+using FoundryGate.Data;
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Exceptions;
+using FoundryGate.Domain.Gateway.Contracts;
+
+namespace FoundryGate.Api.Services.Gateway;
+
+/// <summary>
+/// Default <see cref="IGatewayModelService"/>. Scoped: it shares the request's
+/// <see cref="AppDbContext"/> with <see cref="IAuditService"/> so the audit row commits in this
+/// service's own <c>SaveChangesAsync</c>. See the interface remarks for why reads go to APIM rather
+/// than configuration, what the validation refuses, and where the commit point is.
+/// </summary>
+public sealed partial class GatewayModelService(
+    IApimManagementClient apim,
+    IFoundryDeploymentService deployments,
+    AppSettings appSettings,
+    IAuditService auditService,
+    ICurrentUserAccessor currentUser,
+    AppDbContext dbContext,
+    ILogger<GatewayModelService> logger)
+    : IGatewayModelService
+{
+    /// <summary>
+    /// How the named value is written: camelCase, no indentation. The bicep writes it with ARM's
+    /// <c>string()</c>, which is compact camelCase too — a value written here and a value written by a
+    /// deploy have to be the same document, because the policy substitutes it verbatim into a
+    /// <c>set-variable</c> attribute.
+    /// </summary>
+    private static readonly JsonSerializerOptions MapJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        WriteIndented = false,
+    };
+
+    /// <summary>The alias grammar, compiled once — see <see cref="GatewayModelMap.AliasPattern"/> for why it is lower-case only.</summary>
+    [GeneratedRegex(GatewayModelMap.AliasPattern)]
+    private static partial Regex AliasRegex();
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<GatewayTierResponse>> ListTiersAsync(CancellationToken cancellationToken)
+    {
+        RequireApim();
+
+        var tiers = appSettings.Gateway.Tiers;
+
+        // One named-value read per tier, concurrently: three small reads against independent ARM
+        // resources, and the page cannot render its left-hand side without all of them anyway.
+        var maps = await Task.WhenAll(tiers.Select(tier => ReadMapAsync(tier.ProductId, cancellationToken)));
+
+        return [.. tiers.Select((tier, index) => new GatewayTierResponse(
+            tier.ProductId,
+            DisplayNameOf(tier),
+            tier.IsUnlimited ? null : tier.MonthlyTokenQuota,
+            tier.IsUnlimited,
+            maps[index].Count))];
+    }
+
+    /// <inheritdoc />
+    public async Task<GatewayTierModelsResponse> GetTierModelsAsync(string tier, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+
+        var configured = RequireTier(tier);
+        RequireApim();
+
+        var map = await ReadMapAsync(configured.ProductId, cancellationToken);
+        var placement = await ReadDeploymentPlacementAsync(cancellationToken);
+
+        return new GatewayTierModelsResponse(configured.ProductId, DisplayNameOf(configured), Project(map, placement));
+    }
+
+    /// <inheritdoc />
+    public async Task<GatewayTierModelsResponse> ReplaceTierModelsAsync(string tier, ReplaceTierModelsRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var configured = RequireTier(tier);
+        RequireApim();
+
+        // 403 for an unprovisioned caller, and every refusal, before APIM is touched.
+        _ = await currentUser.GetRequiredUserAsync(cancellationToken);
+
+        var placement = await ReadDeploymentPlacementAsync(cancellationToken);
+        var desired = Validate(request, placement);
+        var current = await ReadMapAsync(configured.ProductId, cancellationToken);
+
+        if (AreEquivalent(current, desired))
+        {
+            // Writing the value it already holds changes nothing at the gateway, so an audit row
+            // claiming an allowlist change would be a lie. Same rule as a no-op capacity PATCH.
+            logger.LogDebug("Gateway tier {Tier} model map is already what was requested; nothing to change", configured.ProductId);
+            return new GatewayTierModelsResponse(configured.ProductId, DisplayNameOf(configured), Project(current, placement));
+        }
+
+        var namedValueName = GatewayModelMap.NamedValueName(configured.ProductId);
+
+        try
+        {
+            await apim.SetNamedValueAsync(namedValueName, JsonSerializer.Serialize(desired, MapJson), cancellationToken);
+        }
+        catch (RequestFailedException exception)
+        {
+            // APIM refusing the write is a state problem the admin can act on (a named value held by
+            // Key Vault, a value APIM will not accept, a concurrent edit) — not an unmapped 500.
+            throw new ConflictException(
+                $"API Management refused the update to named value '{namedValueName}' (HTTP {exception.Status}). " +
+                "The tier's model allowlist was not changed. " +
+                $"API Management said: {exception.Message}",
+                exception);
+        }
+
+        // ---- commit point: APIM has accepted the new map. Nothing below observes cancellationToken. ----
+        logger.LogInformation(
+            "Gateway tier {Tier} model allowlist replaced: {Before} -> {After} aliases ({Aliases})",
+            configured.ProductId,
+            current.Count,
+            desired.Count,
+            string.Join(", ", desired.Keys));
+
+        try
+        {
+            _ = await auditService.LogAsync(
+                AuditActions.GatewayModelsUpdated,
+                AuditTargetTypes.GatewayTier,
+                configured.ProductId,
+                new { before = current, after = desired },
+                CancellationToken.None);
+            _ = await dbContext.SaveChangesAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Gateway tier {Tier}: API Management accepted the new model allowlist but the audit row could not be saved — reconcile manually",
+                configured.ProductId);
+            throw;
+        }
+
+        return new GatewayTierModelsResponse(configured.ProductId, DisplayNameOf(configured), Project(desired, placement));
+    }
+
+    /// <summary>
+    /// Turns the request into the exact document the named value will hold, refusing anything the
+    /// gateway would answer with a 404 instead of an honest 403.
+    /// </summary>
+    private SortedDictionary<string, ModelMapEntry> Validate(ReplaceTierModelsRequest request, IReadOnlyDictionary<string, List<string>> placement)
+    {
+        var accounts = appSettings.Gateway.FoundryAccountNames;
+        var primaryAccount = accounts[0];
+        var map = new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+
+        foreach (var entry in request.Aliases)
+        {
+            var alias = (entry.Alias ?? string.Empty).Trim();
+            var deployment = (entry.DeploymentName ?? string.Empty).Trim();
+            var pool = (entry.Pool ?? string.Empty).Trim();
+
+            if (!AliasRegex().IsMatch(alias))
+            {
+                throw new ArgumentException(
+                    $"'{alias}' is not a usable model alias. An alias is what a developer types into their CLI's model field, so it must be " +
+                    "lower-case and url-safe: start with a letter or digit, then letters, digits, and . _ - only.",
+                    nameof(request));
+            }
+
+            if (map.ContainsKey(alias))
+            {
+                throw new ArgumentException(
+                    $"Alias '{alias}' is listed more than once. The gateway's map is keyed by alias, so a duplicate would let list order decide " +
+                    "which deployment a developer actually reaches.",
+                    nameof(request));
+            }
+
+            if (!GatewayModelMap.Pools.Contains(pool, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(
+                    $"Alias '{alias}' names pool '{pool}', which is not a backend this gateway has. Valid pools: {string.Join(", ", GatewayModelMap.Pools)}.",
+                    nameof(request));
+            }
+
+            if (!placement.TryGetValue(deployment, out var deployedIn))
+            {
+                throw new ArgumentException(
+                    $"Alias '{alias}' points at deployment '{deployment}', which does not exist in any of this gateway's Foundry accounts " +
+                    $"({string.Join(", ", accounts)}). Create the deployment first — every request for this alias would otherwise reach a backend " +
+                    "that has never heard of it.",
+                    nameof(request));
+            }
+
+            var isPooled = !string.Equals(pool, GatewayModelMap.OpenAiPool, StringComparison.OrdinalIgnoreCase);
+            if (isPooled)
+            {
+                // infra/main.bicep's contract: the Anthropic pool fails a 429 over to another region,
+                // so a region missing the deployment turns a throttle into a 404.
+                var missing = accounts.Where(account => !deployedIn.Contains(account, StringComparer.OrdinalIgnoreCase)).ToList();
+                if (missing.Count > 0)
+                {
+                    throw new ArgumentException(
+                        $"Alias '{alias}' routes at the '{GatewayModelMap.AnthropicPool}' pool, so deployment '{deployment}' must exist in every " +
+                        $"Foundry account — it is missing from {string.Join(", ", missing)}. The pool fails a throttled request over to another " +
+                        "region, and a region without the deployment turns that throttle into a 404. Deploy it there, or route this alias at the " +
+                        $"'{GatewayModelMap.OpenAiPool}' backend if it is a single-region model.",
+                        nameof(request));
+                }
+            }
+
+            map[alias] = new ModelMapEntry(
+                deployment,
+                GatewayModelMap.BackendForPool(pool, primaryAccount),
+                ProviderToken(entry.Provider));
+        }
+
+        return map;
+    }
+
+    /// <summary>Reads and parses one tier's named value; an absent or unparseable map is an empty allowlist, which is what the gateway itself makes of it.</summary>
+    private async Task<SortedDictionary<string, ModelMapEntry>> ReadMapAsync(string tierProductId, CancellationToken cancellationToken)
+    {
+        var namedValueName = GatewayModelMap.NamedValueName(tierProductId);
+        var raw = await apim.GetNamedValueAsync(namedValueName, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, ModelMapEntry>>(raw, MapJson) ?? [];
+            return new SortedDictionary<string, ModelMapEntry>(parsed, StringComparer.Ordinal);
+        }
+        catch (JsonException exception)
+        {
+            // The policy fragment treats a map it cannot read as "permits nothing" (fail loud, #86), so
+            // reporting an empty allowlist here matches what developers are actually experiencing.
+            logger.LogError(
+                exception,
+                "APIM named value {NamedValue} does not hold a readable model alias map; reporting the tier as permitting no models",
+                namedValueName);
+            return new SortedDictionary<string, ModelMapEntry>(StringComparer.Ordinal);
+        }
+    }
+
+    /// <summary>Deployment name → the configured accounts that carry it, case-insensitively on both.</summary>
+    private async Task<IReadOnlyDictionary<string, List<string>>> ReadDeploymentPlacementAsync(CancellationToken cancellationToken)
+    {
+        // ListDeploymentsAsync raises FeatureNotConfiguredException (503) when Foundry addressing is
+        // absent — the honest answer, since "does this deployment exist?" cannot be answered without it.
+        var all = await deployments.ListDeploymentsAsync(cancellationToken);
+        var placement = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var deployment in all)
+        {
+            if (!placement.TryGetValue(deployment.DeploymentName, out var accounts))
+            {
+                accounts = [];
+                placement[deployment.DeploymentName] = accounts;
+            }
+
+            accounts.Add(deployment.AccountName);
+        }
+
+        return placement;
+    }
+
+    private IReadOnlyList<GatewayModelAliasResponse> Project(
+        SortedDictionary<string, ModelMapEntry> map,
+        IReadOnlyDictionary<string, List<string>> placement)
+    {
+        var accounts = appSettings.Gateway.FoundryAccountNames;
+
+        return
+        [
+            .. map.Select(pair =>
+            {
+                var deployedIn = placement.TryGetValue(pair.Value.Deployment, out var found) ? found : [];
+
+                return new GatewayModelAliasResponse(
+                    pair.Key,
+                    pair.Value.Deployment,
+                    GatewayModelMap.PoolForBackend(pair.Value.Backend),
+                    ProviderFromToken(pair.Value.Provider),
+                    deployedIn.Count > 0,
+                    [.. accounts.Where(account => !deployedIn.Contains(account, StringComparer.OrdinalIgnoreCase))]);
+            })
+        ];
+    }
+
+    private static bool AreEquivalent(SortedDictionary<string, ModelMapEntry> left, SortedDictionary<string, ModelMapEntry> right) =>
+        left.Count == right.Count
+        && left.All(pair => right.TryGetValue(pair.Key, out var other) && pair.Value == other);
+
+    private static string DisplayNameOf(GatewayTier tier) =>
+        string.IsNullOrWhiteSpace(tier.DisplayName) ? tier.ProductId : tier.DisplayName;
+
+    private GatewayTier RequireTier(string tier) =>
+        appSettings.Gateway.Tiers.FirstOrDefault(t => string.Equals(t.ProductId, tier, StringComparison.OrdinalIgnoreCase))
+        ?? throw new KeyNotFoundException(
+            $"'{tier}' is not one of this gateway's quota tiers ({string.Join(", ", appSettings.Gateway.Tiers.Select(t => t.ProductId))}).");
+
+    private void RequireApim()
+    {
+        if (!appSettings.Gateway.IsApimConfigured)
+        {
+            throw new FeatureNotConfiguredException(
+                "The gateway's model allowlist is not configured: set Gateway:SubscriptionId, Gateway:ResourceGroup and Gateway:ApimName " +
+                "(infra sets these on the Container App as Gateway__*; see issue #108).");
+        }
+    }
+
+    /// <summary>Bicep writes the provider lower-case; so does this, so a map is the same document whoever wrote it.</summary>
+    private static string ProviderToken(ModelProviderType provider) =>
+        provider == ModelProviderType.OpenAi ? GatewayModelMap.OpenAiPool : GatewayModelMap.AnthropicPool;
+
+    private static ModelProviderType ProviderFromToken(string? provider) =>
+        string.Equals(provider, GatewayModelMap.OpenAiPool, StringComparison.OrdinalIgnoreCase)
+            ? ModelProviderType.OpenAi
+            : ModelProviderType.Anthropic;
+
+    /// <summary>
+    /// One entry of the named value, in the wire shape <c>infra/modules/ai-gateway.bicep</c> writes and
+    /// <c>infra/policies/model-alias-fragment.xml</c> reads: the real deployment name, the APIM backend
+    /// id to route at, and the front door the alias belongs to. A record, so two maps compare by value.
+    /// </summary>
+    private sealed record ModelMapEntry(string Deployment, string Backend, string Provider);
+}

--- a/src/FoundryGate.Api/Services/Gateway/GatewayServiceCollectionExtensions.cs
+++ b/src/FoundryGate.Api/Services/Gateway/GatewayServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+namespace FoundryGate.Api.Services.Gateway;
+
+/// <summary>DI registration for the <c>Services/Gateway</c> area (#225). Invoked from <see cref="ApiServiceCollectionExtensions.AddFoundryGateApiServices"/>.</summary>
+public static class GatewayServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IGatewayModelService"/> (scoped — it shares the request's
+    /// <c>AppDbContext</c> with the audit writer). The APIM management client it composes is
+    /// registered once by <c>Services/Keys</c>, which owns that seam's configuration check; the
+    /// Foundry deployment service it reads placement from is registered by <c>Services/Foundry</c>.
+    /// </summary>
+    public static IServiceCollection AddGatewayServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IGatewayModelService, GatewayModelService>();
+
+        return services;
+    }
+}

--- a/src/FoundryGate.Api/Services/Gateway/IGatewayModelService.cs
+++ b/src/FoundryGate.Api/Services/Gateway/IGatewayModelService.cs
@@ -16,7 +16,8 @@ namespace FoundryGate.Api.Services.Gateway;
 /// <b>Why the named value and not configuration.</b> <c>GatewayOptions.ModelAliases</c> carries the
 /// same map, flattened, for the developer-facing <c>GET /users/me</c> panel — but it is a snapshot of
 /// what the last <em>deploy</em> wrote. What the gateway enforces is the named value, so every read
-/// here goes to APIM. (That the two can now diverge until the next deploy is tracked separately.)
+/// here goes to APIM. (That the two can now diverge until the next deploy is
+/// <see href="https://github.com/kolatts/foundry-gate/issues/232">#232</see>.)
 /// </para>
 /// <para>
 /// <b>Validation refuses maps that would 404 rather than 403.</b> An alias must be lower-case and

--- a/src/FoundryGate.Api/Services/Gateway/IGatewayModelService.cs
+++ b/src/FoundryGate.Api/Services/Gateway/IGatewayModelService.cs
@@ -1,0 +1,70 @@
+using FoundryGate.Domain.Gateway.Contracts;
+
+namespace FoundryGate.Api.Services.Gateway;
+
+/// <summary>
+/// The gateway's per-tier model allowlist (#86, plans/25; #225 made it editable). Each quota-tier
+/// product carries an APIM named value <c>fg-model-map-{tier}</c> holding
+/// <c>{ alias: { deployment, backend, provider } }</c>; the tier's product policy hands it to the
+/// <c>fg-model-alias</c> fragment, which rewrites the alias to the real deployment, routes at the
+/// mapped backend, and refuses anything the map does not list with <c>403 model_not_permitted</c>.
+/// <b>The map is the allowlist</b> — there is no second list — so editing it is how an admin grants or
+/// removes a model, and it takes effect without redeploying a policy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the named value and not configuration.</b> <c>GatewayOptions.ModelAliases</c> carries the
+/// same map, flattened, for the developer-facing <c>GET /users/me</c> panel — but it is a snapshot of
+/// what the last <em>deploy</em> wrote. What the gateway enforces is the named value, so every read
+/// here goes to APIM. (That the two can now diverge until the next deploy is tracked separately.)
+/// </para>
+/// <para>
+/// <b>Validation refuses maps that would 404 rather than 403.</b> An alias must be lower-case and
+/// url-safe, unique within the tier, and point at a deployment the configured Foundry accounts
+/// actually have — and for an <c>anthropic</c>-pool alias, at one that <em>every</em> account has:
+/// the pool fails a 429 over to another region, so a region missing the deployment turns a throttle
+/// into a 404 (the contract stated in <c>infra/main.bicep</c>). That check needs the Foundry accounts,
+/// so both reads and the write require Foundry addressing as well as APIM addressing; without it the
+/// service would be answering "is this map safe?" with a guess.
+/// </para>
+/// <para>
+/// <b>Commit point.</b> <see cref="ReplaceTierModelsAsync"/> resolves the caller and does every
+/// refusal before touching APIM; once APIM has accepted the new named value the audit row and save
+/// run on <see cref="CancellationToken.None"/>, per CONVENTIONS.md.
+/// </para>
+/// </remarks>
+public interface IGatewayModelService
+{
+    /// <summary>
+    /// The gateway's quota tiers with the size of each one's current allowlist — what the
+    /// <c>/models</c> page lists down its left-hand side. Tier identity and caps come from the same
+    /// <c>Gateway:Tiers</c> table quota resolution uses; the counts come from APIM.
+    /// </summary>
+    /// <exception cref="Domain.Exceptions.FeatureNotConfiguredException">APIM is not configured (503).</exception>
+    Task<IReadOnlyList<GatewayTierResponse>> ListTiersAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// One tier's allowlist as APIM holds it, with each row flagged for whether its deployment
+    /// actually exists in the configured Foundry accounts.
+    /// </summary>
+    /// <param name="tier">A quota-tier product id (<c>Domain.Constants.GatewayTiers</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="KeyNotFoundException">No such tier (404).</exception>
+    /// <exception cref="Domain.Exceptions.FeatureNotConfiguredException">APIM or Foundry is not configured (503).</exception>
+    Task<GatewayTierModelsResponse> GetTierModelsAsync(string tier, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Replaces a tier's allowlist in full and audits <c>gateway.models.updated</c> with the whole map
+    /// before and after. A request that resolves to the map already stored is a no-op: no APIM call, no
+    /// audit row (an audit trail claiming a change that did not happen is worse than silence).
+    /// </summary>
+    /// <param name="tier">A quota-tier product id.</param>
+    /// <param name="request">The tier's complete allowlist. An empty list is legal and permits nothing.</param>
+    /// <param name="cancellationToken">Cancellation token — not observed past the point APIM accepts.</param>
+    /// <exception cref="KeyNotFoundException">No such tier (404).</exception>
+    /// <exception cref="ArgumentException">A malformed alias, a duplicate alias, an unknown pool, or a deployment the accounts do not have (400).</exception>
+    /// <exception cref="Domain.Exceptions.ConflictException">APIM refused the write (409).</exception>
+    /// <exception cref="UnauthorizedAccessException">The caller has no <c>User</c> row (403 — call <c>GET /users/me</c> first).</exception>
+    /// <exception cref="Domain.Exceptions.FeatureNotConfiguredException">APIM or Foundry is not configured (503).</exception>
+    Task<GatewayTierModelsResponse> ReplaceTierModelsAsync(string tier, ReplaceTierModelsRequest request, CancellationToken cancellationToken);
+}

--- a/src/FoundryGate.Core/Gateway/ArmApimManagementClient.cs
+++ b/src/FoundryGate.Core/Gateway/ArmApimManagementClient.cs
@@ -209,8 +209,10 @@ public sealed class ArmApimManagementClient : IApimManagementClient
             IsSecret = false,
         };
 
+        // No ifMatch: ARM reads `If-Match: *` as "must already exist", which would turn the first write
+        // to a tier whose named value no deploy has created into a 412 the caller cannot act on.
         var namedValues = _armClient.GetApiManagementServiceResource(_serviceId).GetApiManagementNamedValues();
-        _ = await namedValues.CreateOrUpdateAsync(WaitUntil.Completed, namedValueName, content, ifMatch: ETag.All, cancellationToken: cancellationToken);
+        _ = await namedValues.CreateOrUpdateAsync(WaitUntil.Completed, namedValueName, content, cancellationToken: cancellationToken);
     }
 
     private ApiManagementSubscriptionResource Subscription(string subscriptionName) =>

--- a/src/FoundryGate.Core/Gateway/ArmApimManagementClient.cs
+++ b/src/FoundryGate.Core/Gateway/ArmApimManagementClient.cs
@@ -176,6 +176,43 @@ public sealed class ArmApimManagementClient : IApimManagementClient
         }
     }
 
+    /// <inheritdoc />
+    public async Task<string?> GetNamedValueAsync(string namedValueName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(namedValueName);
+
+        var namedValues = _armClient.GetApiManagementServiceResource(_serviceId).GetApiManagementNamedValues();
+        var response = await namedValues.GetIfExistsAsync(namedValueName, cancellationToken);
+
+        if (!response.HasValue || response.Value is not { } resource)
+        {
+            return null;
+        }
+
+        // listValue, not the data off the GET: ARM omits properties.value for a secret named value,
+        // so reading the resource would be right only for the non-secret half of the contract.
+        var secret = await resource.GetValueAsync(cancellationToken);
+        return secret.Value?.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task SetNamedValueAsync(string namedValueName, string value, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(namedValueName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var content = new ApiManagementNamedValueCreateOrUpdateContent
+        {
+            // Must equal the ARM name: {{token}} in a policy resolves against displayName.
+            DisplayName = namedValueName,
+            Value = value,
+            IsSecret = false,
+        };
+
+        var namedValues = _armClient.GetApiManagementServiceResource(_serviceId).GetApiManagementNamedValues();
+        _ = await namedValues.CreateOrUpdateAsync(WaitUntil.Completed, namedValueName, content, ifMatch: ETag.All, cancellationToken: cancellationToken);
+    }
+
     private ApiManagementSubscriptionResource Subscription(string subscriptionName) =>
         _armClient.GetApiManagementSubscriptionResource(
             ApiManagementSubscriptionResource.CreateResourceIdentifier(_subscriptionId, _resourceGroup, _apimName, subscriptionName));

--- a/src/FoundryGate.Core/Gateway/IApimManagementClient.cs
+++ b/src/FoundryGate.Core/Gateway/IApimManagementClient.cs
@@ -65,6 +65,33 @@ public interface IApimManagementClient
 
     /// <summary>Deletes the subscription (the key stops working immediately). <see langword="false"/> when it was already gone — deletion is idempotent.</summary>
     Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The current value of an APIM <em>named value</em>, or <see langword="null"/> when no named value
+    /// of that name exists. The gateway's per-tier model alias maps live in
+    /// <c>fg-model-map-{tier}</c> (plans/25, #86), which is why this pair exists at all: the alias map
+    /// is the allowlist, and editing it is a control-plane operation that must not require a policy
+    /// redeploy.
+    /// </summary>
+    /// <remarks>
+    /// Read through APIM's <c>listValue</c> operation rather than the resource GET: ARM does not fill
+    /// <c>properties.value</c> on a GET for secret named values, and depending on which of the two
+    /// shapes comes back would make the read correct only for the non-secret case.
+    /// </remarks>
+    /// <param name="namedValueName">ARM name of the named value, e.g. <c>fg-model-map-standard</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string?> GetNamedValueAsync(string namedValueName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates or replaces a non-secret named value. <c>displayName</c> is set to the same string as
+    /// the ARM name, because that is what a policy's <c>{{token}}</c> resolves against
+    /// (<c>infra/modules/ai-gateway.bicep</c> does the same) — a mismatch would leave the policy
+    /// reading a token that no longer exists.
+    /// </summary>
+    /// <param name="namedValueName">ARM name of the named value.</param>
+    /// <param name="value">The new value. APIM rejects an empty or whitespace-only value.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetNamedValueAsync(string namedValueName, string value, CancellationToken cancellationToken);
 }
 
 /// <summary>A subscription as the management plane reports it, minus key material.</summary>

--- a/src/FoundryGate.Core/Gateway/UnconfiguredApimManagementClient.cs
+++ b/src/FoundryGate.Core/Gateway/UnconfiguredApimManagementClient.cs
@@ -47,4 +47,12 @@ public sealed class UnconfiguredApimManagementClient : IApimManagementClient
     /// <inheritdoc />
     public Task<bool> DeleteSubscriptionAsync(string subscriptionName, CancellationToken cancellationToken) =>
         throw new FeatureNotConfiguredException(Message);
+
+    /// <inheritdoc />
+    public Task<string?> GetNamedValueAsync(string namedValueName, CancellationToken cancellationToken) =>
+        throw new FeatureNotConfiguredException(Message);
+
+    /// <inheritdoc />
+    public Task SetNamedValueAsync(string namedValueName, string value, CancellationToken cancellationToken) =>
+        throw new FeatureNotConfiguredException(Message);
 }

--- a/src/FoundryGate.Domain/Constants/AuditActions.cs
+++ b/src/FoundryGate.Domain/Constants/AuditActions.cs
@@ -125,6 +125,16 @@ public static class AuditActions
     /// </summary>
     public const string FoundryDeploymentCapacityChanged = "foundry.deployment.capacity-changed";
 
+    // -- Gateway model allowlist (#225) --
+
+    /// <summary>
+    /// <c>PUT /gateway/tiers/{tier}/models</c> — a tier's model allowlist replaced, which is a live
+    /// change to what the gateway permits (the <c>fg-model-map-{tier}</c> named value, #86). Details
+    /// carry the whole map <c>{ before, after }</c>: the map is small, and "which models did this tier
+    /// have last Tuesday" is the question the trail has to answer.
+    /// </summary>
+    public const string GatewayModelsUpdated = "gateway.models.updated";
+
     // -- Config (spec 4.6) --
 
     public const string ConfigUpdated = "config.updated";

--- a/src/FoundryGate.Domain/Constants/AuditTargetTypes.cs
+++ b/src/FoundryGate.Domain/Constants/AuditTargetTypes.cs
@@ -29,4 +29,7 @@ public static class AuditTargetTypes
 
     /// <summary>An Azure AI Foundry model deployment; <c>TargetId</c> is <c>{accountName}/{deploymentName}</c> — the gateway runs one account per region, so the name alone is ambiguous for pooled models.</summary>
     public const string FoundryDeployment = "FoundryDeployment";
+
+    /// <summary>A gateway quota-tier product; <c>TargetId</c> is the tier's APIM product id (a <see cref="GatewayTiers"/> value). What a model-allowlist change is recorded against (#225).</summary>
+    public const string GatewayTier = "GatewayTier";
 }

--- a/src/FoundryGate.Domain/Constants/GatewayModelMap.cs
+++ b/src/FoundryGate.Domain/Constants/GatewayModelMap.cs
@@ -1,0 +1,81 @@
+namespace FoundryGate.Domain.Constants;
+
+/// <summary>
+/// The naming contract between <c>infra/modules/ai-gateway.bicep</c> and the control plane for the
+/// per-tier model alias map (#86, plans/25). The map is the allowlist: one APIM named value per
+/// quota-tier product, holding <c>{ alias: { deployment, backend, provider } }</c>, which the tier's
+/// product policy hands to <c>infra/policies/model-alias-fragment.xml</c>. The control plane edits
+/// those named values through the APIM Management API, which is only safe if it spells the names and
+/// the backend ids exactly as the bicep does — hence these constants rather than string literals in
+/// a service.
+/// </summary>
+/// <remarks>
+/// <c>pool</c> and <c>backend</c> are two views of the same choice: the bicep parameter takes a
+/// logical <c>pool</c> (<c>anthropic</c> / <c>openai</c>) and renders it into the real APIM backend
+/// id before writing the named value, because the policy's <c>set-backend-service</c> needs the id.
+/// <see cref="BackendForPool"/> and <see cref="PoolForBackend"/> are that same mapping, in both
+/// directions, so a value written by the API and a value written by a deploy are indistinguishable.
+/// </remarks>
+public static class GatewayModelMap
+{
+    /// <summary>Prefix of the per-tier named value; the tier's APIM product id completes it.</summary>
+    public const string NamedValuePrefix = "fg-model-map-";
+
+    /// <summary>The multi-region Anthropic backend pool's APIM backend id (<c>ai-gateway.bicep</c>'s <c>anthropicPoolName</c>).</summary>
+    public const string AnthropicPoolBackend = "foundry-anthropic-pool";
+
+    /// <summary>Prefix of the single-account OpenAI backend id (<c>ai-gateway.bicep</c>'s <c>openaiBackendName</c>); the primary Foundry account name completes it.</summary>
+    public const string OpenAiBackendPrefix = "foundry-openai-";
+
+    /// <summary>Logical pool name for the multi-region Anthropic pool — a request routed here may land in any pool member.</summary>
+    public const string AnthropicPool = "anthropic";
+
+    /// <summary>Logical pool name for the primary account's OpenAI backend — single region, no failover.</summary>
+    public const string OpenAiPool = "openai";
+
+    /// <summary>
+    /// The alias names the gateway accepts: lower-case, starting with a letter or digit, and made of
+    /// characters that need no escaping in a request body or a URL. Aliases travel in a JSON
+    /// <c>model</c> field and are compared by the policy without normalization, so mixed case would
+    /// mean <c>Sonnet</c> silently missing an allowlist that lists <c>sonnet</c>.
+    /// </summary>
+    public const string AliasPattern = "^[a-z0-9][a-z0-9._-]*$";
+
+    /// <summary>Both logical pools, in the order the UI offers them.</summary>
+    public static readonly IReadOnlyList<string> Pools = [AnthropicPool, OpenAiPool];
+
+    /// <summary>The named value holding <paramref name="tierProductId"/>'s alias map.</summary>
+    public static string NamedValueName(string tierProductId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tierProductId);
+
+        return NamedValuePrefix + tierProductId.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The APIM backend id a logical pool routes at, resolved exactly as the bicep resolves it:
+    /// <c>openai</c> → the primary account's OpenAI backend, anything else → the Anthropic pool
+    /// (the bicep's own <c>pool == 'openai' ? … : …</c>).
+    /// </summary>
+    /// <param name="pool">A logical pool name (<see cref="Pools"/>).</param>
+    /// <param name="primaryFoundryAccountName">The first entry of <c>Gateway:FoundryAccountNames</c> — the account the OpenAI backend points at.</param>
+    public static string BackendForPool(string pool, string primaryFoundryAccountName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(primaryFoundryAccountName);
+
+        return string.Equals(pool, OpenAiPool, StringComparison.OrdinalIgnoreCase)
+            ? OpenAiBackendPrefix + primaryFoundryAccountName
+            : AnthropicPoolBackend;
+    }
+
+    /// <summary>
+    /// The logical pool a stored backend id came from — the inverse of <see cref="BackendForPool"/>,
+    /// so a map written by a deploy reads back into the same vocabulary the UI edits in. An
+    /// unrecognized backend id reads as <see cref="AnthropicPool"/>, matching the bicep's own
+    /// "anything that is not openai is the pool" default.
+    /// </summary>
+    public static string PoolForBackend(string? backend) =>
+        backend is not null && backend.StartsWith(OpenAiBackendPrefix, StringComparison.OrdinalIgnoreCase)
+            ? OpenAiPool
+            : AnthropicPool;
+}

--- a/src/FoundryGate.Domain/Gateway/Contracts/GatewayContracts.cs
+++ b/src/FoundryGate.Domain/Gateway/Contracts/GatewayContracts.cs
@@ -1,0 +1,112 @@
+using System.ComponentModel.DataAnnotations;
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Domain.Gateway.Contracts;
+
+/// <summary>
+/// One quota-tier product as <c>GET /api/v1/gateway/tiers</c> reports it — the tiers whose model
+/// allowlists <c>/models</c> edits (#225). Same tier table the quota endpoints resolve against
+/// (<c>Gateway:Tiers</c>, projected from <c>infra/main.bicep</c>'s <c>quotaTiers</c>), plus how many
+/// models the tier currently permits.
+/// </summary>
+/// <param name="Tier">APIM product id — a <see cref="GatewayTiers"/> value.</param>
+/// <param name="DisplayName">The tier's human label; falls back to <paramref name="Tier"/> when infra emitted none.</param>
+/// <param name="MonthlyTokenQuota">Tokens per calendar month the tier's <c>llm-token-limit</c> policy enforces, or <see langword="null"/> for the unlimited tier.</param>
+/// <param name="IsUnlimited">True when the tier carries no monthly cap (TPM smoothing only).</param>
+/// <param name="AllowedModelCount">
+/// Aliases the tier's <c>fg-model-map-{tier}</c> named value lists right now. <c>0</c> is a real
+/// answer, not a missing one: a tier with no map permits no models at all (the allowlist fails loud,
+/// by design).
+/// </param>
+public record GatewayTierResponse(
+    string Tier,
+    string DisplayName,
+    long? MonthlyTokenQuota,
+    bool IsUnlimited,
+    int AllowedModelCount);
+
+/// <summary>
+/// A tier's model allowlist — <c>GET /api/v1/gateway/tiers/{tier}/models</c>, admin-only. The rows
+/// are the tier's <c>fg-model-map-{tier}</c> named value as APIM holds it right now, read back
+/// through the Management API rather than from configuration, because the named value is the thing
+/// the gateway actually enforces.
+/// </summary>
+/// <param name="Tier">The tier this map belongs to.</param>
+/// <param name="DisplayName">The tier's human label.</param>
+/// <param name="Aliases">The permitted aliases, ordered by alias.</param>
+public record GatewayTierModelsResponse(
+    string Tier,
+    string DisplayName,
+    IReadOnlyList<GatewayModelAliasResponse> Aliases);
+
+/// <summary>
+/// One row of a tier's alias map, with what the control plane knows about whether it would actually
+/// work. A row whose deployment is missing is still returned — hiding it would make a broken map look
+/// like a smaller one — but it is flagged so the UI can say which model is about to 404.
+/// </summary>
+/// <param name="Alias">The virtual model name a developer pins, e.g. <c>sonnet</c>.</param>
+/// <param name="DeploymentName">The real Foundry deployment it resolves to.</param>
+/// <param name="Pool">The logical backend pool the request is routed at — <c>anthropic</c> or <c>openai</c> (<see cref="GatewayModelMap"/>).</param>
+/// <param name="Provider">The front door the alias belongs to; a right-plan/wrong-door request is refused by the policy naming the correct base path.</param>
+/// <param name="DeploymentExists">
+/// True when at least one configured Foundry account has a deployment of that name. False means every
+/// request for this alias reaches a backend that has never heard of it.
+/// </param>
+/// <param name="MissingFromAccounts">
+/// Configured accounts that do <em>not</em> carry the deployment. Empty for a healthy pooled model.
+/// Non-empty on an <c>anthropic</c>-pool alias is the dangerous shape: the pool fails a 429 over to
+/// another region, and a region missing the deployment turns a throttle into a 404 (the contract
+/// stated in <c>infra/main.bicep</c>).
+/// </param>
+public record GatewayModelAliasResponse(
+    string Alias,
+    string DeploymentName,
+    string Pool,
+    ModelProviderType Provider,
+    bool DeploymentExists,
+    IReadOnlyList<string> MissingFromAccounts);
+
+/// <summary>
+/// <c>PUT /api/v1/gateway/tiers/{tier}/models</c> body: the tier's allowlist in full. A replace, not a
+/// patch — the named value is one JSON document, the map is small, and "these are the models this tier
+/// may use" is the sentence an admin is actually writing. An empty list is legal and means the tier
+/// permits nothing.
+/// </summary>
+/// <remarks>
+/// An init-property record with attributes on the properties, per CONVENTIONS.md — the one placement
+/// MVC model binding, <c>Validator</c> and Blazor's <c>DataAnnotationsValidator</c> all agree on.
+/// </remarks>
+public record ReplaceTierModelsRequest
+{
+    /// <summary>
+    /// The aliases this tier may use. Each alias may appear once; the service refuses duplicates
+    /// (case-insensitively) rather than letting list order decide which deployment wins.
+    /// </summary>
+    [Required]
+    public IList<TierModelAliasRequest> Aliases { get; init; } = [];
+}
+
+/// <summary>One entry of a <see cref="ReplaceTierModelsRequest"/>.</summary>
+public record TierModelAliasRequest
+{
+    /// <summary>The virtual model name, lower-case and url-safe (<see cref="GatewayModelMap.AliasPattern"/>).</summary>
+    [Required]
+    [StringLength(ValidationConstants.FoundryDeploymentNameMaxLength, MinimumLength = 1)]
+    [RegularExpression(GatewayModelMap.AliasPattern)]
+    public string Alias { get; init; } = string.Empty;
+
+    /// <summary>The Foundry deployment it resolves to. Must exist in a configured account — in <em>every</em> configured account for an <c>anthropic</c>-pool alias.</summary>
+    [Required]
+    [StringLength(ValidationConstants.FoundryDeploymentNameMaxLength, MinimumLength = 1)]
+    [RegularExpression(ValidationConstants.FoundryDeploymentNamePattern)]
+    public string DeploymentName { get; init; } = string.Empty;
+
+    /// <summary>The logical backend pool (<c>anthropic</c> or <c>openai</c>); the service resolves it to the real APIM backend id exactly as the bicep does.</summary>
+    [Required]
+    [StringLength(ValidationConstants.FoundryDeploymentNameMaxLength, MinimumLength = 1)]
+    public string Pool { get; init; } = GatewayModelMap.AnthropicPool;
+
+    /// <summary>Which front door the alias belongs to.</summary>
+    public ModelProviderType Provider { get; init; }
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/ApiTestFactory.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -111,6 +112,20 @@ public class ApiTestFactory : WebApplicationFactory<Program>
         }
 
         return client;
+    }
+
+    /// <summary>
+    /// Drops every <see cref="IMemoryCache"/> entry the host holds — the Foundry model and catalogue
+    /// caches, and the gateway model-map and deployment-placement caches. A test class shares one host,
+    /// so a test that seeds a deployment or a named value <em>behind</em> the app's back must call this
+    /// or it may read what an earlier test's request cached.
+    /// </summary>
+    public void ClearCaches()
+    {
+        if (Services.GetRequiredService<IMemoryCache>() is MemoryCache memoryCache)
+        {
+            memoryCache.Clear();
+        }
     }
 
     /// <summary>

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/GatewayEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/GatewayEndpointTests.cs
@@ -1,0 +1,344 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Azure;
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Gateway.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FoundryGate.Tests.Predeployment.Api.Endpoints;
+
+/// <summary>
+/// <c>/api/v1/gateway/*</c> through the real pipeline against the factory's in-memory APIM and ARM
+/// fakes (#225): the auth matrix, the tier list, reading a tier's model allowlist out of the
+/// <c>fg-model-map-{tier}</c> named value, replacing it, the refusals that stop a map the gateway
+/// would answer with a 404 instead of an honest 403, and the audit row a change leaves.
+/// </summary>
+/// <remarks>
+/// One factory per class, so tests share a database and an APIM fake — every test therefore works on
+/// its own tier's named value where it can, and asserts on rows it seeded itself rather than on
+/// absolute counts.
+/// </remarks>
+public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTestFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string TiersPath = "/api/v1/gateway/tiers";
+
+    [Theory]
+    [InlineData("GET", TiersPath)]
+    [InlineData("GET", TiersPath + "/standard/models")]
+    [InlineData("PUT", TiersPath + "/standard/models")]
+    public async Task Anonymous_request_returns_401(string method, string path)
+    {
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), new Uri(path, UriKind.Relative));
+        if (method == "PUT")
+        {
+            request.Content = JsonContent.Create(new ReplaceTierModelsRequest(), options: JsonOptions);
+        }
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("GET", TiersPath)]
+    [InlineData("GET", TiersPath + "/standard/models")]
+    [InlineData("PUT", TiersPath + "/standard/models")]
+    public async Task Non_admin_returns_403(string method, string path)
+    {
+        // The allowlist decides what every developer on a tier can reach, so reading it is admin-only
+        // too — a developer's own view is the filtered alias list on GET /users/me.
+        using var client = factory.CreateClientAs(Guid.NewGuid().ToString(), isAdmin: false);
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), new Uri(path, UriKind.Relative));
+        if (method == "PUT")
+        {
+            request.Content = JsonContent.Create(new ReplaceTierModelsRequest(), options: JsonOptions);
+        }
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Tiers_are_the_configured_quota_tiers_with_their_allowlist_sizes()
+    {
+        factory.Apim.SeedNamedValue(
+            GatewayModelMap.NamedValueName(GatewayTiers.Power),
+            """{"sonnet":{"deployment":"claude-sonnet-4-5","backend":"foundry-anthropic-pool","provider":"anthropic"}}""");
+
+        using var client = await AdminClientAsync();
+
+        var tiers = await client.GetFromJsonAsync<IReadOnlyList<GatewayTierResponse>>(new Uri(TiersPath, UriKind.Relative), JsonOptions);
+
+        Assert.NotNull(tiers);
+        var power = Assert.Single(tiers, tier => tier.Tier == GatewayTiers.Power);
+        Assert.Equal("Power", power.DisplayName);
+        Assert.Equal(1, power.AllowedModelCount);
+
+        var unlimited = Assert.Single(tiers, tier => tier.Tier == GatewayTiers.Unlimited);
+        Assert.True(unlimited.IsUnlimited);
+        Assert.Null(unlimited.MonthlyTokenQuota);
+    }
+
+    [Fact]
+    public async Task A_tiers_models_are_read_from_the_named_value_and_flagged_against_the_real_deployments()
+    {
+        // Deployed in the primary account only, but routed at the pooled Anthropic backend: exactly the
+        // shape that turns a 429 failover into a 404, so the read has to say which region is missing it.
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "half-deployed-model");
+
+        factory.Apim.SeedNamedValue(
+            GatewayModelMap.NamedValueName(GatewayTiers.Standard),
+            """
+            {
+              "half": {"deployment":"half-deployed-model","backend":"foundry-anthropic-pool","provider":"anthropic"},
+              "ghost": {"deployment":"model-nobody-deployed","backend":"foundry-openai-fgtest-eus2","provider":"openai"}
+            }
+            """);
+
+        using var client = await AdminClientAsync();
+
+        var models = await client.GetFromJsonAsync<GatewayTierModelsResponse>(
+            new Uri($"{TiersPath}/{GatewayTiers.Standard}/models", UriKind.Relative),
+            JsonOptions);
+
+        Assert.NotNull(models);
+
+        var half = Assert.Single(models.Aliases, alias => alias.Alias == "half");
+        Assert.True(half.DeploymentExists);
+        Assert.Equal(GatewayModelMap.AnthropicPool, half.Pool);
+        Assert.Equal(ModelProviderType.Anthropic, half.Provider);
+        Assert.Equal([ApiTestFactory.SecondaryFoundryAccount], half.MissingFromAccounts);
+
+        var ghost = Assert.Single(models.Aliases, alias => alias.Alias == "ghost");
+        Assert.False(ghost.DeploymentExists);
+        Assert.Equal(GatewayModelMap.OpenAiPool, ghost.Pool);
+        Assert.Equal(ModelProviderType.OpenAi, ghost.Provider);
+    }
+
+    [Fact]
+    public async Task An_unknown_tier_is_404()
+    {
+        using var client = await AdminClientAsync();
+
+        var response = await client.GetAsync(new Uri($"{TiersPath}/platinum/models", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Replacing_the_allowlist_writes_the_named_value_and_audits_before_and_after()
+    {
+        const string Tier = GatewayTiers.Unlimited;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "audited-openai-model");
+        factory.Apim.SeedNamedValue(GatewayModelMap.NamedValueName(Tier), "{}");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias("audited", "audited-openai-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // The named value carries the resolved APIM backend id, not the logical pool: that is what the
+        // policy's set-backend-service needs, and it is what the bicep writes.
+        var stored = factory.Apim.NamedValueOf(GatewayModelMap.NamedValueName(Tier));
+        Assert.NotNull(stored);
+        Assert.Contains("\"deployment\":\"audited-openai-model\"", stored, StringComparison.Ordinal);
+        Assert.Contains($"\"backend\":\"{GatewayModelMap.OpenAiBackendPrefix}{ApiTestFactory.PrimaryFoundryAccount}\"", stored, StringComparison.Ordinal);
+        Assert.Contains("\"provider\":\"openai\"", stored, StringComparison.Ordinal);
+
+        await using var dbContext = factory.CreateDbContext();
+        var audit = await dbContext.AuditLogs
+            .Where(log => log.Action == AuditActions.GatewayModelsUpdated && log.TargetId == Tier)
+            .OrderByDescending(log => log.AuditLogId)
+            .FirstAsync();
+
+        Assert.Equal(AuditTargetTypes.GatewayTier, audit.TargetType);
+        Assert.Contains("before", audit.Details, StringComparison.Ordinal);
+        Assert.Contains("audited-openai-model", audit.Details, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Writing_the_map_it_already_holds_changes_nothing()
+    {
+        const string Tier = GatewayTiers.Power;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "noop-model");
+        var name = GatewayModelMap.NamedValueName(Tier);
+        var backend = GatewayModelMap.OpenAiBackendPrefix + ApiTestFactory.PrimaryFoundryAccount;
+        factory.Apim.SeedNamedValue(
+            name,
+            "{\"noop\":{\"deployment\":\"noop-model\",\"backend\":\"" + backend + "\",\"provider\":\"openai\"}}");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var before = factory.Apim.Calls.Count(call => call.StartsWith("SetNamedValue:", StringComparison.Ordinal));
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias("noop", "noop-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // An audit row claiming a change that did not happen is worse than silence, and a write APIM
+        // did not need is churn on the thing every request reads.
+        Assert.Equal(before, factory.Apim.Calls.Count(call => call.StartsWith("SetNamedValue:", StringComparison.Ordinal)));
+    }
+
+    [Theory]
+    [InlineData("Sonnet", "Uppercase isn't a usable alias — the policy compares without normalizing.")]
+    [InlineData("-leading", "An alias has to start with a letter or digit.")]
+    public async Task A_malformed_alias_is_400(string alias, string because)
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "malformed-alias-model");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{GatewayTiers.Standard}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias(alias, "malformed-alias-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+            },
+            JsonOptions);
+
+        Assert.True(response.StatusCode == HttpStatusCode.BadRequest, because);
+    }
+
+    [Fact]
+    public async Task An_alias_pointing_at_a_deployment_that_does_not_exist_is_400()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{GatewayTiers.Standard}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias("nowhere", "no-such-deployment-anywhere", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("does not exist in any", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_pooled_alias_whose_deployment_is_missing_from_a_region_is_400()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+
+        // Primary only, routed at the pool: the failover-into-404 shape infra/main.bicep warns about.
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "single-region-model");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{GatewayTiers.Standard}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias("pooled", "single-region-model", GatewayModelMap.AnthropicPool, ModelProviderType.Anthropic)],
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(ApiTestFactory.SecondaryFoundryAccount, await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_same_alias_twice_is_400()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "dupe-model");
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+        var response = await client.PutAsJsonAsync(
+            new Uri($"{TiersPath}/{GatewayTiers.Standard}/models", UriKind.Relative),
+            new ReplaceTierModelsRequest
+            {
+                Aliases =
+                [
+                    Alias("dupe", "dupe-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi),
+                    Alias("dupe", "dupe-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi),
+                ],
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task APIM_refusing_the_write_is_409_and_leaves_the_allowlist_alone()
+    {
+        const string Tier = GatewayTiers.Standard;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "refused-model");
+
+        factory.Apim.ThrowOnSetNamedValue = new RequestFailedException(412, "Precondition failed.");
+        try
+        {
+            using var client = factory.CreateClientAs(oid, isAdmin: true);
+
+            var response = await client.PutAsJsonAsync(
+                new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative),
+                new ReplaceTierModelsRequest
+                {
+                    Aliases = [Alias("refused", "refused-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+                },
+                JsonOptions);
+
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        }
+        finally
+        {
+            factory.Apim.ThrowOnSetNamedValue = null;
+        }
+    }
+
+    /// <summary>An admin whose <c>User</c> row exists — every mutation needs one (403 otherwise).</summary>
+    private async Task<HttpClient> AdminClientAsync()
+    {
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        return factory.CreateClientAs(oid, isAdmin: true);
+    }
+
+    private static TierModelAliasRequest Alias(string alias, string deploymentName, string pool, ModelProviderType provider) =>
+        new()
+        {
+            Alias = alias,
+            DeploymentName = deploymentName,
+            Pool = pool,
+            Provider = provider,
+        };
+}

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/GatewayEndpointTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/GatewayEndpointTests.cs
@@ -124,6 +124,76 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
     }
 
     [Fact]
+    public async Task Reading_a_tier_twice_asks_APIM_once()
+    {
+        // Rendering /models asks for every tier's map twice — once for the counts, once per tier for
+        // the rows — and each read would otherwise re-enumerate every Foundry account behind it.
+        const string Tier = GatewayTiers.Power;
+        factory.Apim.SeedNamedValue(GatewayModelMap.NamedValueName(Tier), "{}");
+
+        using var client = await AdminClientAsync();
+        var path = new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative);
+
+        _ = await client.GetAsync(path);
+        var afterFirst = factory.Apim.Calls.Count(call => call == $"GetNamedValue:{GatewayModelMap.NamedValueName(Tier)}");
+
+        _ = await client.GetAsync(path);
+
+        Assert.Equal(afterFirst, factory.Apim.Calls.Count(call => call == $"GetNamedValue:{GatewayModelMap.NamedValueName(Tier)}"));
+    }
+
+    [Fact]
+    public async Task A_write_replaces_what_the_next_read_serves()
+    {
+        // The read cache must not outlive the change it describes: an admin who allows a model and
+        // sees the old list would reasonably conclude the write failed.
+        const string Tier = GatewayTiers.Power;
+        var oid = Guid.NewGuid().ToString();
+        _ = await factory.SeedUserAsync(oid);
+        _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "cache-busting-model");
+        factory.Apim.SeedNamedValue(GatewayModelMap.NamedValueName(Tier), "{}");
+        factory.ClearCaches();
+
+        using var client = factory.CreateClientAs(oid, isAdmin: true);
+        var path = new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative);
+
+        var before = await client.GetFromJsonAsync<GatewayTierModelsResponse>(path, JsonOptions);
+        Assert.Empty(before!.Aliases);
+
+        _ = await client.PutAsJsonAsync(
+            path,
+            new ReplaceTierModelsRequest
+            {
+                Aliases = [Alias("cachebuster", "cache-busting-model", GatewayModelMap.OpenAiPool, ModelProviderType.OpenAi)],
+            },
+            JsonOptions);
+
+        var after = await client.GetFromJsonAsync<GatewayTierModelsResponse>(path, JsonOptions);
+
+        Assert.Equal("cachebuster", Assert.Single(after!.Aliases).Alias);
+    }
+
+    [Fact]
+    public async Task A_half_written_map_entry_is_dropped_rather_than_rendered()
+    {
+        // plans/25: an entry missing any of its three fields is blocked by the policy exactly as an
+        // absent one is. Reporting it as a row would promise a model the gateway refuses — and would
+        // make the projection look a null deployment name up.
+        const string Tier = GatewayTiers.Unlimited;
+        factory.Apim.SeedNamedValue(
+            GatewayModelMap.NamedValueName(Tier),
+            """{"broken":{"backend":"foundry-anthropic-pool","provider":"anthropic"}}""");
+
+        using var client = await AdminClientAsync();
+
+        var models = await client.GetFromJsonAsync<GatewayTierModelsResponse>(
+            new Uri($"{TiersPath}/{Tier}/models", UriKind.Relative),
+            JsonOptions);
+
+        Assert.Empty(models!.Aliases);
+    }
+
+    [Fact]
     public async Task An_unknown_tier_is_404()
     {
         using var client = await AdminClientAsync();
@@ -143,6 +213,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "audited-openai-model");
         factory.Apim.SeedNamedValue(GatewayModelMap.NamedValueName(Tier), "{}");
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var response = await client.PutAsJsonAsync(
@@ -188,6 +259,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
             name,
             "{\"noop\":{\"deployment\":\"noop-model\",\"backend\":\"" + backend + "\",\"provider\":\"openai\"}}");
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var before = factory.Apim.Calls.Count(call => call.StartsWith("SetNamedValue:", StringComparison.Ordinal));
@@ -216,6 +288,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         _ = await factory.SeedUserAsync(oid);
         _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "malformed-alias-model");
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var response = await client.PutAsJsonAsync(
@@ -235,6 +308,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         var oid = Guid.NewGuid().ToString();
         _ = await factory.SeedUserAsync(oid);
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var response = await client.PutAsJsonAsync(
@@ -258,6 +332,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         // Primary only, routed at the pool: the failover-into-404 shape infra/main.bicep warns about.
         _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "single-region-model");
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var response = await client.PutAsJsonAsync(
@@ -279,6 +354,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         _ = await factory.SeedUserAsync(oid);
         _ = factory.FoundryClient.Seed(ApiTestFactory.PrimaryFoundryAccount, "dupe-model");
 
+        factory.ClearCaches();
         using var client = factory.CreateClientAs(oid, isAdmin: true);
 
         var response = await client.PutAsJsonAsync(
@@ -307,6 +383,7 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         factory.Apim.ThrowOnSetNamedValue = new RequestFailedException(412, "Precondition failed.");
         try
         {
+            factory.ClearCaches();
             using var client = factory.CreateClientAs(oid, isAdmin: true);
 
             var response = await client.PutAsJsonAsync(
@@ -325,11 +402,16 @@ public class GatewayEndpointTests(ApiTestFactory factory) : IClassFixture<ApiTes
         }
     }
 
-    /// <summary>An admin whose <c>User</c> row exists — every mutation needs one (403 otherwise).</summary>
+    /// <summary>
+    /// An admin whose <c>User</c> row exists — every mutation needs one (403 otherwise) — with the
+    /// host's read caches dropped, because this class seeds APIM named values and ARM deployments
+    /// behind the app's back and the service caches both for 15 seconds.
+    /// </summary>
     private async Task<HttpClient> AdminClientAsync()
     {
         var oid = Guid.NewGuid().ToString();
         _ = await factory.SeedUserAsync(oid);
+        factory.ClearCaches();
         return factory.CreateClientAs(oid, isAdmin: true);
     }
 

--- a/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Api/Endpoints/RequestDtoBindingTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Foundry.Contracts;
+using FoundryGate.Domain.Gateway.Contracts;
 using FoundryGate.Domain.Groups.Contracts;
 using FoundryGate.Domain.Requests.Contracts;
 using FoundryGate.Domain.Users.Contracts;
@@ -48,6 +49,8 @@ public class RequestDtoBindingTests(ApiTestFactory factory) : IClassFixture<ApiT
         { "POST", $"/api/v1/requests/{MissingId}/approve", $$"""{"reviewNotes":"{{new string('x', ValidationConstants.ReviewNotesMaxLength + 1)}}"}""", nameof(ReviewQuotaIncreaseRequest.ReviewNotes) },
         { "POST", $"/api/v1/requests/{MissingId}/reject", $$"""{"reviewNotes":"{{new string('x', ValidationConstants.ReviewNotesMaxLength + 1)}}"}""", nameof(ReviewQuotaIncreaseRequest.ReviewNotes) },
         { "PATCH", "/api/v1/foundry/deployments/nowhere/nothing/capacity", """{"capacity":0}""", nameof(UpdateFoundryDeploymentCapacityRequest.Capacity) },
+        { "PUT", $"/api/v1/gateway/tiers/{GatewayTiers.Standard}/models", """{"aliases":[{"alias":"NotLowerCase","deploymentName":"whatever","pool":"openai"}]}""", $"{nameof(ReplaceTierModelsRequest.Aliases)}[0].{nameof(TierModelAliasRequest.Alias)}" },
+        { "PUT", $"/api/v1/gateway/tiers/{GatewayTiers.Standard}/models", """{"aliases":[{"alias":"sonnet","deploymentName":"","pool":"openai"}]}""", $"{nameof(ReplaceTierModelsRequest.Aliases)}[0].{nameof(TierModelAliasRequest.DeploymentName)}" },
     };
 
     [Theory]

--- a/src/FoundryGate.Tests.Predeployment/Domain/GatewayModelMapTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Domain/GatewayModelMapTests.cs
@@ -1,0 +1,56 @@
+using FoundryGate.Domain.Constants;
+
+namespace FoundryGate.Tests.Predeployment.Domain;
+
+/// <summary>
+/// The naming contract between <c>infra/modules/ai-gateway.bicep</c> and the control plane (#225).
+/// A map written by a deploy and a map written by the API have to be the same document — the policy
+/// substitutes it verbatim — so the named-value name and the pool↔backend mapping are checked here
+/// against the literals the bicep uses, not against the service's own opinion of them.
+/// </summary>
+public class GatewayModelMapTests
+{
+    [Fact]
+    public void The_named_value_name_is_the_one_the_bicep_creates()
+    {
+        // infra/modules/ai-gateway.bicep: 'fg-model-map-${tier.name}', one per quotaTiers entry.
+        Assert.Equal("fg-model-map-standard", GatewayModelMap.NamedValueName(GatewayTiers.Standard));
+        Assert.Equal("fg-model-map-unlimited", GatewayModelMap.NamedValueName(GatewayTiers.Unlimited));
+    }
+
+    [Fact]
+    public void A_tier_id_in_the_wrong_case_still_names_the_same_named_value()
+    {
+        // Route values reach the service however the caller spelled them, and APIM named values are
+        // created lower-case.
+        Assert.Equal("fg-model-map-power", GatewayModelMap.NamedValueName("POWER"));
+    }
+
+    [Theory]
+    [InlineData(GatewayModelMap.AnthropicPool, GatewayModelMap.AnthropicPoolBackend)]
+    [InlineData(GatewayModelMap.OpenAiPool, "foundry-openai-fg-eastus2")]
+    public void A_pool_resolves_to_the_backend_id_the_bicep_would_have_written(string pool, string expectedBackend) =>
+        Assert.Equal(expectedBackend, GatewayModelMap.BackendForPool(pool, "fg-eastus2"));
+
+    [Fact]
+    public void An_unrecognised_pool_falls_back_to_the_anthropic_pool_exactly_as_the_bicep_does() =>
+        // The bicep's own expression is `pool == 'openai' ? openai : pool`, so anything else is the pool.
+        Assert.Equal(GatewayModelMap.AnthropicPoolBackend, GatewayModelMap.BackendForPool("something-else", "fg-eastus2"));
+
+    [Theory]
+    [InlineData(GatewayModelMap.AnthropicPoolBackend, GatewayModelMap.AnthropicPool)]
+    [InlineData("foundry-openai-fg-eastus2", GatewayModelMap.OpenAiPool)]
+    [InlineData(null, GatewayModelMap.AnthropicPool)]
+    public void A_stored_backend_id_reads_back_as_the_pool_that_produced_it(string? backend, string expectedPool) =>
+        Assert.Equal(expectedPool, GatewayModelMap.PoolForBackend(backend));
+
+    [Fact]
+    public void Every_pool_survives_the_round_trip_through_a_backend_id()
+    {
+        // What makes a map written by the API editable in the UI's own vocabulary afterwards.
+        foreach (var pool in GatewayModelMap.Pools)
+        {
+            Assert.Equal(pool, GatewayModelMap.PoolForBackend(GatewayModelMap.BackendForPool(pool, "fg-eastus2")));
+        }
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
+++ b/src/FoundryGate.Tests.Predeployment/Support/FakeApimManagementClient.cs
@@ -20,6 +20,7 @@ public sealed class FakeApimManagementClient : IApimManagementClient
     private readonly Lock _gate = new();
     private readonly Dictionary<string, Entry> _subscriptions = new(StringComparer.Ordinal);
     private readonly List<string> _calls = [];
+    private readonly Dictionary<string, string> _namedValues = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Every call, as <c>"{Method}:{subscriptionName}"</c> (plus <c>:{productId}</c> where relevant), in order.</summary>
     public IReadOnlyList<string> Calls
@@ -56,6 +57,9 @@ public sealed class FakeApimManagementClient : IApimManagementClient
 
     /// <summary>When set, <see cref="DeleteSubscriptionAsync"/> throws it instead of deleting — simulates ARM refusing a deprovision.</summary>
     public Exception? ThrowOnDelete { get; set; }
+
+    /// <summary>When set, <see cref="SetNamedValueAsync"/> throws it — simulates APIM refusing a model-map write (#225).</summary>
+    public Exception? ThrowOnSetNamedValue { get; set; }
 
     /// <summary>
     /// Subscription names whose <see cref="DeleteSubscriptionAsync"/> throws a <c>429</c> — for asserting
@@ -127,6 +131,24 @@ public sealed class FakeApimManagementClient : IApimManagementClient
         {
             var entry = _subscriptions[subscriptionName];
             return new ApimSubscriptionKeys(entry.PrimaryKey, entry.SecondaryKey);
+        }
+    }
+
+    /// <summary>Sets a named value behind the caller's back — how a test arranges a tier's existing model alias map (#225).</summary>
+    public void SeedNamedValue(string namedValueName, string value)
+    {
+        lock (_gate)
+        {
+            _namedValues[namedValueName] = value;
+        }
+    }
+
+    /// <summary>The current value of a named value without going through the interface (no call is logged); <see langword="null"/> when absent.</summary>
+    public string? NamedValueOf(string namedValueName)
+    {
+        lock (_gate)
+        {
+            return _namedValues.TryGetValue(namedValueName, out var value) ? value : null;
         }
     }
 
@@ -267,6 +289,34 @@ public sealed class FakeApimManagementClient : IApimManagementClient
             var removed = _subscriptions.Remove(subscriptionName);
             AfterMutation?.Invoke();
             return Task.FromResult(removed);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<string?> GetNamedValueAsync(string namedValueName, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"GetNamedValue:{namedValueName}");
+            return Task.FromResult(_namedValues.TryGetValue(namedValueName, out var value) ? value : null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SetNamedValueAsync(string namedValueName, string value, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _calls.Add($"SetNamedValue:{namedValueName}");
+
+            if (ThrowOnSetNamedValue is { } exception)
+            {
+                throw exception;
+            }
+
+            _namedValues[namedValueName] = value;
+            AfterMutation?.Invoke();
+            return Task.CompletedTask;
         }
     }
 

--- a/src/FoundryGate.Tests.Predeployment/Web/AdminPageAuthorizationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/AdminPageAuthorizationTests.cs
@@ -23,6 +23,7 @@ public class AdminPageAuthorizationTests
         typeof(GroupDetail),
         typeof(Foundry),
         typeof(QuotaAllocations),
+        typeof(GatewayModels),
     ];
 
     [Theory]

--- a/src/FoundryGate.Tests.Predeployment/Web/FakeFoundryGateApiClient.Admin.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/FakeFoundryGateApiClient.Admin.cs
@@ -1,5 +1,6 @@
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Foundry.Contracts;
+using FoundryGate.Domain.Gateway.Contracts;
 using FoundryGate.Domain.Groups.Contracts;
 using FoundryGate.Domain.Users.Contracts;
 using FoundryGate.Web.Services;
@@ -28,6 +29,28 @@ public sealed partial class FakeFoundryGateApiClient
 
     public ApiCallResult<FoundryDeploymentResponse> CreateFoundryDeploymentResult { get; set; } =
         ApiCallResult<FoundryDeploymentResponse>.Fail(ApiCallStatus.Error, "No create result arranged for this test.");
+
+    /// <summary>
+    /// What <c>GET /foundry/deployments/{account}/{name}</c> answers — what <c>/foundry</c> polls after
+    /// a create (#225). Defaults to a failure, which the page reads as "polling will not answer this"
+    /// and stops, so a test that is not about polling never waits for it.
+    /// </summary>
+    public ApiCallResult<FoundryDeploymentResponse> FoundryDeploymentResult { get; set; } =
+        ApiCallResult<FoundryDeploymentResponse>.Fail(ApiCallStatus.Error, "No single-deployment result arranged for this test.");
+
+    /// <summary>What <c>GET /gateway/tiers</c> answers (#225). Defaults to the three tiers infra ships.</summary>
+    public ApiCallResult<IReadOnlyList<GatewayTierResponse>> GatewayTiersResult { get; set; } =
+        ApiCallResult<IReadOnlyList<GatewayTierResponse>>.Ok(WebTestData.AllowlistTiers);
+
+    /// <summary>
+    /// What <c>GET /gateway/tiers/{tier}/models</c> answers, per tier. A tier with no arrangement
+    /// answers an empty allowlist — which is a real state (a tier with no map permits nothing), not a
+    /// missing arrangement.
+    /// </summary>
+    public Dictionary<string, ApiCallResult<GatewayTierModelsResponse>> GatewayTierModelsResults { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>What <c>PUT /gateway/tiers/{tier}/models</c> answers. Defaults to echoing what was sent.</summary>
+    public ApiCallResult<GatewayTierModelsResponse>? ReplaceGatewayTierModelsResult { get; set; }
 
     /// <summary>
     /// What <c>POST /groups/sync-entra</c> answers. A summary, not a status: the run keeps going
@@ -59,6 +82,12 @@ public sealed partial class FakeFoundryGateApiClient
 
     public RecordedCalls<(string AccountName, string DeploymentName)> DeletedDeployments { get; } = new();
 
+    /// <summary>Every single-deployment read the page made — the poll loop's calls, in order.</summary>
+    public RecordedCalls<(string AccountName, string DeploymentName)> ReadDeployments { get; } = new();
+
+    /// <summary>Every allowlist replace the page sent, with the tier it targeted.</summary>
+    public RecordedCalls<(string Tier, ReplaceTierModelsRequest Request)> ReplacedTierModels { get; } = new();
+
     // -- Fluent arrange helpers -----------------------------------------------------------------
 
     /// <summary>What <c>GET /foundry/deployments</c> returns.</summary>
@@ -72,6 +101,17 @@ public sealed partial class FakeFoundryGateApiClient
     public FakeFoundryGateApiClient ArrangeCatalog(params FoundryCatalogEntryResponse[] entries)
     {
         FoundryCatalogResult = ApiCallResult<IReadOnlyList<FoundryCatalogEntryResponse>>.Ok(entries);
+        return this;
+    }
+
+    /// <summary>What <c>GET /gateway/tiers/{tier}/models</c> returns for one tier.</summary>
+    public FakeFoundryGateApiClient ArrangeTierModels(string tier, params GatewayModelAliasResponse[] aliases)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+        ArgumentNullException.ThrowIfNull(aliases);
+
+        GatewayTierModelsResults[tier] = ApiCallResult<GatewayTierModelsResponse>.Ok(
+            new GatewayTierModelsResponse(tier, tier, aliases));
         return this;
     }
 
@@ -111,5 +151,50 @@ public sealed partial class FakeFoundryGateApiClient
     {
         DeletedDeployments.Add((accountName, deploymentName));
         return RespondAsync(nameof(DeleteFoundryDeploymentAsync), MutationResult);
+    }
+
+    public Task<ApiCallResult<FoundryDeploymentResponse>> GetFoundryDeploymentAsync(string accountName, string deploymentName, CancellationToken ct = default)
+    {
+        ReadDeployments.Add((accountName, deploymentName));
+        return RespondAsync(nameof(GetFoundryDeploymentAsync), FoundryDeploymentResult);
+    }
+
+    public Task<ApiCallResult<IReadOnlyList<GatewayTierResponse>>> GetGatewayTiersAsync(CancellationToken ct = default) =>
+        RespondAsync(nameof(GetGatewayTiersAsync), GatewayTiersResult);
+
+    public Task<ApiCallResult<GatewayTierModelsResponse>> GetGatewayTierModelsAsync(string tier, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+
+        var arranged = GatewayTierModelsResults.TryGetValue(tier, out var result)
+            ? result
+            : ApiCallResult<GatewayTierModelsResponse>.Ok(new GatewayTierModelsResponse(tier, tier, []));
+
+        return RespondAsync(nameof(GetGatewayTierModelsAsync), arranged);
+    }
+
+    public Task<ApiCallResult<GatewayTierModelsResponse>> ReplaceGatewayTierModelsAsync(string tier, ReplaceTierModelsRequest request, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+        ArgumentNullException.ThrowIfNull(request);
+
+        ReplacedTierModels.Add((tier, request));
+
+        // Echoing the request back is what a real PUT does, so a page that renders its response
+        // renders what it just asked for — and a test that wants a refusal sets the property instead.
+        var echoed = ReplaceGatewayTierModelsResult
+            ?? ApiCallResult<GatewayTierModelsResponse>.Ok(new GatewayTierModelsResponse(
+                tier,
+                tier,
+                [.. request.Aliases.Select(alias => new GatewayModelAliasResponse(
+                    alias.Alias,
+                    alias.DeploymentName,
+                    alias.Pool,
+                    alias.Provider,
+                    true,
+                    []))]));
+
+        GatewayTierModelsResults[tier] = echoed;
+        return RespondAsync(nameof(ReplaceGatewayTierModelsAsync), echoed);
     }
 }

--- a/src/FoundryGate.Tests.Predeployment/Web/FoundryGateApiClientRouteMatchTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/FoundryGateApiClientRouteMatchTests.cs
@@ -78,6 +78,12 @@ public class FoundryGateApiClientRouteMatchTests(ApiTestFactory factory) : IClas
         { "GET", "/api/v1/foundry/catalog" },
         { "POST", "/api/v1/foundry/deployments" },
         { "DELETE", "/api/v1/foundry/deployments/fg-eastus/gpt-4-1-mini" },
+        { "GET", "/api/v1/foundry/deployments/fg-eastus/gpt-4-1-mini" },
+
+        // Gateway model allowlist (#225)
+        { "GET", "/api/v1/gateway/tiers" },
+        { "GET", "/api/v1/gateway/tiers/standard/models" },
+        { "PUT", "/api/v1/gateway/tiers/standard/models" },
 
         // Admin
         { "GET", "/api/v1/config" },

--- a/src/FoundryGate.Tests.Predeployment/Web/ModelAliasDerivationTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/ModelAliasDerivationTests.cs
@@ -1,0 +1,43 @@
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Web.Services;
+
+namespace FoundryGate.Tests.Predeployment.Web;
+
+/// <summary>
+/// The two fields the alias dialog never asks for (#225). Both are derived from the deployment's ARM
+/// <c>model.format</c> because getting either wrong produces a failure that looks like something
+/// else: a Claude alias routed at the OpenAI backend dies as an opaque 404, and one declared with
+/// the wrong provider is refused by the policy naming a base path the caller did not use.
+/// </summary>
+public class ModelAliasDerivationTests
+{
+    [Theory]
+    [InlineData("Anthropic", ModelProviderType.Anthropic)]
+    [InlineData("anthropic", ModelProviderType.Anthropic)]
+    [InlineData("OpenAI", ModelProviderType.OpenAi)]
+    [InlineData("", ModelProviderType.OpenAi)]
+    public void The_front_door_follows_the_model_format(string modelFormat, ModelProviderType expected) =>
+        Assert.Equal(expected, ModelAliasDerivation.ProviderFor(modelFormat));
+
+    [Theory]
+    [InlineData("Anthropic", GatewayModelMap.AnthropicPool)]
+    [InlineData("OpenAI", GatewayModelMap.OpenAiPool)]
+    public void The_backend_follows_the_model_format(string modelFormat, string expectedPool) =>
+        Assert.Equal(expectedPool, ModelAliasDerivation.PoolFor(modelFormat));
+
+    [Fact]
+    public void A_claude_model_is_provisioned_into_every_region_and_an_openai_model_into_the_primary_one()
+    {
+        // infra/main.bicep's pooled / primary-only split: a Claude model has to exist everywhere,
+        // because the pool sends a throttled request to another region.
+        string[] accounts = ["fg-eastus2", "fg-swedencentral"];
+
+        Assert.Equal(accounts, ModelAliasDerivation.DefaultAccountsFor("Anthropic", accounts));
+        Assert.Equal(["fg-eastus2"], ModelAliasDerivation.DefaultAccountsFor("OpenAI", accounts));
+    }
+
+    [Fact]
+    public void With_no_configured_accounts_there_is_nothing_to_pre_select() =>
+        Assert.Empty(ModelAliasDerivation.DefaultAccountsFor("OpenAI", []));
+}

--- a/src/FoundryGate.Tests.Predeployment/Web/Pages/FoundryPageTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/Pages/FoundryPageTests.cs
@@ -116,6 +116,59 @@ public class FoundryPageTests : WebTestContext
     }
 
     [Fact]
+    public void After_a_create_the_page_offers_to_allow_the_model_for_a_tier()
+    {
+        // Provisioning is half the job: the alias map is the allowlist (#86), so a deployment nobody
+        // is allowed to use is not yet usable. The link carries the name so /models can pre-fill it.
+        Api.ArrangeDeployments(WebTestData.Deployment(accountName: "fg-eastus"));
+        Api.CreateFoundryDeploymentResult = ApiCallResult<FoundryDeploymentResponse>.Ok(
+            WebTestData.Deployment(deploymentName: "gpt-5-codex", provisioningState: "Succeeded"));
+
+        var page = RenderPage<Foundry>();
+        page.WaitForAssertion(() => Assert.NotNull(page.Find("[data-testid=foundry-new]")));
+
+        page.Find("[data-testid=foundry-new]").Click();
+        page.WaitForElement("[data-testid=deployment-create]");
+
+        page.Find("input[data-testid=deployment-name]").Change("gpt-5-codex");
+        page.Find("input[data-testid=deployment-model]").Input("gpt-5-codex");
+        page.Find("input[data-testid=deployment-version]").Input("2026-01-01");
+        page.Find("input[data-testid=deployment-sku]").Input("GlobalStandard");
+        page.Find("[data-testid=deployment-create]").Click();
+
+        page.WaitForAssertion(() =>
+        {
+            var link = page.Find("[data-testid=foundry-allow-link]");
+            Assert.Equal("/models?deployment=gpt-5-codex", link.GetAttribute("href"));
+        });
+    }
+
+    [Fact]
+    public void A_create_that_ARM_reports_as_terminal_is_not_polled()
+    {
+        // Nothing to wait for: ARM answered Succeeded on acceptance, so a poll loop would only add
+        // calls. The absence of reads is the assertion.
+        Api.ArrangeDeployments(WebTestData.Deployment(accountName: "fg-eastus"));
+        Api.CreateFoundryDeploymentResult = ApiCallResult<FoundryDeploymentResponse>.Ok(
+            WebTestData.Deployment(deploymentName: "already-done", provisioningState: "Succeeded"));
+
+        var page = RenderPage<Foundry>();
+        page.WaitForAssertion(() => Assert.NotNull(page.Find("[data-testid=foundry-new]")));
+
+        page.Find("[data-testid=foundry-new]").Click();
+        page.WaitForElement("[data-testid=deployment-create]");
+
+        page.Find("input[data-testid=deployment-name]").Change("already-done");
+        page.Find("input[data-testid=deployment-model]").Input("gpt-5-codex");
+        page.Find("input[data-testid=deployment-version]").Input("2026-01-01");
+        page.Find("input[data-testid=deployment-sku]").Input("GlobalStandard");
+        page.Find("[data-testid=deployment-create]").Click();
+
+        page.WaitForAssertion(() => Assert.Single(Api.CreatedDeployments));
+        Assert.Empty(Api.ReadDeployments);
+    }
+
+    [Fact]
     public void The_create_dialog_offers_what_the_accounts_can_actually_serve()
     {
         // #173: the model and SKU suggestions came from a hardcoded array in the dialog until

--- a/src/FoundryGate.Tests.Predeployment/Web/Pages/GatewayModelsPageTests.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/Pages/GatewayModelsPageTests.cs
@@ -1,0 +1,237 @@
+using Bunit;
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Foundry;
+using FoundryGate.Domain.Gateway.Contracts;
+using FoundryGate.Web.Pages;
+using FoundryGate.Web.Services;
+
+namespace FoundryGate.Tests.Predeployment.Web.Pages;
+
+/// <summary>
+/// <c>/models</c> (#225): what each tier is allowed to use, and the three edits that change it.
+/// Every edit is a full replace of the tier's alias map — the gateway reads one JSON document — so
+/// the assertions are about the map that was <em>sent</em>, not about which row was clicked.
+/// </summary>
+public class GatewayModelsPageTests : WebTestContext
+{
+    public GatewayModelsPageTests() => SignInAsAdmin();
+
+    [Fact]
+    public void Shows_each_tiers_allowed_models_and_what_developers_would_see()
+    {
+        Api.ArrangeDeployments(WebTestData.Deployment(deploymentName: "claude-sonnet-4-5", format: FoundryModelFormatType.Anthropic));
+        Api.ArrangeTierModels(GatewayTiers.Standard, WebTestData.ModelAlias(alias: "sonnet"));
+        Api.ArrangeTierModels(GatewayTiers.Unlimited, WebTestData.ModelAlias(alias: "opus", deploymentName: "claude-opus-4-5"));
+
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() =>
+        {
+            // The overview says which tiers permit which alias — including, by "—", which do not.
+            Assert.Contains("claude-sonnet-4-5", page.Find($"[data-testid=models-cell-{GatewayTiers.Standard}-sonnet]").TextContent, StringComparison.Ordinal);
+            Assert.Contains("—", page.Find($"[data-testid=models-cell-{GatewayTiers.Power}-sonnet]").TextContent, StringComparison.Ordinal);
+
+            // The preview is the developer's-eye view: the aliases, not the deployments behind them.
+            var preview = page.Find($"[data-testid=models-preview-{GatewayTiers.Standard}]").TextContent;
+            Assert.Contains("sonnet", preview, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void A_tier_that_allows_nothing_says_so_rather_than_looking_empty()
+    {
+        // A tier with no map permits nothing, which is a working configuration and a broken one
+        // depending on intent — so the page names the consequence instead of rendering a blank table.
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() =>
+            Assert.Contains(
+                "allows no models at all",
+                page.Find($"[data-testid=models-empty-{GatewayTiers.Standard}]").TextContent,
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_row_whose_deployment_is_gone_is_flagged()
+    {
+        Api.ArrangeTierModels(
+            GatewayTiers.Standard,
+            WebTestData.ModelAlias(alias: "ghost", deploymentName: "deleted-model", deploymentExists: false));
+
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() =>
+            Assert.Contains(
+                "no such deployment",
+                page.Find($"[data-testid=models-missing-{GatewayTiers.Standard}-ghost]").TextContent,
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_pooled_row_missing_from_a_region_is_flagged_separately()
+    {
+        // Different failure from "no such deployment": the model exists, it just cannot survive the
+        // pool's own failover, which is the shape that turns a 429 into a 404.
+        Api.ArrangeTierModels(
+            GatewayTiers.Standard,
+            WebTestData.ModelAlias(alias: "sonnet", missingFromAccounts: ["fg-swedencentral"]));
+
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() =>
+            Assert.Contains(
+                "not in every region",
+                page.Find($"[data-testid=models-partial-{GatewayTiers.Standard}-sonnet]").TextContent,
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Allowing_a_model_sends_the_whole_map_with_the_new_row_added()
+    {
+        Api.ArrangeDeployments(WebTestData.Deployment(deploymentName: "gpt-5-codex"));
+        Api.ArrangeTierModels(GatewayTiers.Standard, WebTestData.ModelAlias(alias: "sonnet"));
+
+        var page = RenderPage<GatewayModels>();
+        page.WaitForElement($"[data-testid=models-add-{GatewayTiers.Standard}]");
+
+        page.Find($"[data-testid=models-add-{GatewayTiers.Standard}]").Click();
+        page.WaitForElement("[data-testid=alias-save]");
+
+        page.Find("input[data-testid=alias-name]").Change("codex");
+        page.Find("[data-testid=alias-save]").Click();
+
+        page.WaitForAssertion(() =>
+        {
+            var (tier, request) = Assert.Single(Api.ReplacedTierModels);
+            Assert.Equal(GatewayTiers.Standard, tier);
+
+            // The existing row travels with the new one: this is a replace, and dropping what was
+            // already allowed would silently revoke it.
+            Assert.Contains(request.Aliases, alias => alias.Alias == "sonnet");
+            var added = Assert.Single(request.Aliases, alias => alias.Alias == "codex");
+            Assert.Equal("gpt-5-codex", added.DeploymentName);
+
+            // Provider and pool are derived from the deployment's model format, never asked.
+            Assert.Equal(ModelProviderType.OpenAi, added.Provider);
+            Assert.Equal(GatewayModelMap.OpenAiPool, added.Pool);
+        });
+    }
+
+    [Fact]
+    public void An_anthropic_deployment_derives_the_anthropic_front_door_and_the_pool()
+    {
+        Api.ArrangeDeployments(WebTestData.Deployment(deploymentName: "claude-haiku-4-5", format: FoundryModelFormatType.Anthropic));
+
+        var page = RenderPage<GatewayModels>();
+        page.WaitForElement($"[data-testid=models-add-{GatewayTiers.Power}]");
+
+        page.Find($"[data-testid=models-add-{GatewayTiers.Power}]").Click();
+        page.WaitForElement("[data-testid=alias-save]");
+
+        page.Find("input[data-testid=alias-name]").Change("haiku");
+        page.Find("[data-testid=alias-save]").Click();
+
+        page.WaitForAssertion(() =>
+        {
+            var (_, request) = Assert.Single(Api.ReplacedTierModels);
+            var added = Assert.Single(request.Aliases);
+            Assert.Equal(ModelProviderType.Anthropic, added.Provider);
+            Assert.Equal(GatewayModelMap.AnthropicPool, added.Pool);
+        });
+    }
+
+    [Fact]
+    public void Removing_a_model_asks_first_and_then_sends_the_map_without_it()
+    {
+        Api.ArrangeTierModels(
+            GatewayTiers.Standard,
+            WebTestData.ModelAlias(alias: "sonnet"),
+            WebTestData.ModelAlias(alias: "haiku", deploymentName: "claude-haiku-4-5"));
+
+        var page = RenderPage<GatewayModels>();
+        page.WaitForElement($"[data-testid=models-remove-{GatewayTiers.Standard}-haiku]");
+
+        page.Find($"[data-testid=models-remove-{GatewayTiers.Standard}-haiku]").Click();
+        page.WaitForElement("[data-testid=confirm-ok]");
+        page.Find("[data-testid=confirm-ok]").Click();
+
+        page.WaitForAssertion(() =>
+        {
+            var (_, request) = Assert.Single(Api.ReplacedTierModels);
+            var kept = Assert.Single(request.Aliases);
+            Assert.Equal("sonnet", kept.Alias);
+        });
+    }
+
+    [Fact]
+    public void A_refused_replace_says_what_the_api_said()
+    {
+        // "That deployment isn't in every region" is a sentence an admin can act on; reducing it to
+        // "couldn't save" would throw away the only useful part of the refusal.
+        Api.ArrangeTierModels(GatewayTiers.Standard, WebTestData.ModelAlias(alias: "sonnet"));
+        Api.ReplaceGatewayTierModelsResult = ApiCallResult<GatewayTierModelsResponse>.Fail(
+            ApiCallStatus.Error,
+            "Alias 'sonnet' routes at the 'anthropic' pool, so it must exist in every Foundry account.");
+
+        var page = RenderPage<GatewayModels>();
+        page.WaitForElement($"[data-testid=models-remove-{GatewayTiers.Standard}-sonnet]");
+
+        page.Find($"[data-testid=models-remove-{GatewayTiers.Standard}-sonnet]").Click();
+        page.WaitForElement("[data-testid=confirm-ok]");
+        page.Find("[data-testid=confirm-ok]").Click();
+
+        page.WaitForAssertion(() =>
+            Assert.Contains(Snackbars, snackbar => snackbar.Message?.Contains("every Foundry account", StringComparison.Ordinal) == true));
+    }
+
+    [Fact]
+    public void A_deployment_arriving_from_the_foundry_page_is_offered_for_a_tier()
+    {
+        // The follow-through from /foundry: a model nobody is allowed to use is not yet useful.
+        Api.ArrangeDeployments(WebTestData.Deployment(deploymentName: "gpt-5-codex"));
+
+        var page = RenderPage<GatewayModels>(("DeploymentQuery", "gpt-5-codex"));
+
+        page.WaitForAssertion(() =>
+            Assert.Contains(
+                "isn't allowed for any tier yet",
+                page.Find("[data-testid=models-pending-deployment]").TextContent,
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_deployment_that_is_already_allowed_is_not_offered_again()
+    {
+        Api.ArrangeDeployments(WebTestData.Deployment(deploymentName: "claude-sonnet-4-5", format: FoundryModelFormatType.Anthropic));
+        Api.ArrangeTierModels(GatewayTiers.Standard, WebTestData.ModelAlias(alias: "sonnet"));
+
+        var page = RenderPage<GatewayModels>(("DeploymentQuery", "claude-sonnet-4-5"));
+
+        page.WaitForAssertion(() => Assert.NotEmpty(page.FindAll($"[data-testid=models-panel-{GatewayTiers.Standard}]")));
+        Assert.Empty(page.FindAll("[data-testid=models-pending-deployment]"));
+    }
+
+    [Fact]
+    public void A_403_from_the_api_renders_access_denied()
+    {
+        Api.GatewayTiersResult = ApiCallResult<IReadOnlyList<GatewayTierResponse>>
+            .Fail(ApiCallStatus.Forbidden, "You don't have permission to do that.");
+
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() => Assert.Contains("Access denied", page.Markup, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_503_names_the_configuration_the_operator_has_to_fix()
+    {
+        Api.GatewayTiersResult = ApiCallResult<IReadOnlyList<GatewayTierResponse>>
+            .Fail(ApiCallStatus.Error, "The gateway's model allowlist is not configured: set Gateway:ApimName.");
+
+        var page = RenderPage<GatewayModels>();
+
+        page.WaitForAssertion(() =>
+            Assert.Contains("Gateway:ApimName", page.Find("[data-testid=models-error]").TextContent, StringComparison.Ordinal));
+    }
+}

--- a/src/FoundryGate.Tests.Predeployment/Web/WebTestData.cs
+++ b/src/FoundryGate.Tests.Predeployment/Web/WebTestData.cs
@@ -6,6 +6,7 @@ using FoundryGate.Domain.Constants;
 using FoundryGate.Domain.Dashboard.Contracts;
 using FoundryGate.Domain.Foundry;
 using FoundryGate.Domain.Foundry.Contracts;
+using FoundryGate.Domain.Gateway.Contracts;
 using FoundryGate.Domain.Groups.Contracts;
 using FoundryGate.Domain.Keys.Contracts;
 using FoundryGate.Domain.Quota;
@@ -35,6 +36,28 @@ public static class WebTestData
         new(GatewayTiers.Power, "Power", 20_000_000, false),
         new(GatewayTiers.Unlimited, "Unlimited", null, true),
     ];
+
+    /// <summary>
+    /// The same three tiers as <see cref="Tiers"/>, in the shape <c>GET /gateway/tiers</c> answers
+    /// (#225) — what <c>/models</c> lists down its left-hand side. Allowlist sizes are 0 by default;
+    /// a test arranges the rows it cares about with <c>ArrangeTierModels</c>.
+    /// </summary>
+    public static IReadOnlyList<GatewayTierResponse> AllowlistTiers { get; } =
+    [
+        new(GatewayTiers.Standard, "Standard", 5_000_000, false, 0),
+        new(GatewayTiers.Power, "Power", 20_000_000, false, 0),
+        new(GatewayTiers.Unlimited, "Unlimited", null, true, 0),
+    ];
+
+    /// <summary>One row of a tier's model allowlist, healthy unless <paramref name="missingFromAccounts"/> says otherwise.</summary>
+    public static GatewayModelAliasResponse ModelAlias(
+        string alias = "sonnet",
+        string deploymentName = "claude-sonnet-4-5",
+        string pool = GatewayModelMap.AnthropicPool,
+        ModelProviderType provider = ModelProviderType.Anthropic,
+        bool deploymentExists = true,
+        IReadOnlyList<string>? missingFromAccounts = null) =>
+        new(alias, deploymentName, pool, provider, deploymentExists, missingFromAccounts ?? []);
 
     public static UserResponse User(
         int userId = 7,

--- a/src/FoundryGate.Web/Layout/NavMenu.razor
+++ b/src/FoundryGate.Web/Layout/NavMenu.razor
@@ -31,6 +31,7 @@
                             </MudBadge>
                         </MudNavLink>
                         <MudNavLink Href="foundry" Icon="@Icons.Material.Filled.Memory">Foundry Deployments</MudNavLink>
+                        <MudNavLink Href="models" Icon="@Icons.Material.Filled.Tune">Models &amp; Access</MudNavLink>
                         <MudNavLink Href="config" Icon="@Icons.Material.Filled.Settings">Configuration</MudNavLink>
                         <MudNavLink Href="audit" Icon="@Icons.Material.Filled.History">Audit Log</MudNavLink>
                     </MudNavGroup>

--- a/src/FoundryGate.Web/Pages/Foundry.razor
+++ b/src/FoundryGate.Web/Pages/Foundry.razor
@@ -1,4 +1,5 @@
 @page "/foundry"
+@implements IDisposable
 @attribute [Authorize(Roles = RoleNames.Admin)]
 @inject IFoundryGateApiClient Api
 @inject IDialogService DialogService
@@ -26,6 +27,26 @@ else
         gateway only once it is in the right backend pool
         (<MudLink Href="https://github.com/kolatts/foundry-gate/issues/83" Target="_blank">#83</MudLink>).
     </MudText>
+
+    @if (_provisioned is { Length: > 0 } provisioned)
+    {
+        @* A deployment nobody is allowed to use is not yet useful: the alias map is the allowlist
+           (#86), so provisioning is only half the job. Deep-links into /models with the deployment
+           pre-filled rather than leaving the admin to find the page and retype the name. *@
+        <MudAlert Severity="Severity.Success" Class="mb-4" data-testid="foundry-provisioned">
+            '@provisioned' exists now, but no tier is allowed to use it yet.
+            <MudLink Href="@($"/models?deployment={Uri.EscapeDataString(provisioned)}")" data-testid="foundry-allow-link">
+                Add it to a tier's allowed models
+            </MudLink>
+        </MudAlert>
+    }
+
+    @if (_polling)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Class="mb-4" data-testid="foundry-polling">
+            Waiting for Azure to finish provisioning — this page refreshes itself until it does.
+        </MudAlert>
+    }
 
     @if (_loading && _deployments is null)
     {
@@ -110,11 +131,25 @@ else
 }
 
 @code {
+    /// <summary>How long between polls while a create finishes. ARM takes tens of seconds, so a tighter loop would only add calls.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
+
+    /// <summary>Polls before giving up and leaving the grid's state chips to say where it got to (about a minute).</summary>
+    private const int MaxPollAttempts = 20;
+
+    /// <summary>ARM provisioning states that are not going to change on their own.</summary>
+    private static readonly string[] TerminalStates = ["Succeeded", "Failed", "Canceled"];
+
     private IReadOnlyList<FoundryDeploymentResponse>? _deployments;
     private string? _unavailable;
+    private string? _provisioned;
+    private bool _polling;
     private bool _loading;
     private bool _busy;
     private bool _accessDenied;
+
+    /// <summary>Cancelled when the page goes away, so a poll loop cannot outlive it.</summary>
+    private readonly CancellationTokenSource _pageCts = new();
 
     private static bool IsAnthropic(FoundryDeploymentResponse deployment) =>
         string.Equals(deployment.ModelFormat, nameof(FoundryModelFormatType.Anthropic), StringComparison.OrdinalIgnoreCase);
@@ -169,7 +204,7 @@ else
         var dialog = await DialogService.ShowAsync<FoundryDeploymentDialog>("New deployment", parameters);
         var dialogResult = await dialog.Result;
 
-        if (dialogResult is not { Canceled: false, Data: CreateFoundryDeploymentRequest request })
+        if (dialogResult is not { Canceled: false, Data: FoundryProvisionPlan plan })
         {
             return;
         }
@@ -177,20 +212,99 @@ else
         _busy = true;
         try
         {
-            var result = await Api.CreateFoundryDeploymentAsync(request);
-            if (!result.IsSuccess || result.Value is null)
+            // One POST per account, in order, each reported on its own: the API creates one deployment
+            // in one account by design (E-007), and a second region failing must not read as the first
+            // one having failed too.
+            var created = new List<FoundryDeploymentResponse>();
+            foreach (var accountName in plan.AccountNames)
             {
-                Snackbar.Add(result.Message ?? "Couldn't create the deployment.", Severity.Error);
+                var result = await Api.CreateFoundryDeploymentAsync(plan.Template with { AccountName = accountName });
+                if (result is { IsSuccess: true, Value: not null })
+                {
+                    created.Add(result.Value);
+                    continue;
+                }
+
+                Snackbar.Add(
+                    result.Message ?? $"Couldn't create '{plan.Template.DeploymentName}' in {accountName}.",
+                    Severity.Error);
+            }
+
+            if (created.Count == 0)
+            {
                 return;
             }
 
-            // ARM accepts the create and provisions asynchronously, so the row lands as Creating.
-            Snackbar.Add($"'{result.Value.DeploymentName}' is provisioning — refresh to watch its state.", Severity.Success);
+            // ARM accepts the create and provisions asynchronously, so the rows land as Creating.
+            Snackbar.Add(
+                created.Count == 1
+                    ? $"'{created[0].DeploymentName}' is provisioning in {created[0].AccountName}."
+                    : $"'{created[0].DeploymentName}' is provisioning in {created.Count} accounts.",
+                Severity.Success);
+
+            _provisioned = created[0].DeploymentName;
             await LoadAsync();
+            await PollUntilSettledAsync(created);
         }
         finally
         {
             _busy = false;
+        }
+    }
+
+    /// <summary>
+    /// Refreshes each new deployment until ARM stops moving it, so the admin does not have to press
+    /// refresh to find out whether the thing they just asked for actually works. Gives up after
+    /// <see cref="MaxPollAttempts"/> — at which point the grid's state chips are still the truth, they
+    /// are just no longer updating themselves.
+    /// </summary>
+    private async Task PollUntilSettledAsync(IReadOnlyList<FoundryDeploymentResponse> created)
+    {
+        var pending = created
+            .Where(d => !TerminalStates.Contains(d.ProvisioningState, StringComparer.OrdinalIgnoreCase))
+            .Select(d => (d.AccountName, d.DeploymentName))
+            .ToList();
+
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        _polling = true;
+        try
+        {
+            for (var attempt = 0; attempt < MaxPollAttempts && pending.Count > 0; attempt++)
+            {
+                await Task.Delay(PollInterval, _pageCts.Token);
+
+                foreach (var (accountName, deploymentName) in pending.ToList())
+                {
+                    var result = await Api.GetFoundryDeploymentAsync(accountName, deploymentName, _pageCts.Token);
+
+                    // A read that failed says nothing about the deployment, but it does say polling is
+                    // not going to answer the question — stop asking rather than burning the budget.
+                    if (result is not { IsSuccess: true, Value: not null })
+                    {
+                        _ = pending.Remove((accountName, deploymentName));
+                        continue;
+                    }
+
+                    if (TerminalStates.Contains(result.Value.ProvisioningState, StringComparer.OrdinalIgnoreCase))
+                    {
+                        _ = pending.Remove((accountName, deploymentName));
+                    }
+                }
+
+                await LoadAsync();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The page went away mid-wait. Nothing to report to a UI that no longer exists.
+        }
+        finally
+        {
+            _polling = false;
         }
     }
 
@@ -225,5 +339,12 @@ else
         {
             _busy = false;
         }
+    }
+
+    /// <summary>Stops any poll loop the page started — bUnit's teardown does not reach pages rendered inside a fragment, and neither does a real navigation without this.</summary>
+    public void Dispose()
+    {
+        _pageCts.Cancel();
+        _pageCts.Dispose();
     }
 }

--- a/src/FoundryGate.Web/Pages/Foundry.razor
+++ b/src/FoundryGate.Web/Pages/Foundry.razor
@@ -209,13 +209,14 @@ else
             return;
         }
 
+        var created = new List<FoundryDeploymentResponse>();
+
         _busy = true;
         try
         {
             // One POST per account, in order, each reported on its own: the API creates one deployment
             // in one account by design (E-007), and a second region failing must not read as the first
             // one having failed too.
-            var created = new List<FoundryDeploymentResponse>();
             foreach (var accountName in plan.AccountNames)
             {
                 var result = await Api.CreateFoundryDeploymentAsync(plan.Template with { AccountName = accountName });
@@ -244,12 +245,15 @@ else
 
             _provisioned = created[0].DeploymentName;
             await LoadAsync();
-            await PollUntilSettledAsync(created);
         }
         finally
         {
             _busy = false;
         }
+
+        // Deliberately outside the busy block: waiting for ARM is not a reason to disable the page for
+        // a minute, and the poll loop renders as it goes.
+        await PollUntilSettledAsync(created);
     }
 
     /// <summary>
@@ -270,32 +274,51 @@ else
             return;
         }
 
+        // Captured once: Dispose() cancels and then disposes the source, and reading .Token afterwards
+        // throws ObjectDisposedException rather than the cancellation this loop is waiting for.
+        var cancellationToken = _pageCts.Token;
+
         _polling = true;
+
+        // The loop runs inside the click handler's await chain, so Blazor renders nothing until it
+        // returns unless it asks — without these the "waiting for Azure" line and every refreshed row
+        // would appear all at once, a minute after they stopped being news.
+        StateHasChanged();
+
         try
         {
             for (var attempt = 0; attempt < MaxPollAttempts && pending.Count > 0; attempt++)
             {
-                await Task.Delay(PollInterval, _pageCts.Token);
+                await Task.Delay(PollInterval, cancellationToken);
 
+                var settled = false;
                 foreach (var (accountName, deploymentName) in pending.ToList())
                 {
-                    var result = await Api.GetFoundryDeploymentAsync(accountName, deploymentName, _pageCts.Token);
+                    var result = await Api.GetFoundryDeploymentAsync(accountName, deploymentName, cancellationToken);
 
                     // A read that failed says nothing about the deployment, but it does say polling is
                     // not going to answer the question — stop asking rather than burning the budget.
                     if (result is not { IsSuccess: true, Value: not null })
                     {
                         _ = pending.Remove((accountName, deploymentName));
+                        settled = true;
                         continue;
                     }
 
                     if (TerminalStates.Contains(result.Value.ProvisioningState, StringComparer.OrdinalIgnoreCase))
                     {
                         _ = pending.Remove((accountName, deploymentName));
+                        settled = true;
                     }
                 }
 
-                await LoadAsync();
+                // The grid is a multi-account ARM listing; re-reading it every three seconds to render
+                // the same chips is the expensive way to display nothing new. Only a state that moved
+                // is worth a refresh.
+                if (settled)
+                {
+                    await LoadAsync();
+                }
             }
         }
         catch (OperationCanceledException)
@@ -305,6 +328,7 @@ else
         finally
         {
             _polling = false;
+            StateHasChanged();
         }
     }
 

--- a/src/FoundryGate.Web/Pages/GatewayModels.razor
+++ b/src/FoundryGate.Web/Pages/GatewayModels.razor
@@ -268,17 +268,21 @@ else
             var deploymentsResult = await Api.GetFoundryDeploymentsAsync();
             _deployments = deploymentsResult is { IsSuccess: true, Value: not null } ? deploymentsResult.Value : [];
 
+            // Concurrently, not one after another: the tiers are independent reads and a fork with six
+            // of them should not open this page six round trips slowly.
+            var modelResults = await Task.WhenAll(_tiers.Select(tier => Api.GetGatewayTierModelsAsync(tier.Tier)));
+
             _aliasesByTier.Clear();
-            foreach (var tier in _tiers)
+            for (var i = 0; i < _tiers.Count; i++)
             {
-                var modelsResult = await Api.GetGatewayTierModelsAsync(tier.Tier);
+                var modelsResult = modelResults[i];
                 if (!modelsResult.IsSuccess || modelsResult.Value is null)
                 {
-                    _unavailable = modelsResult.Message ?? $"Couldn't read the models allowed for {tier.DisplayName}.";
+                    _unavailable = modelsResult.Message ?? $"Couldn't read the models allowed for {_tiers[i].DisplayName}.";
                     return;
                 }
 
-                _aliasesByTier[tier.Tier] = modelsResult.Value.Aliases;
+                _aliasesByTier[_tiers[i].Tier] = modelsResult.Value.Aliases;
             }
 
             _unavailable = null;

--- a/src/FoundryGate.Web/Pages/GatewayModels.razor
+++ b/src/FoundryGate.Web/Pages/GatewayModels.razor
@@ -214,7 +214,7 @@ else
     /// after a successful provision. A model nobody is allowed to use is not yet useful, so the page
     /// says so and opens the add dialog pre-filled rather than leaving the admin to find it.
     /// </summary>
-    [SupplyParameterFromQuery(Name = "deployment")]
+    [Parameter, SupplyParameterFromQuery(Name = "deployment")]
     public string? DeploymentQuery { get; set; }
 
     private IReadOnlyList<GatewayTierResponse>? _tiers;

--- a/src/FoundryGate.Web/Pages/GatewayModels.razor
+++ b/src/FoundryGate.Web/Pages/GatewayModels.razor
@@ -1,0 +1,416 @@
+@page "/models"
+@attribute [Authorize(Roles = RoleNames.Admin)]
+@inject IFoundryGateApiClient Api
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<PageTitle>Models &amp; access — Foundry Gate</PageTitle>
+
+@if (_accessDenied)
+{
+    <AccessDenied />
+}
+else
+{
+    <div class="d-flex align-center justify-space-between mb-1">
+        <MudText Typo="Typo.h4">Models &amp; access</MudText>
+        <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                       Disabled="@_loading"
+                       OnClick="@LoadAsync"
+                       aria-label="Refresh"
+                       data-testid="models-refresh" />
+    </div>
+    <MudText Typo="Typo.body1" Class="mud-text-secondary mb-4" Style="max-width: 48rem;">
+        Which models each quota tier is allowed to use. This list <em>is</em> the rule the gateway
+        enforces: a developer asking for a model their tier doesn't list is refused at the gateway
+        with <code>model_not_permitted</code>, before it costs them any quota. Changes take effect
+        without redeploying anything.
+    </MudText>
+
+    @if (_loading && _tiers is null)
+    {
+        <MudSkeleton Width="100%" Height="3rem" data-testid="models-loading" />
+        <MudSkeleton Width="100%" Height="12rem" Class="mt-2" />
+    }
+    else if (_unavailable is { } unavailable)
+    {
+        <MudAlert Severity="Severity.Error" data-testid="models-error">@unavailable</MudAlert>
+    }
+    else
+    {
+        @if (_pendingDeployment is { Length: > 0 } pending)
+        {
+            <MudAlert Severity="Severity.Info" Class="mb-4" data-testid="models-pending-deployment">
+                '@pending' isn't allowed for any tier yet — nobody can use it until it is.
+                <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="@(() => AddAsync(null, pending))" data-testid="models-pending-add">
+                    Allow it for a tier
+                </MudButton>
+            </MudAlert>
+        }
+
+        <MudPaper Elevation="1" Class="pa-4 mb-6">
+            <MudText Typo="Typo.h6" Class="mb-2">At a glance</MudText>
+            <MudSimpleTable Dense="true" Hover="true" Striped="true" Style="overflow-x: auto;" data-testid="models-matrix">
+                <thead>
+                    <tr>
+                        <th>Alias</th>
+                        @foreach (var tier in _tiers ?? [])
+                        {
+                            <th>@tier.DisplayName</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var alias in AllAliases)
+                    {
+                        <tr>
+                            <td><code>@alias</code></td>
+                            @foreach (var tier in _tiers ?? [])
+                            {
+                                var row = RowFor(tier.Tier, alias);
+                                <td data-testid="@($"models-cell-{tier.Tier}-{alias}")">
+                                    @if (row is null)
+                                    {
+                                        <span class="mud-text-secondary">—</span>
+                                    }
+                                    else
+                                    {
+                                        <span>@row.DeploymentName</span>
+                                    }
+                                </td>
+                            }
+                        </tr>
+                    }
+                    @if (AllAliases.Count == 0)
+                    {
+                        <tr>
+                            <td colspan="@(1 + (_tiers?.Count ?? 0))" class="mud-text-secondary" data-testid="models-matrix-empty">
+                                No tier allows any model yet, so every request is refused. Allow one below.
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </MudSimpleTable>
+        </MudPaper>
+
+        <MudExpansionPanels MultiExpansion="true" Elevation="1">
+            @foreach (var tier in _tiers ?? [])
+            {
+                var rows = RowsFor(tier.Tier);
+                <MudExpansionPanel Expanded="true" data-testid="@($"models-panel-{tier.Tier}")">
+                    <TitleContent>
+                        <div class="d-flex align-center gap-3">
+                            <MudText Typo="Typo.subtitle1">@tier.DisplayName</MudText>
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                                @rows.Count model@(rows.Count == 1 ? string.Empty : "s")
+                            </MudChip>
+                        </div>
+                    </TitleContent>
+                    <ChildContent>
+                        @if (rows.Count == 0)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3" data-testid="@($"models-empty-{tier.Tier}")">
+                                This tier allows no models at all, so every request from a developer on it is refused.
+                            </MudAlert>
+                        }
+                        else
+                        {
+                            <MudSimpleTable Dense="true" Hover="true">
+                                <thead>
+                                    <tr>
+                                        <th>Alias</th>
+                                        <th>Deployment</th>
+                                        <th>Front door</th>
+                                        <th>Backend</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var row in rows)
+                                    {
+                                        <tr>
+                                            <td><code>@row.Alias</code></td>
+                                            <td>
+                                                @row.DeploymentName
+                                                @if (!row.DeploymentExists)
+                                                {
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Error" Variant="Variant.Filled" Class="ml-2"
+                                                             data-testid="@($"models-missing-{tier.Tier}-{row.Alias}")">
+                                                        no such deployment
+                                                    </MudChip>
+                                                }
+                                                else if (row.MissingFromAccounts.Count > 0 && row.Pool == GatewayModelMap.AnthropicPool)
+                                                {
+                                                    <MudTooltip Text="@($"Missing from {string.Join(", ", row.MissingFromAccounts)} — a pooled model must exist in every region.")">
+                                                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled" Class="ml-2"
+                                                                 data-testid="@($"models-partial-{tier.Tier}-{row.Alias}")">
+                                                            not in every region
+                                                        </MudChip>
+                                                    </MudTooltip>
+                                                }
+                                            </td>
+                                            <td>@row.Provider</td>
+                                            <td>@row.Pool</td>
+                                            <td class="text-right">
+                                                <MudIconButton Icon="@Icons.Material.Filled.SwapHoriz"
+                                                               Size="Size.Small"
+                                                               Disabled="@_busy"
+                                                               OnClick="@(() => RetargetAsync(tier, row))"
+                                                               aria-label="@($"Retarget {row.Alias}")"
+                                                               data-testid="@($"models-retarget-{tier.Tier}-{row.Alias}")" />
+                                                <MudIconButton Icon="@Icons.Material.Filled.DeleteOutline"
+                                                               Color="Color.Error"
+                                                               Size="Size.Small"
+                                                               Disabled="@_busy"
+                                                               OnClick="@(() => RemoveAsync(tier, row))"
+                                                               aria-label="@($"Remove {row.Alias}")"
+                                                               data-testid="@($"models-remove-{tier.Tier}-{row.Alias}")" />
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        }
+
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   Class="mt-3"
+                                   Disabled="@_busy"
+                                   OnClick="@(() => AddAsync(tier.Tier, null))"
+                                   data-testid="@($"models-add-{tier.Tier}")">
+                            Allow a model
+                        </MudButton>
+
+                        <MudPaper Elevation="0" Class="pa-3 mt-4" Style="background: var(--mud-palette-background-grey);">
+                            <MudText Typo="Typo.subtitle2">What developers on this tier see</MudText>
+                            <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">
+                                These are the names they put in their CLI's model setting. Anything else is refused.
+                            </MudText>
+                            @if (rows.Count == 0)
+                            {
+                                <MudText Typo="Typo.body2" data-testid="@($"models-preview-{tier.Tier}")">Nothing — no model is available to them.</MudText>
+                            }
+                            else
+                            {
+                                <div class="d-flex flex-wrap gap-2" data-testid="@($"models-preview-{tier.Tier}")">
+                                    @foreach (var row in rows)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="Color.Primary">@row.Alias</MudChip>
+                                    }
+                                </div>
+                            }
+                        </MudPaper>
+                    </ChildContent>
+                </MudExpansionPanel>
+            }
+        </MudExpansionPanels>
+    }
+}
+
+@code {
+    /// <summary>
+    /// Query-string parameter <c>/models?deployment=…</c> — the follow-through from <c>/foundry</c>
+    /// after a successful provision. A model nobody is allowed to use is not yet useful, so the page
+    /// says so and opens the add dialog pre-filled rather than leaving the admin to find it.
+    /// </summary>
+    [SupplyParameterFromQuery(Name = "deployment")]
+    public string? DeploymentQuery { get; set; }
+
+    private IReadOnlyList<GatewayTierResponse>? _tiers;
+    private IReadOnlyList<FoundryDeploymentResponse> _deployments = [];
+    private readonly Dictionary<string, IReadOnlyList<GatewayModelAliasResponse>> _aliasesByTier = new(StringComparer.OrdinalIgnoreCase);
+    private string? _pendingDeployment;
+    private string? _unavailable;
+    private bool _loading;
+    private bool _busy;
+    private bool _accessDenied;
+
+    /// <summary>The gateway's accounts as the deployment list reveals them — pool order isn't knowable here, so display order is alphabetical.</summary>
+    private IReadOnlyList<string> ConfiguredAccounts =>
+        [.. _deployments.Select(d => d.AccountName).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)];
+
+    /// <summary>Every alias any tier allows — the rows of the overview matrix.</summary>
+    private IReadOnlyList<string> AllAliases =>
+        [.. _aliasesByTier.Values.SelectMany(rows => rows).Select(row => row.Alias).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)];
+
+    private IReadOnlyList<GatewayModelAliasResponse> RowsFor(string tier) =>
+        _aliasesByTier.TryGetValue(tier, out var rows) ? rows : [];
+
+    private GatewayModelAliasResponse? RowFor(string tier, string alias) =>
+        RowsFor(tier).FirstOrDefault(row => string.Equals(row.Alias, alias, StringComparison.OrdinalIgnoreCase));
+
+    protected override Task OnInitializedAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try
+        {
+            var tiersResult = await Api.GetGatewayTiersAsync();
+
+            if (tiersResult.Status == ApiCallStatus.Forbidden)
+            {
+                _accessDenied = true;
+                return;
+            }
+
+            if (!tiersResult.IsSuccess || tiersResult.Value is null)
+            {
+                // A 503 here means the Gateway section doesn't address APIM (or names a resource Azure
+                // doesn't have) — an operator fixes that from the message, so show it whole.
+                _unavailable = tiersResult.Message ?? "Couldn't read the gateway's tiers.";
+                return;
+            }
+
+            _tiers = tiersResult.Value;
+
+            var deploymentsResult = await Api.GetFoundryDeploymentsAsync();
+            _deployments = deploymentsResult is { IsSuccess: true, Value: not null } ? deploymentsResult.Value : [];
+
+            _aliasesByTier.Clear();
+            foreach (var tier in _tiers)
+            {
+                var modelsResult = await Api.GetGatewayTierModelsAsync(tier.Tier);
+                if (!modelsResult.IsSuccess || modelsResult.Value is null)
+                {
+                    _unavailable = modelsResult.Message ?? $"Couldn't read the models allowed for {tier.DisplayName}.";
+                    return;
+                }
+
+                _aliasesByTier[tier.Tier] = modelsResult.Value.Aliases;
+            }
+
+            _unavailable = null;
+
+            // Only worth mentioning while it is still true: a deployment already allowed somewhere
+            // needs no prompting.
+            _pendingDeployment = DeploymentQuery is { Length: > 0 } deployment
+                && !_aliasesByTier.Values.SelectMany(rows => rows).Any(row => string.Equals(row.DeploymentName, deployment, StringComparison.OrdinalIgnoreCase))
+                ? deployment
+                : null;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task AddAsync(string? tier, string? deploymentName)
+    {
+        var parameters = new DialogParameters<ModelAliasDialog>
+        {
+            { x => x.Tiers, _tiers ?? [] },
+            { x => x.Deployments, _deployments },
+            { x => x.ConfiguredAccounts, ConfiguredAccounts },
+            { x => x.ExistingAliases, [.. RowsFor(tier ?? string.Empty).Select(row => row.Alias)] },
+            { x => x.Tier, tier ?? string.Empty },
+            { x => x.DeploymentName, deploymentName ?? string.Empty },
+        };
+
+        var dialog = await DialogService.ShowAsync<ModelAliasDialog>("Allow a model", parameters);
+        var result = await dialog.Result;
+
+        if (result is not { Canceled: false, Data: ModelAliasEdit edit })
+        {
+            return;
+        }
+
+        // The alias map is one document, so every edit is a full replace: take what the tier has,
+        // drop any row with the same alias, add this one.
+        var next = RowsFor(edit.Tier)
+            .Where(row => !string.Equals(row.Alias, edit.Alias.Alias, StringComparison.OrdinalIgnoreCase))
+            .Select(ToRequest)
+            .Append(edit.Alias)
+            .ToList();
+
+        await SaveAsync(edit.Tier, next, $"'{edit.Alias.Alias}' is now allowed.");
+    }
+
+    private async Task RetargetAsync(GatewayTierResponse tier, GatewayModelAliasResponse row)
+    {
+        var parameters = new DialogParameters<ModelAliasDialog>
+        {
+            { x => x.Tiers, _tiers ?? [] },
+            { x => x.Deployments, _deployments },
+            { x => x.ConfiguredAccounts, ConfiguredAccounts },
+            { x => x.ExistingAliases, [.. RowsFor(tier.Tier).Select(r => r.Alias)] },
+            { x => x.Tier, tier.Tier },
+            { x => x.Alias, row.Alias },
+            { x => x.DeploymentName, row.DeploymentName },
+            { x => x.IsRetarget, true },
+        };
+
+        var dialog = await DialogService.ShowAsync<ModelAliasDialog>($"Retarget {row.Alias}", parameters);
+        var result = await dialog.Result;
+
+        if (result is not { Canceled: false, Data: ModelAliasEdit edit })
+        {
+            return;
+        }
+
+        var next = RowsFor(tier.Tier)
+            .Where(r => !string.Equals(r.Alias, row.Alias, StringComparison.OrdinalIgnoreCase))
+            .Select(ToRequest)
+            .Append(edit.Alias)
+            .ToList();
+
+        await SaveAsync(tier.Tier, next, $"'{row.Alias}' now resolves to {edit.Alias.DeploymentName}.");
+    }
+
+    private async Task RemoveAsync(GatewayTierResponse tier, GatewayModelAliasResponse row)
+    {
+        var confirmed = await DialogService.ConfirmAsync(
+            title: "Remove model",
+            message: $"Stop allowing '{row.Alias}' for {tier.DisplayName}?",
+            detail: "Developers on this tier who have it configured start getting refused as soon as the gateway picks the change up. Nothing is deleted in Azure — the deployment stays.",
+            confirmText: "Remove",
+            confirmColor: Color.Error);
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        var next = RowsFor(tier.Tier)
+            .Where(r => !string.Equals(r.Alias, row.Alias, StringComparison.OrdinalIgnoreCase))
+            .Select(ToRequest)
+            .ToList();
+
+        await SaveAsync(tier.Tier, next, $"'{row.Alias}' is no longer allowed for {tier.DisplayName}.");
+    }
+
+    private async Task SaveAsync(string tier, List<TierModelAliasRequest> aliases, string successMessage)
+    {
+        _busy = true;
+        try
+        {
+            var result = await Api.ReplaceGatewayTierModelsAsync(tier, new ReplaceTierModelsRequest { Aliases = aliases });
+
+            if (!result.IsSuccess || result.Value is null)
+            {
+                // The API's refusals are the interesting ones here — "that deployment isn't in every
+                // region" is a sentence an admin can act on, and reducing it to "couldn't save" would
+                // waste it.
+                Snackbar.Add(result.Message ?? "Couldn't update the allowed models.", Severity.Error);
+                return;
+            }
+
+            _aliasesByTier[tier] = result.Value.Aliases;
+            _pendingDeployment = null;
+            Snackbar.Add(successMessage, Severity.Success);
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private static TierModelAliasRequest ToRequest(GatewayModelAliasResponse row) => new()
+    {
+        Alias = row.Alias,
+        DeploymentName = row.DeploymentName,
+        Pool = row.Pool,
+        Provider = row.Provider,
+    };
+}

--- a/src/FoundryGate.Web/Services/FoundryGateApiClient.Admin.cs
+++ b/src/FoundryGate.Web/Services/FoundryGateApiClient.Admin.cs
@@ -1,5 +1,6 @@
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Foundry.Contracts;
+using FoundryGate.Domain.Gateway.Contracts;
 using FoundryGate.Domain.Users.Contracts;
 
 namespace FoundryGate.Web.Services;
@@ -58,6 +59,33 @@ public sealed partial class FoundryGateApiClient
             $"foundry/deployments/{Uri.EscapeDataString(accountName)}/{Uri.EscapeDataString(deploymentName)}",
             body: null,
             ct);
+    }
+
+    public Task<ApiCallResult<FoundryDeploymentResponse>> GetFoundryDeploymentAsync(string accountName, string deploymentName, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accountName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(deploymentName);
+        return GetAsync<FoundryDeploymentResponse>(
+            $"foundry/deployments/{Uri.EscapeDataString(accountName)}/{Uri.EscapeDataString(deploymentName)}",
+            ct);
+    }
+
+    // Gateway model allowlist — api.md §Gateway (#225)
+
+    public Task<ApiCallResult<IReadOnlyList<GatewayTierResponse>>> GetGatewayTiersAsync(CancellationToken ct = default) =>
+        GetAsync<IReadOnlyList<GatewayTierResponse>>("gateway/tiers", ct);
+
+    public Task<ApiCallResult<GatewayTierModelsResponse>> GetGatewayTierModelsAsync(string tier, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+        return GetAsync<GatewayTierModelsResponse>($"gateway/tiers/{Uri.EscapeDataString(tier)}/models", ct);
+    }
+
+    public Task<ApiCallResult<GatewayTierModelsResponse>> ReplaceGatewayTierModelsAsync(string tier, ReplaceTierModelsRequest request, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tier);
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync<GatewayTierModelsResponse>(HttpMethod.Put, $"gateway/tiers/{Uri.EscapeDataString(tier)}/models", request, ct);
     }
 
     // ── Query-string helpers ───────────────────────────────────────────────────

--- a/src/FoundryGate.Web/Services/FoundryProvisionPlan.cs
+++ b/src/FoundryGate.Web/Services/FoundryProvisionPlan.cs
@@ -1,0 +1,18 @@
+using FoundryGate.Domain.Foundry.Contracts;
+
+namespace FoundryGate.Web.Services;
+
+/// <summary>
+/// What <c>FoundryDeploymentDialog</c> hands back to <c>/foundry</c>: the same deployment, to be
+/// created in one or several of the gateway's Foundry accounts (#225).
+/// </summary>
+/// <remarks>
+/// The API deliberately creates <b>one</b> deployment in <b>one</b> account per call — a pooled model
+/// is several requests, so that each create is an explicit, auditable decision rather than a loop the
+/// API drives on an admin's behalf (fable-refactor-log E-007). This plan keeps that property while
+/// letting the admin say "and the other region too" once: the page still issues one POST per account,
+/// in order, and reports each result on its own.
+/// </remarks>
+/// <param name="AccountNames">Accounts to create in, chosen account first. Never empty; entries are distinct.</param>
+/// <param name="Template">The deployment to create; its <c>AccountName</c> is the first entry and is replaced per account.</param>
+public sealed record FoundryProvisionPlan(IReadOnlyList<string> AccountNames, CreateFoundryDeploymentRequest Template);

--- a/src/FoundryGate.Web/Services/IFoundryGateApiClient.Admin.cs
+++ b/src/FoundryGate.Web/Services/IFoundryGateApiClient.Admin.cs
@@ -1,5 +1,6 @@
 using FoundryGate.Domain.Common;
 using FoundryGate.Domain.Foundry.Contracts;
+using FoundryGate.Domain.Gateway.Contracts;
 using FoundryGate.Domain.Users.Contracts;
 
 namespace FoundryGate.Web.Services;
@@ -62,4 +63,28 @@ public partial interface IFoundryGateApiClient
     /// deployments are refused with a 400 for the same reason creates are.
     /// </summary>
     Task<ApiCallResult<bool>> DeleteFoundryDeploymentAsync(string accountName, string deploymentName, CancellationToken ct = default);
+
+    /// <summary>
+    /// <c>GET /foundry/deployments/{accountName}/{deploymentName}</c> — one deployment, live from ARM.
+    /// What <c>/foundry</c> polls after a create: ARM accepts asynchronously, so the row lands as
+    /// <c>Accepted</c>/<c>Creating</c> and only this says when it is actually serving.
+    /// </summary>
+    Task<ApiCallResult<FoundryDeploymentResponse>> GetFoundryDeploymentAsync(string accountName, string deploymentName, CancellationToken ct = default);
+
+    // Gateway model allowlist — api.md §Gateway (#225)
+
+    /// <summary><c>GET /gateway/tiers</c> — the quota tiers and how many models each currently permits.</summary>
+    Task<ApiCallResult<IReadOnlyList<GatewayTierResponse>>> GetGatewayTiersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// <c>GET /gateway/tiers/{tier}/models</c> — one tier's allowlist as APIM holds it, each row
+    /// flagged for whether its deployment exists in the configured Foundry accounts.
+    /// </summary>
+    Task<ApiCallResult<GatewayTierModelsResponse>> GetGatewayTierModelsAsync(string tier, CancellationToken ct = default);
+
+    /// <summary>
+    /// <c>PUT /gateway/tiers/{tier}/models</c> — replace a tier's allowlist in full. Add, retarget and
+    /// remove are all this call: the map is one document and the gateway reads it whole.
+    /// </summary>
+    Task<ApiCallResult<GatewayTierModelsResponse>> ReplaceGatewayTierModelsAsync(string tier, ReplaceTierModelsRequest request, CancellationToken ct = default);
 }

--- a/src/FoundryGate.Web/Services/ModelAliasEdit.cs
+++ b/src/FoundryGate.Web/Services/ModelAliasEdit.cs
@@ -1,0 +1,56 @@
+using FoundryGate.Domain.Config;
+using FoundryGate.Domain.Constants;
+using FoundryGate.Domain.Foundry;
+using FoundryGate.Domain.Gateway.Contracts;
+
+namespace FoundryGate.Web.Services;
+
+/// <summary>
+/// What <c>ModelAliasDialog</c> hands back to <c>/models</c>: which tier's allowlist to change, and
+/// the one row to put in it. The page turns it into a full-replace <see cref="ReplaceTierModelsRequest"/>,
+/// because that is the only shape the gateway's named value has (#225).
+/// </summary>
+/// <param name="Tier">The quota-tier product id whose allowlist gains (or re-points) this alias.</param>
+/// <param name="Alias">The row itself, with <c>pool</c> and <c>provider</c> already derived from the deployment.</param>
+public sealed record ModelAliasEdit(string Tier, TierModelAliasRequest Alias);
+
+/// <summary>
+/// How a Foundry deployment's model format decides the two fields an admin should never have to
+/// answer: which front door the alias belongs to, and which APIM backend it routes at.
+/// </summary>
+/// <remarks>
+/// Both are derived rather than offered because getting either wrong produces a failure that looks
+/// like something else — a Claude alias routed at the OpenAI backend dies as an opaque 404, and one
+/// declared with the wrong provider is refused by the policy naming a base path the caller did not
+/// use. The deployment's ARM <c>model.format</c> already answers both, so the form asks the question
+/// once, in the deployment picker.
+/// </remarks>
+public static class ModelAliasDerivation
+{
+    /// <summary>The front door a deployment of this ARM <c>model.format</c> is served through.</summary>
+    public static ModelProviderType ProviderFor(string? modelFormat) =>
+        IsAnthropic(modelFormat) ? ModelProviderType.Anthropic : ModelProviderType.OpenAi;
+
+    /// <summary>
+    /// The logical backend pool it routes at. Anthropic models are deployed in every region and
+    /// served through the multi-region pool; OpenAI models live in the primary account alone
+    /// (<c>infra/main.bicep</c>'s pooled / primary-only split).
+    /// </summary>
+    public static string PoolFor(string? modelFormat) =>
+        IsAnthropic(modelFormat) ? GatewayModelMap.AnthropicPool : GatewayModelMap.OpenAiPool;
+
+    /// <summary>
+    /// The accounts a model of this format should be deployed into, out of the gateway's configured
+    /// accounts: every account for a pooled (Anthropic) model, the primary account alone otherwise.
+    /// What the provision dialog pre-selects.
+    /// </summary>
+    public static IReadOnlyList<string> DefaultAccountsFor(string? modelFormat, IReadOnlyList<string> configuredAccounts)
+    {
+        ArgumentNullException.ThrowIfNull(configuredAccounts);
+
+        return IsAnthropic(modelFormat) || configuredAccounts.Count == 0 ? configuredAccounts : [configuredAccounts[0]];
+    }
+
+    private static bool IsAnthropic(string? modelFormat) =>
+        string.Equals(modelFormat, nameof(FoundryModelFormatType.Anthropic), StringComparison.OrdinalIgnoreCase);
+}

--- a/src/FoundryGate.Web/Shared/FoundryDeploymentDialog.razor
+++ b/src/FoundryGate.Web/Shared/FoundryDeploymentDialog.razor
@@ -221,6 +221,18 @@
         {
             _accountName = KnownAccounts[0];
         }
+
+        // Which accounts a model belongs in is infra/main.bicep's pooled / primary-only split, not a
+        // preference: a pooled model must exist in every region or a 429 failover becomes a 404. This
+        // form creates OpenAI-format deployments, so the answer today is "the primary account alone"
+        // and nothing extra is pre-selected — the rule lives in ModelAliasDerivation so it stays true
+        // on the day Anthropic creates become possible (#126) rather than being re-derived then.
+        _additionalAccounts =
+        [
+            .. ModelAliasDerivation
+                .DefaultAccountsFor(nameof(FoundryModelFormatType.OpenAI), KnownAccounts)
+                .Where(account => !string.Equals(account, _accountName, StringComparison.OrdinalIgnoreCase)),
+        ];
     }
 
     /// <summary>

--- a/src/FoundryGate.Web/Shared/FoundryDeploymentDialog.razor
+++ b/src/FoundryGate.Web/Shared/FoundryDeploymentDialog.razor
@@ -45,6 +45,30 @@
                              HelperText="One account per region. Pick an existing one, or type a configured account that has no deployments yet."
                              data-testid="deployment-account" />
 
+            @if (OtherAccounts.Count > 0)
+            {
+                @* A model that has to survive a pool failover must exist in every region — the Anthropic
+                   pool sends a throttled request to another account, and an account without the
+                   deployment turns that throttle into a 404 (infra/main.bicep's contract). This form
+                   creates OpenAI-format deployments, which are primary-only by that same split, so the
+                   extra accounts are offered rather than pre-selected: one create per account, each one
+                   an explicit decision (E-007: never a loop the API drives on your behalf). *@
+                <MudSelect T="string"
+                           MultiSelection="true"
+                           SelectedValues="@_additionalAccounts"
+                           SelectedValuesChanged="@OnAdditionalAccountsChanged"
+                           Label="Also create in"
+                           Variant="Variant.Outlined"
+                           Class="mt-4"
+                           HelperText="Optional. One create per account, run in order — pick every region for a model that has to survive a pool failover."
+                           data-testid="deployment-extra-accounts">
+                    @foreach (var account in OtherAccounts)
+                    {
+                        <MudSelectItem T="string" Value="@account">@account</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
             <MudTextField @bind-Value="_deploymentName"
                           Label="Deployment name"
                           Variant="Variant.Outlined"
@@ -160,6 +184,7 @@
     private bool _includeRetired;
     private int _retiredCount;
     private string _accountName = string.Empty;
+    private IReadOnlyCollection<string> _additionalAccounts = [];
     private string _deploymentName = string.Empty;
     private string _modelName = string.Empty;
     private string _modelVersion = string.Empty;
@@ -223,6 +248,13 @@
                 : null;
         }
     }
+
+    /// <summary>Known accounts other than the one already chosen — the only ones "also create in" can add.</summary>
+    private IReadOnlyList<string> OtherAccounts =>
+        [.. KnownAccounts.Where(account => !string.Equals(account, _accountName, StringComparison.OrdinalIgnoreCase))];
+
+    private void OnAdditionalAccountsChanged(IReadOnlyCollection<string> accounts) =>
+        _additionalAccounts = accounts ?? [];
 
     private Task<IEnumerable<string>> SearchAccountsAsync(string value, CancellationToken cancellationToken) =>
         Task.FromResult(Filter(KnownAccounts, value));
@@ -356,7 +388,14 @@
             Capacity = _capacity,
         };
 
-        Instance.Close(DialogResult.Ok(request));
+        // The chosen account first, then any extras — the page creates them in this order and reports
+        // each one separately, so a second-region failure never looks like the first one failing too.
+        var accounts = new List<string> { request.AccountName };
+        accounts.AddRange(_additionalAccounts
+            .Select(account => account.Trim())
+            .Where(account => account.Length > 0 && !accounts.Contains(account, StringComparer.OrdinalIgnoreCase)));
+
+        Instance.Close(DialogResult.Ok(new FoundryProvisionPlan(accounts, request)));
     }
 
     private void Cancel() => Instance.Cancel();

--- a/src/FoundryGate.Web/Shared/ModelAliasDialog.razor
+++ b/src/FoundryGate.Web/Shared/ModelAliasDialog.razor
@@ -1,0 +1,221 @@
+@* Add or retarget one row of a tier's model allowlist (#225). The gateway's alias map IS the
+   allowlist (#86), so this dialog is where a model becomes usable by a tier — and where it stops
+   being usable, by pointing the same alias somewhere else.
+
+   Two of the four fields are derived, not asked: `provider` and `pool` both follow from the chosen
+   deployment's ARM model.format, and getting either wrong produces a failure that looks like
+   something else (a Claude alias routed at the OpenAI backend dies as an opaque 404). They are shown
+   so the admin can see what will be written, and are not editable. *@
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary mb-4" Style="max-width: 34rem;">
+            An alias is the model name developers put in their CLI. The gateway rewrites it to the
+            deployment below and refuses anything this tier doesn't list.
+        </MudText>
+
+        @if (_deploymentNames.Count == 0)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-4" data-testid="alias-no-deployments">
+                There are no Foundry deployments to point an alias at yet. Provision one first.
+            </MudAlert>
+        }
+
+        <MudForm @ref="_form">
+            <MudSelect T="string"
+                       Value="@_tier"
+                       ValueChanged="@OnTierChanged"
+                       Label="Tier"
+                       Variant="Variant.Outlined"
+                       Disabled="@IsRetarget"
+                       data-testid="alias-tier">
+                @foreach (var tier in Tiers)
+                {
+                    <MudSelectItem T="string" Value="@tier.Tier">@tier.DisplayName</MudSelectItem>
+                }
+            </MudSelect>
+
+            <MudTextField @bind-Value="_alias"
+                          Label="Alias"
+                          Variant="Variant.Outlined"
+                          Class="mt-4"
+                          Disabled="@IsRetarget"
+                          Required="true"
+                          RequiredError="An alias needs a name."
+                          MaxLength="@ValidationConstants.FoundryDeploymentNameMaxLength"
+                          HelperText="Lower-case: letters, digits, and . _ - after the first character. e.g. sonnet"
+                          data-testid="alias-name" />
+
+            <MudSelect T="string"
+                       Value="@_deploymentName"
+                       ValueChanged="@OnDeploymentChanged"
+                       Label="Deployment"
+                       Variant="Variant.Outlined"
+                       Class="mt-4"
+                       Required="true"
+                       RequiredError="Pick the deployment this alias resolves to."
+                       data-testid="alias-deployment">
+                @foreach (var name in _deploymentNames)
+                {
+                    <MudSelectItem T="string" Value="@name">@name</MudSelectItem>
+                }
+            </MudSelect>
+
+            @if (_deploymentName.Length > 0)
+            {
+                <div class="d-flex align-center gap-2 mt-4" data-testid="alias-derived">
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info">
+                        @Provider front door
+                    </MudChip>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
+                        @Pool backend
+                    </MudChip>
+                </div>
+
+                @if (MissingFrom.Count > 0 && Pool == GatewayModelMap.AnthropicPool)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-4" data-testid="alias-missing-regions">
+                        '@_deploymentName' is missing from @string.Join(", ", MissingFrom). A pooled model has to
+                        exist in every region — the pool sends a throttled request to another one, and a region
+                        without the deployment turns that throttle into a 404. The API will refuse this.
+                    </MudAlert>
+                }
+
+                @if (_alias.Length > 0 && ExistingAliases.Contains(_alias, StringComparer.OrdinalIgnoreCase) && !IsRetarget)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-4" data-testid="alias-replaces">
+                        This tier already allows '@_alias'. Saving re-points it at '@_deploymentName'.
+                    </MudAlert>
+                }
+            }
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel" data-testid="alias-cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Disabled="@(_deploymentNames.Count == 0)"
+                   OnClick="@SubmitAsync"
+                   data-testid="alias-save">@(IsRetarget ? "Retarget" : "Allow")</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance Instance { get; set; } = default!;
+
+    /// <summary>Tiers whose allowlist this dialog may write to. Fixed to one when retargeting.</summary>
+    [Parameter]
+    public IReadOnlyList<GatewayTierResponse> Tiers { get; set; } = [];
+
+    /// <summary>Every deployment in every configured account — the source of the deployment picker and of the derived fields.</summary>
+    [Parameter]
+    public IReadOnlyList<FoundryDeploymentResponse> Deployments { get; set; } = [];
+
+    /// <summary>The gateway's configured accounts, in pool order, so "missing from" names them all.</summary>
+    [Parameter]
+    public IReadOnlyList<string> ConfiguredAccounts { get; set; } = [];
+
+    /// <summary>Aliases the chosen tier already allows — so adding one that exists says it is a replacement.</summary>
+    [Parameter]
+    public IReadOnlyList<string> ExistingAliases { get; set; } = [];
+
+    /// <summary>Tier to start on.</summary>
+    [Parameter]
+    public string Tier { get; set; } = string.Empty;
+
+    /// <summary>Alias to start with — set when retargeting, or when a deep link named one.</summary>
+    [Parameter]
+    public string Alias { get; set; } = string.Empty;
+
+    /// <summary>Deployment to start with — what <c>/foundry</c>'s "allow this model" link pre-fills.</summary>
+    [Parameter]
+    public string DeploymentName { get; set; } = string.Empty;
+
+    /// <summary>True when the alias and tier are fixed and only the deployment moves.</summary>
+    [Parameter]
+    public bool IsRetarget { get; set; }
+
+    private MudForm? _form;
+    private string _tier = string.Empty;
+    private string _alias = string.Empty;
+    private string _deploymentName = string.Empty;
+    private List<string> _deploymentNames = [];
+
+    /// <summary>The ARM model format of the chosen deployment — what both derived fields follow from.</summary>
+    private string? ChosenFormat =>
+        Deployments.FirstOrDefault(d => string.Equals(d.DeploymentName, _deploymentName, StringComparison.OrdinalIgnoreCase))?.ModelFormat;
+
+    private ModelProviderType Provider => ModelAliasDerivation.ProviderFor(ChosenFormat);
+
+    private string Pool => ModelAliasDerivation.PoolFor(ChosenFormat);
+
+    /// <summary>Configured accounts that don't carry the chosen deployment — fatal for a pooled model.</summary>
+    private IReadOnlyList<string> MissingFrom
+    {
+        get
+        {
+            var carrying = Deployments
+                .Where(d => string.Equals(d.DeploymentName, _deploymentName, StringComparison.OrdinalIgnoreCase))
+                .Select(d => d.AccountName)
+                .ToList();
+
+            return [.. ConfiguredAccounts.Where(account => !carrying.Contains(account, StringComparer.OrdinalIgnoreCase))];
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        _tier = Tier.Length > 0 ? Tier : Tiers.FirstOrDefault()?.Tier ?? string.Empty;
+        _alias = Alias;
+        _deploymentName = DeploymentName;
+        _deploymentNames = [.. Deployments
+            .Select(d => d.DeploymentName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private void OnTierChanged(string? tier) => _tier = tier ?? string.Empty;
+
+    private void OnDeploymentChanged(string? deploymentName)
+    {
+        _deploymentName = deploymentName ?? string.Empty;
+
+        // A blank alias follows the deployment: "claude-sonnet-4-5" is a fine first guess at what the
+        // alias should be called, and an admin who wants "sonnet" only has to shorten it. An alias
+        // they have already typed is theirs and is left alone.
+        if (_alias.Length == 0)
+        {
+            _alias = _deploymentName.ToLowerInvariant();
+        }
+    }
+
+    private async Task SubmitAsync()
+    {
+        if (_form is not null)
+        {
+            await _form.ValidateAsync();
+            if (!_form.IsValid)
+            {
+                return;
+            }
+        }
+
+        if (_tier.Length == 0 || _deploymentName.Length == 0)
+        {
+            return;
+        }
+
+        var row = new TierModelAliasRequest
+        {
+            Alias = _alias.Trim().ToLowerInvariant(),
+            DeploymentName = _deploymentName.Trim(),
+            Pool = Pool,
+            Provider = Provider,
+        };
+
+        Instance.Close(DialogResult.Ok(new ModelAliasEdit(_tier, row)));
+    }
+
+    private void Cancel() => Instance.Cancel();
+}

--- a/src/FoundryGate.Web/Shared/ModelAliasDialog.razor
+++ b/src/FoundryGate.Web/Shared/ModelAliasDialog.razor
@@ -173,6 +173,14 @@
             .Select(d => d.DeploymentName)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase)];
+
+        // One deployment is not a choice — pre-select it, the way the provision dialog pre-selects a
+        // lone account, so the common early-days case is "name the alias" rather than "name the alias
+        // and confirm the only possible answer".
+        if (_deploymentName.Length == 0 && _deploymentNames.Count == 1)
+        {
+            OnDeploymentChanged(_deploymentNames[0]);
+        }
     }
 
     private void OnTierChanged(string? tier) => _tier = tier ?? string.Empty;

--- a/src/FoundryGate.Web/_Imports.razor
+++ b/src/FoundryGate.Web/_Imports.razor
@@ -11,8 +11,10 @@
 @using MudBlazor
 @using FoundryGate.Domain.Constants
 @using FoundryGate.Domain.Common
+@using FoundryGate.Domain.Config
 @using FoundryGate.Domain.Foundry
 @using FoundryGate.Domain.Foundry.Contracts
+@using FoundryGate.Domain.Gateway.Contracts
 @using FoundryGate.Domain.Groups
 @using FoundryGate.Domain.Groups.Contracts
 @using FoundryGate.Domain.Keys.Contracts


### PR DESCRIPTION
Closes #225.

The owner's ask: *"We also want to make it easy to provision new models and set allowed models in the
front end of the app."* Both halves were file edits before this — granting a tier a model meant
editing `infra/main.bicep` and running an infra deploy, and `/foundry` could create one deployment in
one account with no follow-through.

## Allowed models per tier

The per-tier alias map **is** the allowlist (#86): each quota-tier product carries the APIM named
value `fg-model-map-{tier}` holding `{ alias: { deployment, backend, provider } }`, applied by a
policy fragment ahead of `llm-token-limit`, and anything a tier does not list is
`403 model_not_permitted` before it costs any quota. plans/25 always intended the control plane to
edit those named values through the Management API — no policy redeploy — and left it as "later, with
#82". This is that.

- `IApimManagementClient` (Core) gains `GetNamedValueAsync` / `SetNamedValueAsync`. The read goes
  through APIM's `listValue`, not the resource GET, because ARM omits `properties.value` for a secret
  named value and depending on which shape comes back would make the read right for only half the
  contract.
- `GET /api/v1/gateway/tiers`, `GET|PUT /api/v1/gateway/tiers/{tier}/models` — admin-only, audited
  (`gateway.models.updated`, target type `GatewayTier`, details carrying the whole map before/after).
  `PUT` is a full replace, because the named value is one document the gateway reads whole.
- `GatewayModelMap` (Domain) holds the naming contract shared with
  `infra/modules/ai-gateway.bicep`: the named-value name, and the pool↔backend mapping in both
  directions, so a map written by the API and a map written by a deploy are indistinguishable.
- Validation refuses maps the gateway would answer with a **404** rather than an honest 403: alias
  grammar (lower-case, url-safe — the policy compares without normalizing), no duplicate alias, a
  known pool, a deployment that exists in a configured account — and in **every** account for an
  `anthropic`-pool alias, mirroring the contract stated in `infra/main.bicep` (the pool fails a
  throttled request over to another region, and a region missing the deployment turns a 429 into a
  404). APIM refusing the write is a `409` carrying what APIM said. Writing the map a tier already
  holds is a no-op: no APIM call, no audit row.
- New admin page **`/models`** ("Models & access"), linked in the nav beside Foundry deployments: an
  alias × tier overview, per-tier allow / retarget / remove, and a "what developers on this tier see"
  preview. `provider` and `pool` are *derived* from the chosen deployment's ARM `model.format` rather
  than asked — getting either wrong produces a failure that looks like something else.

## Easier model provisioning

- The provision dialog can name several accounts ("Also create in"): still one
  `POST /foundry/deployments` per account, run in order and reported separately, so a second region
  failing never reads as the first one having failed too (E-007: never a loop the API drives on the
  admin's behalf). Which accounts a model belongs in is `infra/main.bicep`'s pooled / primary-only
  split, now expressed once in `ModelAliasDerivation` so it stays true when #126 lifts.
- After a create the page polls each new deployment to a terminal state, refreshing the grid, and
  gives up after ~1 minute rather than spinning.
- The Claude/Anthropic refusal stays an inline explanation with the issue links, not a generic error.
- A successful create ends with a link into `/models?deployment=…`, which that page turns into a
  pre-filled "allow a model" dialog — a deployment nobody may use is not yet useful.

## Docs

All three levels per CLAUDE.md invariant 2: one plain sentence in the `why-foundrygate` comparison
table, a paragraph in `architecture/overview` under APIM enforcement, and precise endpoint/page
behaviour in `reference/api.md` and `reference/web-ui.md`. Landing page re-read — no claim became
false, so it is untouched. plans/25's control-plane checkbox is now ticked.

## Verification

- `dotnet build FoundryGate.sln -c Release` — 0 warnings, 0 errors
- `dotnet test src/FoundryGate.Tests.Predeployment -c Release` — **1599 passed** (1545 before)
- `dotnet format FoundryGate.sln --verify-no-changes` — clean
- `npm ci && npm run build` in `docs-site/` — green

## Follow-ups filed

- **#226** (`live-validation`) — PUT of an `fg-model-map` named value against real APIM, and a real
  request routing through a newly added alias. The named-value round trip is the one mechanism here
  with no offline proof.
- **#232** — `GET /users/me` still advertises the *deploy-time* alias map (`Gateway__ModelAliases__*`)
  while the gateway now enforces the named value, so the two can diverge until the next deploy. Found
  while building this; the worse direction is advertising a model we will now 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
