### PR TITLE
fix(infra): APIM product-API links must be products/apis, not apiLinks

### DIFF
--- a/infra/modules/ai-gateway.bicep
+++ b/infra/modules/ai-gateway.bicep
@@ -363,23 +363,24 @@ resource tierProducts 'Microsoft.ApiManagement/service/products@2024-06-01-previ
   }
 ]
 
-resource tierProductAnthropicLinks 'Microsoft.ApiManagement/service/products/apiLinks@2024-06-01-preview' = [
+// Which APIs each tier product exposes. Deliberately `products/apis` and NOT the newer
+// `products/apiLinks`: `apiLinks` is not idempotent. Its identity is the link name, but
+// APIM additionally enforces uniqueness on the (product, api) PAIR, so a second PUT of an
+// already-linked pair fails with `Conflict — Link already exists between specified Product
+// and Api` even though nothing changed. That makes the whole template single-use, which
+// broke the first re-run of the dev deploy (#239). `products/apis` names the association by
+// the API itself, so a re-PUT is a genuine no-op. Verified against APIM BasicV2, 2026-09-05.
+resource tierProductAnthropicApis 'Microsoft.ApiManagement/service/products/apis@2024-06-01-preview' = [
   for (tier, i) in quotaTiers: {
     parent: tierProducts[i]
-    name: 'anthropic-link'
-    properties: {
-      apiId: anthropicApi.id
-    }
+    name: anthropicApi.name
   }
 ]
 
-resource tierProductOpenaiLinks 'Microsoft.ApiManagement/service/products/apiLinks@2024-06-01-preview' = [
+resource tierProductOpenaiApis 'Microsoft.ApiManagement/service/products/apis@2024-06-01-preview' = [
   for (tier, i) in quotaTiers: {
     parent: tierProducts[i]
-    name: 'openai-link'
-    properties: {
-      apiId: openaiApi.id
-    }
+    name: openaiApi.name
   }
 ]
 


### PR DESCRIPTION
## What

The gateway template could only ever be applied **once**. Every re-run of `main.bicep` died in the `foundrygate-ai-gateway` module with four of:

\\\
Conflict — "Link already exists between specified Product and Api."
\\\

`products/apiLinks` is not idempotent. Its ARM identity is the *link name* (`anthropic-link`), but APIM separately enforces uniqueness on the **(product, api) pair** — so a re-PUT of an unchanged link is not read as "already exists, no-op" but as "you are creating a second link for a pair that already has one". No property change makes it converge.

`products/apis` names the association by the API itself, so a re-PUT is a genuine no-op.

## Verification — live, on the pair that actually 409s

Against the deployed `apim-foundrygate-dev-e7k2` (BasicV2), on a product/API pair that **already had a link**:

\\\
PUT .../products/standard/apis/foundrygate-anthropic?api-version=2024-06-01-preview  -> 200
PUT .../products/standard/apis/foundrygate-anthropic?api-version=2024-06-01-preview  -> 200
\\\

Two consecutive PUTs, both 200. `az bicep build` clean; generated architecture model unchanged (`npm run generate:architecture` produces no diff).

`apiLinks` is a newer surface over the same underlying relationship, so switching orphans nothing and the gateway serves exactly what it served before.

## Why it survived to now

The 2026-09-01 gateway live-validation deployed the stack **once** and tore it down, so a second apply had never happened. It took the first real `Deploy All → dev` to find it — on the second run, [33972516153](https://github.com/kolatts/foundry-gate/actions/runs/33972516153) and [33972522833](https://github.com/kolatts/foundry-gate/actions/runs/33972522833), sequential and identical, so not a race.

Worth internalising as a general warning about `-preview` APIM types: `apiLinks` reads like the modern replacement for `products/apis` and is what the portal emits, but it carries a uniqueness rule its own resource identity does not express.

Closes #239
Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)