### PR TITLE
fix(infra): decouple the SQL server's region — eastus2 is closed to new servers

### DIFF
--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -122,6 +122,7 @@ workflows resolve resources from these patterns — changing one is a contract c
 | `deployControlPlane` | `true` | `true` | default `false` (gateway only) |
 | `appEnvironment` | `qa` | `prod` | `ASPNETCORE_ENVIRONMENT` — lowercase `qa`/`prod`; `local` is docker-only |
 | `sqlAdminGroupObjectId` / `sqlAdminGroupName` | `SG_FOUNDRYGATE_SQL_ADMINS` | `$FG_SQL_ADMIN_GROUP_OBJECT_ID` / `$FG_SQL_ADMIN_GROUP_NAME` (required) | SQL server administrator (Entra-only auth; no SQL login exists) |
+| `sqlLocation` | `centralus` | set it explicitly | region for the SQL logical server, defaulting to `location`. Dev overrides it because **`eastus2` and `eastus` are both closed to new Azure SQL servers** on this subscription — see below |
 | `sqlDatabaseSku` | `GP_S_Gen5` ×1 — serverless, 60-min auto-pause | `GP_Gen5_2`, provisioned | serverless is derived from the SKU name (`GP_S_*`) |
 | `sqlBackupStorageRedundancy` | `Local` | `Geo` | |
 | `sqlZoneRedundant` | `false` | `true` | survives the loss of one availability zone without a restore; adds ~60% to the SQL compute meter (see [Cost & capacity](/foundry-gate/reference/cost-and-capacity/)) |
@@ -143,6 +144,33 @@ workflows resolve resources from these patterns — changing one is a contract c
 Nothing in a parameter file is a secret: SQL is Entra-only, storage is identity-based,
 registry pulls are identity-based, and the App Insights connection string is a module
 output. Entra object ids and client ids are identifiers, not credentials.
+
+### Why `sqlLocation` exists
+
+Azure closes individual regions to **new** Azure SQL logical servers as a capacity action,
+and there is no way to see it coming: it is not a quota you can read, not a SKU
+availability query, not anything `az sql server list-usages` reports. The only signal is
+attempting a create and getting `ProvisioningDisabled` / `RegionDoesNotAllowProvisioning`.
+
+Probed on the dev subscription, 2026-09-05:
+
+| Region | New SQL server |
+|---|---|
+| `eastus2` | refused |
+| `eastus` | refused |
+| `centralus` | created |
+
+Both the primary region and its obvious neighbour were shut, which is why dev's SQL lives
+in `centralus` while everything else stays in `eastus2`. Existing servers in a closed
+region keep working — only creation is blocked, and it can reopen (or close) without
+notice. The cross-region hop between the Container App and SQL is a real latency cost,
+accepted for dev.
+
+**Set `sqlLocation` explicitly for production** rather than letting it inherit `location`,
+so a prod day-0 does not discover this the way dev did
+([#241](https://github.com/kolatts/foundry-gate/issues/241)). The alternative is a support
+request (Issue type *Service and subscription limits*) to reopen the primary region — worth
+it when co-location matters, not worth blocking a first deploy on.
 
 ## Role assignments
 

--- a/docs-site/src/content/docs/reference/infrastructure.md
+++ b/docs-site/src/content/docs/reference/infrastructure.md
@@ -172,6 +172,18 @@ so a prod day-0 does not discover this the way dev did
 request (Issue type *Service and subscription limits*) to reopen the primary region — worth
 it when co-location matters, not worth blocking a first deploy on.
 
+:::danger[`sqlLocation` is immutable once the server exists]
+`Microsoft.Sql/servers.location` cannot be changed in place. Setting it is a **one-shot
+decision per environment**: change it after the first deploy and the incremental deployment
+*fails* rather than moving anything, and the recovery is exporting the database and
+re-creating it on a new server. Pick it before an environment's first deploy — afterwards it
+is a migration, not a parameter.
+
+Two things must agree with it: `sqlZoneRedundant` requires a region that actually has
+availability zones, and `sqlBackupStorageRedundancy = 'Geo'` geo-pairs from *this* region,
+not from `location`.
+:::
+
 ## Role assignments
 
 All scoped to the individual resource, never the resource group; names are

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,6 +15,9 @@ param environmentName string
 @description('Primary Azure region for shared resources (APIM, monitoring).')
 param location string = 'eastus2'
 
+@description('Region for the Azure SQL logical server. Defaults to `location`. Override when the primary region is closed to NEW SQL servers — Azure does this per region without notice and it is invisible to quota/SKU queries (#241); see modules/sql.bicep.')
+param sqlLocation string = location
+
 @description('Globally-unique suffix for DNS-named resources (APIM, Foundry accounts).')
 param nameSuffix string
 
@@ -367,6 +370,7 @@ module controlPlane 'modules/control-plane.bicep' = if (deployControlPlane) {
   params: {
     environmentName: environmentName
     location: location
+    sqlLocation: sqlLocation
     nameSuffix: nameSuffix
     tags: standardTags
     appEnvironment: appEnvironment

--- a/infra/modules/control-plane.bicep
+++ b/infra/modules/control-plane.bicep
@@ -33,6 +33,10 @@
 //   stapp-foundrygate-{env}            Static Web App
 param environmentName string
 param location string
+
+@description('Region for the Azure SQL logical server. Defaults to `location`; override only when the primary region refuses new SQL servers (see modules/sql.bicep).')
+param sqlLocation string = location
+
 param nameSuffix string
 param tags object = {}
 
@@ -160,7 +164,7 @@ module sql 'sql.bicep' = {
   params: {
     sqlServerName: names.sqlServer
     sqlDatabaseName: names.sqlDatabase
-    location: location
+    location: sqlLocation
     tags: controlPlaneTags
     entraAdminGroupObjectId: sqlAdminGroupObjectId
     entraAdminGroupName: sqlAdminGroupName

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -25,6 +25,13 @@
 // jobs (#84) should keep their cadence above the pause delay or accept an always-on vCore.
 param sqlServerName string
 param sqlDatabaseName string
+
+// NOT necessarily the deployment's primary region. Azure closes individual regions to NEW
+// SQL logical servers without warning and without it showing up in any quota or SKU query —
+// the only way to find out is to try, and the error is `ProvisioningDisabled` /
+// `RegionDoesNotAllowProvisioning`, not a quota error. Both `eastus2` and `eastus` were
+// closed to this subscription on 2026-09-05, which is what pushed dev's SQL to `centralus`
+// (#241). Existing servers in a closed region keep working; only creation is blocked.
 param location string
 param tags object = {}
 

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -32,6 +32,12 @@ param sqlDatabaseName string
 // `RegionDoesNotAllowProvisioning`, not a quota error. Both `eastus2` and `eastus` were
 // closed to this subscription on 2026-09-05, which is what pushed dev's SQL to `centralus`
 // (#241). Existing servers in a closed region keep working; only creation is blocked.
+//
+// IMMUTABLE ONCE DEPLOYED. `Microsoft.Sql/servers.location` cannot be changed in place, so
+// this is a one-shot decision per environment: changing it later makes the incremental
+// deployment FAIL rather than move anything, and the recovery is exporting the database and
+// re-creating it on a new server. Choose it deliberately before an environment's first
+// deploy — after that it is a migration, not a parameter.
 param location string
 param tags object = {}
 

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -51,6 +51,13 @@ param sqlAdminGroupName = 'SG_FOUNDRYGATE_SQL_ADMINS'
 // deliberately hits the hermetic /health, not /health/ready (modules/container-app.bicep).
 param sqlBackupStorageRedundancy = 'Local'
 
+// NOT eastus2, and this is not a preference. On 2026-09-05 both eastus2 and eastus were
+// closed to new Azure SQL logical servers for this subscription — `RegionDoesNotAllowProvisioning`,
+// which no quota or SKU query predicts. centralus was open; probed directly (#241). The
+// cross-region hop to the Container App in eastus2 is acceptable for dev; revisit if the
+// primary region reopens.
+param sqlLocation = 'centralus'
+
 param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')
 param apiContainerImage = readEnvironmentVariable('FG_API_IMAGE')
 

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -52,10 +52,14 @@ param sqlAdminGroupName = 'SG_FOUNDRYGATE_SQL_ADMINS'
 param sqlBackupStorageRedundancy = 'Local'
 
 // NOT eastus2, and this is not a preference. On 2026-09-05 both eastus2 and eastus were
-// closed to new Azure SQL logical servers for this subscription — `RegionDoesNotAllowProvisioning`,
-// which no quota or SKU query predicts. centralus was open; probed directly (#241). The
-// cross-region hop to the Container App in eastus2 is acceptable for dev; revisit if the
-// primary region reopens.
+// closed to new Azure SQL logical servers for this subscription — the ARM deploy fails with
+// `ProvisioningDisabled` and a direct `az sql server create` with
+// `RegionDoesNotAllowProvisioning`; no quota or SKU query predicts either. centralus was
+// open; probed directly (#241). The cross-region hop to the Container App in eastus2 is
+// acceptable for dev.
+//
+// Immutable: `Microsoft.Sql/servers.location` cannot change in place, so moving this back to
+// eastus2 if the region reopens is a database migration, not a param edit.
 param sqlLocation = 'centralus'
 
 param entraApiClientId = readEnvironmentVariable('FG_ENTRA_API_CLIENT_ID', '00000000-0000-0000-0000-000000000000')

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -57,7 +57,25 @@ param sqlDatabaseSku = {
 // halves zone-tolerant; it is not the default here only because it costs more and the
 // restore path of last resort is the geo-secondary either way. Revisit with #105.
 param sqlBackupStorageRedundancy = 'Geo'
-// Zone-redundant database: survives the loss of one availability zone in eastus2 without a
+
+// DECIDE THIS BEFORE PRODUCTION'S FIRST DEPLOY (#241). Left unset deliberately, so it
+// inherits `location` — but that is a placeholder, not a decision:
+//
+//   param sqlLocation = '<region confirmed open>'
+//
+// Azure closes individual regions to NEW Azure SQL logical servers without notice, and it
+// is invisible to every quota and SKU query — the only way to know is to attempt a create.
+// eastus2 AND eastus were both closed to this subscription on 2026-09-05, which is why dev
+// runs SQL in centralus. Probe the intended region before the first prod deploy rather than
+// finding out mid-deployment.
+//
+// Two constraints if you set it, because `Microsoft.Sql/servers.location` is IMMUTABLE and
+// this is therefore one-shot:
+//   * `sqlZoneRedundant = true` below needs a region that actually has availability zones.
+//   * `sqlBackupStorageRedundancy = 'Geo'` above geo-pairs from THIS region, not `location`.
+
+// Zone-redundant database: survives the loss of one availability zone in the SQL region
+// (eastus2 unless `sqlLocation` above says otherwise) without a
 // restore. Adds ~60% to the SQL compute line, not 2x — eastus2 retail (2026-09-02) is
 // $0.152217/vCore-hr plus a $0.09133/vCore-hr zone-redundancy surcharge
 // (docs reference/cost-and-capacity).


### PR DESCRIPTION
## What

The dev deploy got past the APIM fix (#239) and died one module later, in `foundrygate-cp-sql`:

\\\
Microsoft.Sql/servers/sql-foundrygate-dev-e7k2 -> Failed
  ProvisioningDisabled: "Provisioning is restricted in this region."
\\\

New `sqlLocation` param, defaulting to `location`, threaded `main.bicep` → `control-plane.bicep` → `sql.bicep`. Dev overrides it to `centralus`; everything else stays in `eastus2`.

## The part worth knowing

**This is invisible until you try.** Not a quota you can read, not a SKU availability query, not anything `az sql server list-usages` reports. Azure closes individual regions to *new* SQL logical servers as a capacity action and the only signal is attempting a create.

Probed directly on this subscription, 2026-09-05:

| Region | New SQL server |
|---|---|
| `eastus2` | refused — `RegionDoesNotAllowProvisioning` |
| `eastus` | refused |
| `centralus` | **created** (probe server deleted afterwards) |

The primary region *and* its obvious neighbour are both shut, so nudging `location` was not an option. Existing servers in a closed region keep working; only creation is blocked, and it can reopen without notice.

## Trade accepted

Dev now has a cross-region hop between the Container App (eastus2) and SQL (centralus). That is a real latency cost and it is the right call for dev, where the alternative is blocking the first deploy on an Azure support turnaround (Issue type *Service and subscription limits*).

`prod.bicepparam` deliberately gets **no** value here. Production should set `sqlLocation` explicitly after confirming a region is open, rather than inheriting `location` and rediscovering this on its own day 0 — that is a checkbox on #241.

## Verification

- `az bicep build-params --file infra/parameters/dev.bicepparam` renders `"sqlLocation": { "value": "centralus" }`; template builds clean.
- Generated architecture model unchanged (`npm run generate:architecture` — no diff).
- `npm run build` in `docs-site/` green, 17 pages.
- `reference/infrastructure` gains the parameter row and a "Why `sqlLocation` exists" section with the probe table, so the next person does not re-derive it from a red deploy.

Closes #241
Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)