### PR TITLE
fix(ci): the API smoke test must supply Gateway__Tiers, which is never optional

### DIFF
--- a/.github/actions/build-api-image/action.yml
+++ b/.github/actions/build-api-image/action.yml
@@ -91,6 +91,16 @@ runs:
         # /health itself is hermetic, so placeholder values are the point.
         # KeyProtection__Provider=DataProtection is the documented local-only substitute for a
         # Key Vault wrapping key (the real one is Gateway__KeyEncryptionKeyUri, an infra output).
+        #
+        # Gateway__Tiers__* is REQUIRED — GatewayOptions.Tiers is the one member that is never
+        # optional, because quota resolution has no meaning without a tier table. The image no
+        # longer ships appsettings.local.json (the .dockerignore fix above), so nothing supplies
+        # it here unless this step does. Two tiers, not one: validation insists on exactly one
+        # unlimited tier (MonthlyTokenQuota = 0) AND at least one finite tier for finite quotas to
+        # map onto, so a single-tier table fails just as loudly as an empty one. The product ids
+        # must be real (GatewayTiers.All / infra's quotaTiers) — unknown ids are rejected by name.
+        # The CAPS are deliberately not the real ones: this proves the host starts and serves
+        # /health, not what dev's quotas are.
         docker run -d --name "$container" -p 8080:8080 \
           -e 'KeyProtection__Provider=DataProtection' \
           -e 'AzureAd__Instance=https://login.microsoftonline.com/' \
@@ -99,6 +109,12 @@ runs:
           -e 'AzureAd__TenantId=00000000-0000-0000-0000-000000000000' \
           -e 'AzureAd__ClientId=00000000-0000-0000-0000-000000000000' \
           -e 'AzureAd__Audience=api://00000000-0000-0000-0000-000000000000' \
+          -e 'Gateway__Tiers__0__ProductId=standard' \
+          -e 'Gateway__Tiers__0__DisplayName=Standard' \
+          -e 'Gateway__Tiers__0__MonthlyTokenQuota=1000000' \
+          -e 'Gateway__Tiers__1__ProductId=unlimited' \
+          -e 'Gateway__Tiers__1__DisplayName=Unlimited' \
+          -e 'Gateway__Tiers__1__MonthlyTokenQuota=0' \
           "$IMAGE"
         for i in $(seq 1 "$TIMEOUT"); do
           code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health || true)"

--- a/src/FoundryGate.Api/Dockerfile
+++ b/src/FoundryGate.Api/Dockerfile
@@ -11,8 +11,19 @@
 #     -e AzureAd__Audience=api://00000000-0000-0000-0000-000000000000 \
 #     -e KeyProtection__Provider=DataProtection \
 #     -e AzureAd__Instance=https://login.microsoftonline.com/ \
+#     -e Gateway__Tiers__0__ProductId=standard \
+#     -e Gateway__Tiers__0__DisplayName=Standard \
+#     -e Gateway__Tiers__0__MonthlyTokenQuota=1000000 \
+#     -e Gateway__Tiers__1__ProductId=unlimited \
+#     -e Gateway__Tiers__1__DisplayName=Unlimited \
+#     -e Gateway__Tiers__1__MonthlyTokenQuota=0 \
 #     foundrygate-api:local
 #   curl -i http://localhost:8080/health          # 200 (hermetic liveness; no DB needed)
+#
+# Two tiers, and both are needed: GatewayOptions requires exactly one unlimited tier
+# (MonthlyTokenQuota = 0) and at least one finite tier, so a single entry fails as loudly as
+# none. The product ids must be real ones (FoundryGate.Domain.Constants.GatewayTiers); the caps
+# here are placeholders.
 #
 # Those settings are required by Program.cs's startup validation and MUST come from the
 # environment — the image ships no appsettings.local.json (.dockerignore, enforced by


### PR DESCRIPTION
## What

The API stage of the first dev deploy died **before touching Azure**, in the local `docker run` smoke test:

\\\
/health did not return 200 within 30s for foundrygate-api:0.1.0-613e50d
ConfigurationValidationException: Gateway.Tiers: Tiers must contain at least one tier.
\\\

The smoke step **already** passes placeholder configuration — `AzureAd__*`, the connection string, `KeyProtection__Provider` — precisely because `Program.cs` validates at startup and the host exits without them. `Gateway__Tiers` was just missing from that list. So this is the smaller change: extend a list that already exists, in the pattern the file already documents.

## Which of the two options, and why

The coordinator's framing was right that a hermetic `/health` should not need SQL/APIM config — and it doesn't. `GatewayOptions`' *addressing* members (`ApimName`, `FoundryAccountNames`, `LogAnalyticsWorkspaceId`…) are all optional; the features that need them fail with a clean `503`. `Tiers` is the deliberate exception:

> `Tiers` is *always* required — quota resolution has no meaning without it.

So **placeholder config in the smoke step**, not weakened validation. That error was a *good* error: it named the env vars, the bicep parameter and the local file. Making `/health` reachable by relaxing a real production guard would trade a genuine fail-fast for a green check.

**Two tiers, not one.** Validation insists on exactly one unlimited tier (`MonthlyTokenQuota = 0`) **and** at least one finite tier for finite quotas to map onto — a one-entry table fails as loudly as an empty one. Product ids must be real (`GatewayTiers.All`) because unknown ids are rejected by name; the caps are deliberately fake, since this proves the host starts and serves `/health`, not what dev's quotas are.

## Why it survived until the first real deploy

The image used to ship `appsettings.local.json` past a mis-cased `.dockerignore` pattern, and that file carried `Gateway:Tiers` into the container. The *Verify the image ships no local configuration* step directly above — added to close that hole — removed the accidental supply without anyone adding the deliberate one. **This smoke test only ever passed because of the bug that step now catches.**

## Verification — real image, both directions

Built `src/FoundryGate.Api/Dockerfile` locally and ran the exact env from the action:

\\\
old env -> curl 000; ConfigurationValidationException: Gateway.Tiers … in docker logs
new env -> /health 200 after 2s
           {"status":"Healthy","version":"0.1.0-local","environment":"local"}
           /health/ready -> 503   (no SQL — hermetic/ready split intact)
\\\

The `/health/ready` 503 is the part worth noting: it confirms the fix does **not** paper over the readiness probe. `/health` is hermetic and answers; `/health/ready` still tells the truth about the database.

Touching `.github/` here is the documented exception — the workflow is the thing that is actually broken.

Closes #246
Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)