### PR TITLE
docs: the pipeline has run against Azure — say so, and stop telling forkers to edit appsettings

### DIFF
--- a/docs-site/src/components/DeployPipeline.astro
+++ b/docs-site/src/components/DeployPipeline.astro
@@ -2,8 +2,10 @@
 // Deploy pipeline — the GitHub Actions flow FoundryGate is built around
 // (CONVENTIONS.md §CI/CD, plans/22-cicd-pipelines.md). A merge to main runs exactly one
 // workflow, deploy-all.yml: infra → database → api → functions/ui → post-deploy tests →
-// summary. It exists on main (#67 / #68–#75) together with the GitHub Environments that gate
-// it; none of it has run against Azure yet, which is what the "unvalidated · #105" badge means.
+// summary. Every stage has now run green against Azure on `dev` (2026-09-05, run 33979330341),
+// which is what the "validated on dev" badge means — the chain has been executed end to end,
+// not merely linted. Getting there took five attempts and turned up five real defects (#239,
+// #241, #245, #246, #252), which is the argument for the badge distinction existing at all.
 // Keep the stages and status badges in step with .github/workflows/* and docs reference/ci-cd.
 interface Stage {
   title: string;
@@ -40,12 +42,12 @@ const main: Stage[] = [
   {
     title: 'Infra',
     detail: 'Bicep, subscription scope · what-if first · model deployments create-once',
-    status: 'exists · unvalidated · #105',
+    status: 'validated on dev · 2026-09-05',
   },
   {
     title: 'Database',
     detail: 'reusable database workflow',
-    status: 'exists · unvalidated · #105',
+    status: 'validated on dev · 2026-09-05',
     sub: [
       'whitelist runner IP',
       'wait 60 s for firewall',
@@ -59,16 +61,16 @@ const main: Stage[] = [
   {
     title: 'API',
     detail: 'image → ACR → Container Apps · replaces the day-0 placeholder',
-    status: 'exists · unvalidated · #105',
+    status: 'validated on dev · 2026-09-05',
   },
   {
     title: 'Functions + UI',
     detail: 'in parallel, after the API',
-    status: 'exists · unvalidated · #105',
+    status: 'validated on dev · 2026-09-05',
     parallel: ['Functions → Flex Consumption', 'UI → Static Web Apps'],
   },
-  { title: 'Post-deploy tests', detail: 'scaffold smoke test · reporting only until #139', status: 'exists · unvalidated · #105' },
-  { title: 'Summary', detail: 'job summary · Environment deploy record', status: 'exists · unvalidated · #105' },
+  { title: 'Post-deploy tests', detail: 'scaffold smoke test · reporting only until #139', status: 'validated on dev · 2026-09-05' },
+  { title: 'Summary', detail: 'job summary · Environment deploy record', status: 'validated on dev · 2026-09-05' },
 ];
 ---
 
@@ -89,8 +91,8 @@ const main: Stage[] = [
     contained database users, and remove the runner's firewall rule again), then the API, then Functions and UI in
     parallel, then post-deploy tests, then a summary. Functions and UI wait for the API because on the very first
     deploy the API stage re-runs the infrastructure template to replace the placeholder image. A production run stops
-    at the reviewer gate six times, once per pending job, and the plan stage lists them. Every workflow file
-    exists on main; badges mark that none has yet run against Azure (live validation is #105).
+    at the reviewer gate six times, once per pending job, and the plan stage lists them. Every stage has run
+    green against Azure on <code>dev</code>, which is what the badges mark.
   </p>
 
   <section class="fgd-plane fgd-plane--neutral">
@@ -161,7 +163,7 @@ const main: Stage[] = [
   </section>
 
   <figcaption class="fgd-legend">
-    <span class="fgd-legend__item"><span class="fgd-badge fgd-badge--muted">exists · unvalidated · #105</span> workflow file and Environment gate are on <code>main</code>; not yet run against Azure (owner OIDC setup #109, live validation #105)</span>
+    <span class="fgd-legend__item"><span class="fgd-badge fgd-badge--muted">validated on dev · 2026-09-05</span> the stage has run green against Azure on <code>dev</code>, not just linted (run 33979330341; #105). Production has never been deployed.</span>
   </figcaption>
 </figure>
 

--- a/docs-site/src/content/docs/architecture/overview.mdx
+++ b/docs-site/src/content/docs/architecture/overview.mdx
@@ -354,10 +354,13 @@ authorizes every resource as a write, so no read-only identity can run it — an
 switched off pending a decision (#229). A pull request runs its own copy of the workflow files,
 so the identity, not the workflow, is the boundary. The owner-side OIDC setup is **done for dev**
 (the [Owner Setup Runbook](/foundry-gate/reference/owner-setup/) is the commands that did it);
-**what has not happened yet** is the first full run against Azure, tracked in #105. Badges on the
-diagram mark the
-difference; the [CI/CD reference](/foundry-gate/reference/ci-cd/) lists every workflow, trigger
-and variable.
+and the whole chain has now **run green against Azure on `dev`** — infra, database, API, UI,
+Functions and post-deploy tests (#105, closed). It took five attempts, and each failure was a real
+defect the 1545 hermetic tests could not see: a gateway template that could only be applied once,
+two Azure regions closed to new SQL servers, a Graph role with no application-type variant, a smoke
+test that started the container with no configuration, and a CLI projection that made the Functions
+check unpassable. **Production has never been deployed.** Badges on the diagram mark which is which;
+the [CI/CD reference](/foundry-gate/reference/ci-cd/) lists every workflow, trigger and variable.
 
 <DeployPipeline />
 

--- a/handoff-orchestrator.md
+++ b/handoff-orchestrator.md
@@ -76,13 +76,32 @@ the badge stays until #105 closes.
 which stays open because Claude end-to-end is still unvalidated (#88) and its dependent
 live-validation issues (#125, #132, #178) are open.
 
-## Nothing has been deployed live yet
+## `dev` is deployed. Production is not.
 
-No `dev` or `production` environment has ever been stood up from this control-plane
-Bicep. The gateway data plane was live-validated once (2026-09-01, Imagile Paid) and
-**torn down** immediately after — `rg-foundrygate-test` deleted, soft-deleted resources
-purged. Every "live-validate X" issue below describes work that literally cannot be
-attempted until a real `dev` deploy exists.
+**Superseded 2026-09-05.** `rg-foundrygate-dev` is live on Imagile Paid and the whole
+`Deploy All` chain runs green — infra → database → API → UI → Functions → post-deploy tests
+([run 33979330341](https://github.com/kolatts/foundry-gate/actions/runs/33979330341); #105
+closed). Endpoints, and the evidence for every checklist item, are on #105 and #101.
+
+| | |
+|---|---|
+| API | `https://ca-foundrygate-api-dev.wittygrass-b608ecfa.eastus2.azurecontainerapps.io` |
+| UI | `https://brave-ocean-01f4a4f0f.6.azurestaticapps.net` |
+| APIM | `https://apim-foundrygate-dev-e7k2.azure-api.net` |
+
+Two things that surprised this deploy and will surprise the next one:
+
+- **SQL lives in `centralus`, not `eastus2`** — both eastus2 and eastus are closed to *new*
+  Azure SQL logical servers on this subscription, invisibly to every quota query (#241). The
+  server's location is immutable, so this is a one-shot decision per environment.
+- **No model deployments exist.** Claude is wedged at the subscription's Marketplace agreement
+  (#88, `needs-human`) and `gpt-4-1-mini` was skipped because every post-day-0 run must carry
+  `create-model-deployments=false`. The gateway 404s on any model until one is created out of
+  band, which is the control plane's job (#60/#64) rather than ARM's.
+
+**Production has never been deployed** and has no identities, no SQL admin group and no
+Environment variables — that is the open half of #109. The "live-validate X" issues below are
+now unblocked; #142 is next in #220's order.
 
 Until 2026-09-05 the first `Deploy All` run on main **stopped at the OIDC guard by
 design**: `dev`'s `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID` variables

--- a/src/FoundryGate.Web/wwwroot/appsettings.json
+++ b/src/FoundryGate.Web/wwwroot/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "_README": "PLACEHOLDER configuration. AzureAd values below are not a real app registration — replace TenantId/ClientId with your fork's Entra app registration (foundrygate-spec.md #12: 'Configuration for Forks') before deploying. Every value in this file is safe to ship (no secrets); only public client IDs live here per MSAL.js conventions.",
+  "_README": "PLACEHOLDER configuration, and it should STAY placeholder — do not put your fork's real ids here. _deploy-ui.yml rewrites the PUBLISHED copy of this file at deploy time (AzureAd.Authority from the AZURE_TENANT_ID Environment variable, AzureAd.ClientId from FG_ENTRA_WEB_CLIENT_ID, Api.Scopes from FG_ENTRA_API_CLIENT_ID, Api.BaseUrl from the infra output containerAppFqdn) and deletes this key, so one repo serves every environment and a fork never inherits someone else's tenant. Editing this file only changes what `dotnet run` uses locally. Every value here is safe to ship (no secrets); only public client IDs belong in it at all, per MSAL.js conventions. Setup: docs reference/owner-setup.",
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000",
     "ClientId": "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
## What

The whole `Deploy All` chain is green on dev ([run 33979330341](https://github.com/kolatts/foundry-gate/actions/runs/33979330341), #105 closed). Three places still said otherwise, and a fourth would cost a forker their tenant's client ids.

**`DeployPipeline.astro`** — all six stage badges said `exists · unvalidated · #105`, meaning "the workflow file is on main but has never run against Azure". All six have now run green, so they say `validated on dev · 2026-09-05`. The legend spells out what that badge is claiming — *executed end to end, not merely linted* — and adds the thing the old legend had no way to express once dev went live: **production has still never been deployed**.

**`architecture/overview.mdx`** — said "what has not happened yet is the first full run against Azure". It happened. Replaced with what it actually cost: five attempts and five real defects the 1545 hermetic tests could not see (#239, #241, #245, #246, #252). That is the argument for the badge distinction existing at all, so it belongs next to the badges.

**`handoff-orchestrator.md`** — the section headed *"Nothing has been deployed live yet"* is now the opposite of true. Rewritten with the endpoints and the two things that will surprise the next person: SQL lives in `centralus` because eastus2 **and** eastus are closed to new servers and the location is immutable (#241), and there are **no model deployments at all** (#88 plus the create-once rule).

**`src/FoundryGate.Web/wwwroot/appsettings.json`** — the `_README` told forkers to *"replace TenantId/ClientId with your fork's Entra app registration before deploying"*. Doing that commits a tenant's ids into a public repo for no benefit: `_deploy-ui.yml` rewrites the **published** copy at deploy time (`AzureAd.Authority` ← `AZURE_TENANT_ID`, `AzureAd.ClientId` ← `FG_ENTRA_WEB_CLIENT_ID`, `Api.Scopes` ← `FG_ENTRA_API_CLIENT_ID`, `Api.BaseUrl` ← the `containerAppFqdn` infra output) and deletes the `_README` key. It now says **do not edit it**, names each key's real source, and points at the owner-setup runbook.

That last one is the same class of error as the handoff line fixed in #227: the repo told you to do the one thing the pipeline exists to make unnecessary.

## Verification

- `npm run build` in `docs-site/` — clean, 17 pages.
- Checked the **built** HTML rather than the source: `dist/architecture/overview/index.html` contains the new badge 7 times (6 stages + legend), `unvalidated` **0** times, and the production caveat twice.
- `appsettings.json` still parses and its placeholder zero-GUIDs are untouched — the only change is the `_README` string.

## Note on the preview

This PR touches `src/FoundryGate.Web/**`, so it should trigger the SWA PR preview — which is the outstanding check on **#238**. The `ui-preview` identity got its custom role after the first successful infra deploy created it; whether a *resource-scoped* assignment is enough for `az login` to enumerate the subscription is the open question, and this PR is the test. I will report the result on #238 either way.

Refs #105, #220, #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
